### PR TITLE
Sprint 28: Re-land process_action_outcome() + MCP tool + v0.22.0

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,25 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-07 (Sprint 27 T1)*
+*Last updated: 2026-04-08 (Sprint 24 T1 resubmission)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 28 Summary: Re-land Sprint 24 + MCP Tool + v0.22.0 (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: Re-land process_action_outcome + MCP tool + v0.22.0 | DONE | 2 new exports (364 total), 18 new tests, 8 MCP tools (5 data + 3 behavioral) |
+
+### Sprint 24 Summary: Action Outcome Processing Pipeline (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: `process_action_outcome()` function + `ActionOutcomeResult` | DONE | Cross-module composition: R7Action + ReputationEngine + TrustProfile + ATPAccount |
 
 ### Sprint 27 Summary: MCP Behavioral Tools (COMPLETE)
 
@@ -27,6 +39,12 @@
 | Task | Status | Notes |
 |------|--------|-------|
 | T1: `resolve_trust()` function + `TrustResolution` dataclass | DONE | MRH graph + T3 tensor composition: indirect trust through intermediaries, 2 new exports (362 total), 22 new tests |
+
+### Sprint 24 Summary: Action Outcome Processing Pipeline (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: `process_action_outcome()` function + `ActionOutcomeResult` | DONE | Cross-module composition: R7Action + ReputationEngine + TrustProfile + ATPAccount, 2 new exports (364 total), 18 new tests |
 
 ### Sprint 23 Summary: Release Housekeeping v0.20.0 (COMPLETE)
 
@@ -55,15 +73,15 @@ See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all
 
 ## SDK Status
 
-- **Version**: 0.21.0
+- **Version**: 0.22.0
 - **Modules**: 22 library modules + MCP server entry point (trust, lct, atp, federation, r6, mrh, acp, dictionary, entity, capability, errors, metabolic, binding, society, reputation, security, protocol, mcp, attestation, validation, deserialize, generate, mcp_server)
-- **Tests**: 2567 passing
-- **Exports**: 362 symbols via `web4/__init__.py`
+- **Tests**: 2585 passing
+- **Exports**: 364 symbols via `web4/__init__.py`
 - **from_dict()**: 58 classmethods across 10 modules — all classes with to_dict()/as_dict() have matching from_dict()
 - **Dispatcher**: 23 types via `web4.from_jsonld()` (19 class-based + 3 function-based + TrustQuery)
 - **Generator**: 23 types via `web4.generate()` — minimal valid JSON-LD documents
-- **Behavioral**: 3 functions — `evaluate_trust_query()` (direct trust resolution), `resolve_trust()` (indirect trust through MRH graph), `process_action_outcome()` (action consequences — PR #137)
-- **MCP Server**: `web4-mcp` / `python -m web4.mcp_server` — 7 tools (info, validate, generate, roundtrip, list_types, evaluate_trust, resolve_trust)
+- **Behavioral**: 3 functions — `evaluate_trust_query()` (direct trust resolution), `resolve_trust()` (indirect trust through MRH graph), `process_action_outcome()` (action consequences)
+- **MCP Server**: `web4-mcp` / `python -m web4.mcp_server` — 8 tools (info, validate, generate, roundtrip, list_types, evaluate_trust, resolve_trust, process_action_outcome)
 - **CLI**: `web4 info/validate/list-schemas/roundtrip/generate` (console script + `python -m web4`)
 - **Optional extras**: `web4[validation]` (jsonschema), `web4[mcp]` (mcp), `web4[dev]` (full toolchain)
 - **License**: MIT (SDK), AGPL-3.0 (root repo)
@@ -105,34 +123,35 @@ Web4 SDK development aligns with ARIA grant requirements:
 ## Recent Commits
 
 ```
+16b4d96 Sprint 27 T1: Expose behavioral functions as MCP tools (#140)
+0fc2545 Sprint 26 T1: SDK v0.21.0 release housekeeping (#139)
 4c2585f Sprint 25 T1: resolve_trust() — indirect trust resolution through MRH graphs (#138)
 3a36de3 Sprint 23 T1: SDK v0.20.0 release housekeeping (#136)
 d997500 Sprint 22 T1: evaluate_trust_query() — trust resolution pipeline (#133)
-a0b426a [Publisher] Maintenance: AttestationEnvelope + R6/R7 glossary entries, rebuild artifacts
-dc45c22 Sprint 21 T1: SDK v0.19.0 release housekeeping (#132)
 ```
 
 ---
 
 ## Open PRs
 
-- PR #137: Sprint 24 T1: process_action_outcome() — action consequence pipeline (REVIEW_REQUIRED)
+*None — PR #137 was closed (scope overlap). Sprint 24 resubmitted as a clean PR.*
 
 ---
 
 ## Completeness Summary
 
-- All 27 sprints COMPLETE (Sprints 1-27)
+- All 28 sprints COMPLETE (Sprints 1-28)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
 - Generic `from_jsonld(doc)` dispatches 23 types by `@type` field (web4.deserialize)
 - `web4.generate(type_name)` produces minimal valid JSON-LD for any of 23 types
 - `evaluate_trust_query()` — direct trust resolution composing TrustQuery + TrustProfile + ATPAccount
+- `process_action_outcome()` — action consequence pipeline composing R7Action + ReputationEngine + TrustProfile + ATPAccount
 - `resolve_trust()` — indirect trust resolution composing MRHGraph + TrustProfile T3 tensors
-- MCP server: 7 tools exposing SDK data operations + behavioral trust resolution to MCP clients
+- MCP server: 8 tools exposing SDK data operations + behavioral trust resolution to MCP clients
 - TrustQuery: to_jsonld() for dispatcher + to_dict() for schema validation (trust-query.schema.json)
-- All 22 submodules have `__all__` declarations, 362 root exports
+- All 22 submodules have `__all__` declarations, 364 root exports
 - All public methods have docstrings and return type annotations
 - `mypy --strict` passes with 0 errors across 25 source files
 - Test coverage: 96.2% overall (4 modules at 100%, 16 at 95%+)
@@ -141,4 +160,4 @@ dc45c22 Sprint 21 T1: SDK v0.19.0 release housekeeping (#132)
 
 ---
 
-*Updated by autonomous session, 2026-04-07 (Sprint 27 T1)*
+*Updated by autonomous session, 2026-04-08 (Sprint 24 T1 resubmission)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,7 +1,7 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-07 (Sprint 27 T1)
+**Updated**: 2026-04-08 (Sprint 24 T1 resubmission)
 **Phase**: Development
 **Track**: web4 (Legion)
 

--- a/web4-standard/implementation/sdk/pyproject.toml
+++ b/web4-standard/implementation/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "web4"
-version = "0.21.0"
+version = "0.22.0"
 description = "Web4 SDK — trust tensors, LCTs, ATP/ADP, federation (SAL), R7 actions, MRH, ACP, security, protocol types"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/web4-standard/implementation/sdk/tests/test_cli.py
+++ b/web4-standard/implementation/sdk/tests/test_cli.py
@@ -42,7 +42,7 @@ class TestInfo:
         r = run_cli(["info"])
         assert r.returncode == 0
         assert "web4" in r.stdout
-        assert "0.21.0" in r.stdout
+        assert "0.22.0" in r.stdout
 
     def test_info_shows_module_count(self) -> None:
         r = run_cli(["info"])

--- a/web4-standard/implementation/sdk/tests/test_mcp_server.py
+++ b/web4-standard/implementation/sdk/tests/test_mcp_server.py
@@ -268,9 +268,9 @@ class TestServerRegistration:
     def test_server_name(self) -> None:
         assert mcp.name == "web4"
 
-    def test_seven_tools_registered(self) -> None:
+    def test_eight_tools_registered(self) -> None:
         tools = asyncio.run(mcp.list_tools())
-        assert len(tools) == 7
+        assert len(tools) == 8
 
     def test_tool_names(self) -> None:
         tools = asyncio.run(mcp.list_tools())
@@ -283,6 +283,7 @@ class TestServerRegistration:
             "web4_list_types",
             "web4_evaluate_trust",
             "web4_resolve_trust",
+            "web4_process_action_outcome",
         }
 
     def test_all_tools_have_descriptions(self) -> None:

--- a/web4-standard/implementation/sdk/tests/test_package_api.py
+++ b/web4-standard/implementation/sdk/tests/test_package_api.py
@@ -10,11 +10,11 @@ import web4
 
 class TestPackageVersion:
     def test_version_string(self):
-        assert web4.__version__ == "0.21.0"
+        assert web4.__version__ == "0.22.0"
 
     def test_version_accessible(self):
         from web4 import __version__
-        assert __version__ == "0.21.0"
+        assert __version__ == "0.22.0"
 
 
 class TestAllExports:

--- a/web4-standard/implementation/sdk/tests/test_process_action_outcome.py
+++ b/web4-standard/implementation/sdk/tests/test_process_action_outcome.py
@@ -1,0 +1,338 @@
+"""Tests for process_action_outcome() — the action → consequence pipeline.
+
+Tests the cross-module composition: R7Action + ReputationEngine + TrustProfile
++ ATPAccount → ActionOutcomeResult with updated trust and ATP settlement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from web4.atp import ATPAccount
+from web4.r6 import (
+    ActionStatus,
+    ContributingFactor,
+    R7Action,
+    Request,
+    ResourceRequirements,
+    Result,
+    Role,
+    Rules,
+)
+from web4.reputation import (
+    ActionOutcomeResult,
+    DimensionImpact,
+    Modifier,
+    ReputationEngine,
+    ReputationRule,
+    ReputationStore,
+    process_action_outcome,
+)
+from web4.trust import T3, TrustProfile, V3
+
+
+# ── Fixtures ───────────────────────────────────────────────────
+
+
+def _make_action(
+    *,
+    status: ActionStatus = ActionStatus.SUCCESS,
+    action_type: str = "data_analysis",
+    quality: float = 0.8,
+    atp_stake: float = 10.0,
+    actor: str = "lct:alice",
+    role_lct: str = "web4:DataAnalyst",
+    t3: T3 | None = None,
+    v3: V3 | None = None,
+) -> R7Action:
+    """Build a completed R7Action for testing."""
+    return R7Action(
+        rules=Rules(permissions=[action_type]),
+        role=Role(
+            actor=actor,
+            role_lct=role_lct,
+            t3_in_role=t3 or T3(0.7, 0.8, 0.9),
+            v3_in_role=v3 or V3(0.6, 0.7, 0.8),
+        ),
+        request=Request(action=action_type, atp_stake=atp_stake),
+        resource=ResourceRequirements(required_atp=atp_stake, available_atp=atp_stake),
+        result=Result(
+            status=status,
+            output={"quality": quality},
+        ),
+    )
+
+
+def _make_engine() -> ReputationEngine:
+    """Build an engine with a standard rule for data_analysis actions."""
+    engine = ReputationEngine()
+    engine.add_rule(ReputationRule(
+        rule_id="R001",
+        trigger_conditions={"action_type": "data_analysis", "result_status": "success"},
+        t3_impacts={
+            "talent": DimensionImpact(base_delta=0.05),
+            "training": DimensionImpact(
+                base_delta=0.03,
+                modifiers=[Modifier(condition="high_accuracy", multiplier=1.5)],
+            ),
+        },
+        v3_impacts={
+            "veracity": DimensionImpact(base_delta=0.02),
+        },
+    ))
+    return engine
+
+
+# ── Success path ───────────────────────────────────────────────
+
+
+class TestSuccessPath:
+    """Tests for successful action outcomes."""
+
+    def test_basic_success_returns_result(self) -> None:
+        action = _make_action()
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        profile.set_role("web4:DataAnalyst", T3(0.7, 0.8, 0.9), V3(0.6, 0.7, 0.8))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert isinstance(result, ActionOutcomeResult)
+        assert result.delta is not None
+        assert result.atp_committed == 10.0
+        assert result.atp_rolled_back == 0.0
+
+    def test_t3_updated_in_profile(self) -> None:
+        action = _make_action()
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        profile.set_role("web4:DataAnalyst", T3(0.7, 0.8, 0.9))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        # Talent should increase by 0.05
+        assert result.updated_t3.talent == pytest.approx(0.75, abs=1e-6)
+        # Profile should be mutated
+        assert profile.get_t3("web4:DataAnalyst").talent == pytest.approx(0.75, abs=1e-6)
+
+    def test_v3_updated_in_profile(self) -> None:
+        action = _make_action()
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        # V3 field order: valuation, veracity, validity
+        profile.set_role("web4:DataAnalyst", v3=V3(0.6, 0.7, 0.8))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        # Veracity (0.7) should increase by 0.02 → 0.72
+        assert result.updated_v3.veracity == pytest.approx(0.72, abs=1e-6)
+        assert profile.get_v3("web4:DataAnalyst").veracity == pytest.approx(0.72, abs=1e-6)
+
+    def test_atp_committed_on_success(self) -> None:
+        action = _make_action(atp_stake=15.0)
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=0.0, locked=15.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.atp_committed == 15.0
+        assert account.locked == 0.0
+        assert account.adp == 15.0
+
+    def test_modifier_applied_with_high_quality(self) -> None:
+        action = _make_action(quality=0.9)  # triggers high_accuracy factor
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        profile.set_role("web4:DataAnalyst", T3(0.7, 0.8, 0.9))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        # Training base_delta=0.03 * 1.5 (high_accuracy modifier) = 0.045
+        assert result.updated_t3.training == pytest.approx(0.845, abs=1e-6)
+
+
+# ── Failure path ───────────────────────────────────────────────
+
+
+class TestFailurePath:
+    """Tests for failed action outcomes."""
+
+    def test_atp_rolled_back_on_failure(self) -> None:
+        action = _make_action(status=ActionStatus.FAILURE)
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.atp_committed == 0.0
+        assert result.atp_rolled_back == 10.0
+        assert account.locked == 0.0
+        assert account.available == 10.0
+
+    def test_no_delta_when_no_rules_match_failure(self) -> None:
+        # Engine only has a rule for result_status=success
+        action = _make_action(status=ActionStatus.FAILURE)
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        profile.set_role("web4:DataAnalyst", T3(0.7, 0.8, 0.9))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.delta is None
+        # Trust unchanged
+        assert result.updated_t3.talent == pytest.approx(0.7, abs=1e-6)
+
+    def test_failure_with_matching_rule(self) -> None:
+        action = _make_action(status=ActionStatus.FAILURE)
+        engine = ReputationEngine()
+        engine.add_rule(ReputationRule(
+            rule_id="R002",
+            trigger_conditions={"action_type": "data_analysis", "result_status": "failure"},
+            t3_impacts={
+                "temperament": DimensionImpact(base_delta=-0.05),
+            },
+        ))
+        profile = TrustProfile("lct:alice")
+        profile.set_role("web4:DataAnalyst", T3(0.7, 0.8, 0.9))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.delta is not None
+        assert result.updated_t3.temperament == pytest.approx(0.85, abs=1e-6)
+        assert result.atp_rolled_back == 10.0
+
+
+# ── Edge cases ─────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    """Edge cases and validation."""
+
+    def test_rejects_pending_action(self) -> None:
+        action = _make_action()
+        action.result.status = ActionStatus.PENDING
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=100.0)
+
+        with pytest.raises(ValueError, match="expected 'success' or 'failure'"):
+            process_action_outcome(action, engine, profile, account)
+
+    def test_rejects_in_progress_action(self) -> None:
+        action = _make_action()
+        action.result.status = ActionStatus.IN_PROGRESS
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=100.0)
+
+        with pytest.raises(ValueError, match="expected 'success' or 'failure'"):
+            process_action_outcome(action, engine, profile, account)
+
+    def test_zero_atp_stake(self) -> None:
+        action = _make_action(atp_stake=0.0)
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=100.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.atp_committed == 0.0
+        assert result.atp_rolled_back == 0.0
+        assert account.available == 100.0
+
+    def test_no_matching_rules(self) -> None:
+        action = _make_action(action_type="unknown_action")
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        profile.set_role("web4:DataAnalyst", T3(0.7, 0.8, 0.9), V3(0.6, 0.7, 0.8))
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.delta is None
+        assert result.updated_t3.talent == pytest.approx(0.7, abs=1e-6)
+        # V3(0.6, 0.7, 0.8) → valuation=0.6, veracity=0.7, validity=0.8
+        assert result.updated_v3.veracity == pytest.approx(0.7, abs=1e-6)
+        # ATP still committed (success path)
+        assert result.atp_committed == 10.0
+
+    def test_profile_without_prior_role(self) -> None:
+        """Profile has no entry for the role — should use defaults (0.5)."""
+        action = _make_action()
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        # Don't set role — profile defaults to T3(0.5, 0.5, 0.5)
+        # But engine computes delta based on action.role.t3_in_role = T3(0.7, 0.8, 0.9)
+        # Delta to_value for talent = 0.7 + 0.05 = 0.75
+        # process_action_outcome applies delta to_value directly to profile
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        result = process_action_outcome(action, engine, profile, account)
+
+        assert result.delta is not None
+        # Delta to_value = 0.75 (computed from action's T3, not profile's)
+        assert result.updated_t3.talent == pytest.approx(0.75, abs=1e-6)
+        # Profile should now have the role set
+        assert "web4:DataAnalyst" in profile.roles
+
+
+# ── Store integration ──────────────────────────────────────────
+
+
+class TestStoreIntegration:
+    """Tests for optional ReputationStore recording."""
+
+    def test_delta_recorded_in_store(self) -> None:
+        action = _make_action()
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=0.0, locked=10.0)
+        store = ReputationStore()
+
+        process_action_outcome(action, engine, profile, account, store=store)
+
+        assert store.has_history("lct:alice", "web4:DataAnalyst")
+
+    def test_no_store_recording_without_delta(self) -> None:
+        action = _make_action(action_type="unknown_action")
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=0.0, locked=10.0)
+        store = ReputationStore()
+
+        process_action_outcome(action, engine, profile, account, store=store)
+
+        assert not store.has_history("lct:alice", "web4:DataAnalyst")
+
+    def test_no_store_recording_when_store_not_provided(self) -> None:
+        action = _make_action()
+        engine = _make_engine()
+        profile = TrustProfile("lct:alice")
+        account = ATPAccount(available=0.0, locked=10.0)
+
+        # Should not raise even without store
+        result = process_action_outcome(action, engine, profile, account)
+        assert result.delta is not None
+
+
+# ── Import from web4 root ──────────────────────────────────────
+
+
+class TestRootImport:
+    """Verify exports are accessible from web4 root."""
+
+    def test_process_action_outcome_importable(self) -> None:
+        from web4 import process_action_outcome as pao
+        assert callable(pao)
+
+    def test_action_outcome_result_importable(self) -> None:
+        from web4 import ActionOutcomeResult as AOR
+        assert AOR is not None

--- a/web4-standard/implementation/sdk/web4/__init__.py
+++ b/web4-standard/implementation/sdk/web4/__init__.py
@@ -26,7 +26,7 @@ Provides offline-capable primitives for:
 - Deserialization — generic JSON-LD dispatcher for all Web4 types
 - Generation — produce minimal valid JSON-LD documents for any Web4 type
 
-22 modules + MCP server, 362 exports, 3 behavioral functions. These modules
+22 modules + MCP server, 364 exports, 3 behavioral functions. These modules
 define the canonical data types and algorithms specified in the web4-standard.
 They work offline (no network services required) and are designed to be
 imported by applications, services, and other SDKs that build on web4.
@@ -241,7 +241,9 @@ from .reputation import (
     Modifier,
     ReputationEngine,
     ReputationStore,
+    ActionOutcomeResult,
     analyze_factors,
+    process_action_outcome,
 )
 
 # ── Entity Taxonomy ────────────────────────────────────────────
@@ -569,7 +571,8 @@ __all__ = [
     "AmbiguityHandling", "ChainStep", "EvolutionConfig", "FeedbackRecord",
     # reputation
     "ReputationRule", "DimensionImpact", "Modifier",
-    "ReputationEngine", "ReputationStore", "analyze_factors",
+    "ReputationEngine", "ReputationStore", "ActionOutcomeResult",
+    "analyze_factors", "process_action_outcome",
     # entity
     "BehavioralMode", "EnergyPattern", "InteractionType",
     "EntityTypeInfo", "ENTITY_JSONLD_CONTEXT",

--- a/web4-standard/implementation/sdk/web4/mcp_server.py
+++ b/web4-standard/implementation/sdk/web4/mcp_server.py
@@ -16,7 +16,8 @@ Tools provided:
 - ``web4_roundtrip``        — deserialize + re-serialize for conformance testing
 - ``web4_list_types``       — list all supported types for generation and deserialization
 - ``web4_evaluate_trust``   — evaluate a trust query (ATP stake + T3 lookup + disclosure)
-- ``web4_resolve_trust``    — resolve trust through MRH graph (direct/indirect/none)
+- ``web4_resolve_trust``           — resolve trust through MRH graph (direct/indirect/none)
+- ``web4_process_action_outcome``  — process action through reputation pipeline (T3/V3 + ATP)
 
 Requires the ``mcp`` package: ``pip install 'web4[mcp]'``
 """
@@ -28,7 +29,10 @@ from typing import Any, Dict, List, Optional
 
 from mcp.server.fastmcp import FastMCP
 
-__all__ = ["mcp", "run", "web4_evaluate_trust", "web4_resolve_trust"]
+__all__ = [
+    "mcp", "run",
+    "web4_evaluate_trust", "web4_resolve_trust", "web4_process_action_outcome",
+]
 
 # ---------------------------------------------------------------------------
 # Server instance
@@ -372,6 +376,138 @@ def web4_resolve_trust(
         strategy=strategy, decay_factor=decay_factor,
     )
     return resolution.to_dict()
+
+
+@mcp.tool(
+    name="web4_process_action_outcome",
+    description=(
+        "Process a completed R7 action through the reputation pipeline. "
+        "Evaluates reputation rules, applies T3/V3 deltas to the actor's "
+        "trust profile, and settles ATP (commit on success, rollback on failure)."
+    ),
+)
+def web4_process_action_outcome(
+    action: str,
+    rules: str,
+    profile_entity_id: str,
+    profile_roles: str = "{}",
+    atp_available: float = 0.0,
+    atp_locked: float = 0.0,
+) -> Dict[str, Any]:
+    """Process a completed action through the reputation and trust pipeline.
+
+    Args:
+        action: JSON string of R7Action fields (must include role with
+            role_lct, request with atp_stake, result with status).
+        rules: JSON string -- list of reputation rule objects, each with
+            rule_id, trigger_conditions, and t3_impacts/v3_impacts.
+        profile_entity_id: Entity ID for the actor's trust profile.
+        profile_roles: JSON string mapping role names to T3/V3 dicts, e.g.
+            ``{"analyst": {"talent": 0.8, "training": 0.9, "temperament": 0.7}}``.
+        atp_available: Available (unlocked) ATP balance. Default 0.
+        atp_locked: Locked ATP balance (the stake). Default 0.
+    """
+    from web4.atp import ATPAccount
+    from web4.r6 import (
+        R7Action as R7ActionCls,
+        Reference,
+        Request,
+        ResourceRequirements,
+        Result,
+        Role,
+        Rules,
+    )
+    from web4.reputation import (
+        DimensionImpact,
+        Modifier,
+        ReputationEngine,
+        ReputationRule,
+        process_action_outcome,
+    )
+    from web4.trust import T3, V3, TrustProfile
+
+    # Parse action from component dicts
+    try:
+        action_dict = json.loads(action)
+    except json.JSONDecodeError as exc:
+        return {"error": f"Invalid action JSON: {exc}"}
+    try:
+        r7 = R7ActionCls(
+            rules=Rules.from_dict(action_dict.get("rules", {})),
+            role=Role.from_dict(action_dict.get("role", {"actor": "", "role_lct": ""})),
+            request=Request.from_dict(action_dict.get("request", {"action": ""})),
+            reference=Reference.from_dict(action_dict.get("reference", {})),
+            resource=ResourceRequirements.from_dict(action_dict.get("resource", {})),
+            result=Result.from_dict(action_dict.get("result", {})),
+        )
+    except (KeyError, ValueError, TypeError) as exc:
+        return {"error": f"Invalid R7Action: {exc}"}
+
+    # Build reputation engine from rules
+    try:
+        rules_list = json.loads(rules)
+    except json.JSONDecodeError as exc:
+        return {"error": f"Invalid rules JSON: {exc}"}
+    if not isinstance(rules_list, list):
+        return {"error": "rules must be a JSON array of rule objects"}
+
+    engine = ReputationEngine()
+    for rule_data in rules_list:
+        try:
+            t3_impacts = {}
+            for dim, impact_data in rule_data.get("t3_impacts", {}).items():
+                modifiers = [
+                    Modifier(**m) for m in impact_data.get("modifiers", [])
+                ]
+                t3_impacts[dim] = DimensionImpact(
+                    base_delta=impact_data["base_delta"],
+                    modifiers=modifiers,
+                )
+            v3_impacts = {}
+            for dim, impact_data in rule_data.get("v3_impacts", {}).items():
+                modifiers = [
+                    Modifier(**m) for m in impact_data.get("modifiers", [])
+                ]
+                v3_impacts[dim] = DimensionImpact(
+                    base_delta=impact_data["base_delta"],
+                    modifiers=modifiers,
+                )
+            engine.add_rule(ReputationRule(
+                rule_id=rule_data["rule_id"],
+                trigger_conditions=rule_data.get("trigger_conditions", {}),
+                t3_impacts=t3_impacts,
+                v3_impacts=v3_impacts,
+            ))
+        except (KeyError, ValueError, TypeError) as exc:
+            return {"error": f"Invalid rule: {exc} -- data: {rule_data}"}
+
+    # Build actor profile
+    profile = TrustProfile(profile_entity_id)
+    try:
+        roles_dict = json.loads(profile_roles)
+    except json.JSONDecodeError as exc:
+        return {"error": f"Invalid profile_roles JSON: {exc}"}
+    for role_name, tensor_data in roles_dict.items():
+        t3 = T3.from_dict(tensor_data) if "talent" in tensor_data else None
+        v3 = V3.from_dict(tensor_data) if "valuation" in tensor_data else None
+        profile.set_role(role_name, t3=t3, v3=v3)
+
+    # Build ATP account
+    account = ATPAccount(available=atp_available, locked=atp_locked)
+
+    # Process
+    try:
+        result = process_action_outcome(r7, engine, profile, account)
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return {
+        "delta": result.delta.to_dict() if result.delta is not None else None,
+        "updated_t3": result.updated_t3.as_dict(),
+        "updated_v3": result.updated_v3.as_dict(),
+        "atp_committed": result.atp_committed,
+        "atp_rolled_back": result.atp_rolled_back,
+    }
 
 
 @mcp.tool(

--- a/web4-standard/implementation/sdk/web4/reputation.py
+++ b/web4-standard/implementation/sdk/web4/reputation.py
@@ -23,20 +23,24 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+from .atp import ATPAccount
 from .r6 import (
+    ActionStatus,
     ContributingFactor,
     R7Action,
     ReputationDelta,
     TensorDelta,
 )
-from .trust import T3, V3, _clamp
+from .trust import T3, TrustProfile, V3, _clamp
 
 __all__ = [
     # Classes
     "ReputationRule", "DimensionImpact", "Modifier",
     "ReputationEngine", "ReputationStore",
+    "ActionOutcomeResult",
     # Functions
     "analyze_factors",
+    "process_action_outcome",
 ]
 
 
@@ -483,3 +487,119 @@ class ReputationStore:
     def has_history(self, entity_lct: str, role_lct: str) -> bool:
         """Check if store has any deltas for this entity+role pair."""
         return (entity_lct, role_lct) in self._deltas
+
+
+# ── Action Outcome Processing ──────────────────────────────────
+
+
+@dataclass
+class ActionOutcomeResult:
+    """Result of processing a completed R7Action through the reputation pipeline.
+
+    Contains the reputation delta (if rules matched), the updated T3/V3
+    tensors for the actor's role, and ATP settlement details.
+    """
+    delta: Optional[ReputationDelta]
+    updated_t3: T3
+    updated_v3: V3
+    atp_committed: float
+    atp_rolled_back: float
+
+
+def process_action_outcome(
+    action: R7Action,
+    engine: ReputationEngine,
+    profile: TrustProfile,
+    account: ATPAccount,
+    *,
+    store: Optional[ReputationStore] = None,
+) -> ActionOutcomeResult:
+    """Process a completed R7Action through the reputation and trust pipeline.
+
+    This is the core "action → consequence" composition function. It takes
+    a completed action (status SUCCESS or FAILURE) and:
+
+    1. Evaluates reputation rules via the engine → ReputationDelta
+    2. Applies T3/V3 deltas to the actor's TrustProfile
+    3. Settles ATP: commits locked stake on success, rolls back on failure
+    4. Optionally records the delta in a ReputationStore
+
+    Does NOT evaluate policy (that's PolicyGate). Operates on the OUTCOME
+    of an already-completed action.
+
+    Args:
+        action: A completed R7Action (status must be SUCCESS or FAILURE).
+        engine: ReputationEngine with rules to evaluate.
+        profile: Actor's TrustProfile (mutated in place with updated tensors).
+        account: Actor's ATPAccount (mutated in place with ATP settlement).
+        store: Optional ReputationStore to record the delta for aggregation.
+
+    Returns:
+        ActionOutcomeResult with delta, updated tensors, and ATP settlement.
+
+    Raises:
+        ValueError: If action status is not SUCCESS or FAILURE.
+    """
+    status = action.result.status
+    if status not in (ActionStatus.SUCCESS, ActionStatus.FAILURE):
+        raise ValueError(
+            f"Cannot process action with status '{status.value}'; "
+            f"expected 'success' or 'failure'"
+        )
+
+    # Step 1: Evaluate reputation rules
+    delta = engine.evaluate(action)
+
+    # Step 2: Apply T3/V3 deltas to the actor's trust profile
+    role = action.role.role_lct
+    current_t3 = profile.get_t3(role)
+    current_v3 = profile.get_v3(role)
+
+    if delta is not None:
+        # Apply T3 deltas
+        t3_kwargs = {
+            "talent": current_t3.talent,
+            "training": current_t3.training,
+            "temperament": current_t3.temperament,
+        }
+        for dim, td in delta.t3_delta.items():
+            t3_kwargs[dim] = td.to_value
+
+        # Apply V3 deltas
+        v3_kwargs = {
+            "veracity": current_v3.veracity,
+            "validity": current_v3.validity,
+            "valuation": current_v3.valuation,
+        }
+        for dim, td in delta.v3_delta.items():
+            v3_kwargs[dim] = td.to_value
+
+        updated_t3 = T3(**t3_kwargs)
+        updated_v3 = V3(**v3_kwargs)
+        profile.set_role(role, t3=updated_t3, v3=updated_v3)
+    else:
+        updated_t3 = current_t3
+        updated_v3 = current_v3
+
+    # Step 3: Settle ATP — commit on success, rollback on failure
+    atp_stake = action.request.atp_stake
+    atp_committed = 0.0
+    atp_rolled_back = 0.0
+
+    if atp_stake > 0:
+        if status == ActionStatus.SUCCESS:
+            atp_committed = account.commit(atp_stake)
+        else:
+            atp_rolled_back = account.rollback(atp_stake)
+
+    # Step 4: Optionally record in store for time-weighted aggregation
+    if delta is not None and store is not None:
+        store.record(delta)
+
+    return ActionOutcomeResult(
+        delta=delta,
+        updated_t3=updated_t3,
+        updated_v3=updated_v3,
+        atp_committed=atp_committed,
+        atp_rolled_back=atp_rolled_back,
+    )


### PR DESCRIPTION
## Summary

- Re-lands `process_action_outcome()` + `ActionOutcomeResult` from closed PR #137 (Sprint 24 T1)
- Adds `web4_process_action_outcome` MCP tool (8 tools total: 5 data + 3 behavioral)
- Version bump 0.21.0 → 0.22.0 with CHANGELOG entry

## Context

PR #137 bundled Sprint 24 + Sprint 25 content. Sprint 25 landed separately via PR #138, causing merge conflicts. PR #137 was closed as stale. This PR re-lands only the Sprint 24 content (process_action_outcome) cleanly against current main.

## Changes

- `web4/reputation.py` — `ActionOutcomeResult` dataclass + `process_action_outcome()` function (~120 lines)
- `web4/mcp_server.py` — `web4_process_action_outcome` MCP tool wrapper
- `web4/__init__.py` — 2 new exports (364 total)
- `tests/test_process_action_outcome.py` — 18 new tests (1 new file)
- `tests/test_mcp_server.py` — updated registration tests (7 → 8 tools)
- `pyproject.toml` — version 0.22.0
- `CHANGELOG.md`, `SESSION_FOCUS.md`, `docs/SPRINT.md` — metadata updates

## Test plan

- [x] 2585 tests passing (up from 2567)
- [x] mypy --strict clean (25 files, 0 errors)
- [x] All 18 new tests cover: success path (5), failure path (3), edge cases (5), store integration (3), root imports (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)