### PR TITLE
Sprint 30 T1: web4 trust CLI subcommand

### DIFF
--- a/web4-standard/implementation/sdk/tests/test_cli.py
+++ b/web4-standard/implementation/sdk/tests/test_cli.py
@@ -311,6 +311,147 @@ class TestGenerate:
         assert "type argument required" in err
 
 
+# ── trust subcommand (in-process) ──────────────────────────────────
+
+
+class TestTrust:
+    def test_trust_with_flags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["trust", "--actor", "lct:alice", "--target", "lct:bob", "--role", "analyst"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        doc = json.loads(out)
+        assert doc["status"] == "APPROVED"
+        assert doc["response"]["entity"] == "lct:bob"
+        assert doc["response"]["role"] == "analyst"
+
+    def test_trust_with_profile_roles(self, capsys: pytest.CaptureFixture[str]) -> None:
+        roles = '{"analyst": {"talent": 0.8, "training": 0.9, "temperament": 0.7}}'
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--profile-roles", roles,
+        ])
+        out = capsys.readouterr().out
+        assert rc == 0
+        doc = json.loads(out)
+        assert doc["status"] == "APPROVED"
+        t3 = doc["response"]["t3_in_role"]
+        # With range disclosure (default), T3 composite is returned
+        assert "talent" in t3 or "composite" in t3
+
+    def test_trust_precise_disclosure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        roles = '{"analyst": {"talent": 0.8, "training": 0.9, "temperament": 0.7}}'
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--disclosure-level", "precise",
+            "--profile-roles", roles,
+        ])
+        out = capsys.readouterr().out
+        assert rc == 0
+        doc = json.loads(out)
+        assert doc["status"] == "APPROVED"
+        t3 = doc["response"]["t3_in_role"]
+        assert t3["talent"] == 0.8
+
+    def test_trust_binary_disclosure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--disclosure-level", "binary",
+        ])
+        out = capsys.readouterr().out
+        assert rc == 0
+        doc = json.loads(out)
+        assert doc["status"] == "APPROVED"
+        # Binary disclosure does not reveal T3 dimensions
+        assert doc["response"].get("t3_in_role") is None
+
+    def test_trust_insufficient_atp(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--atp-balance", "5",
+        ])
+        out = capsys.readouterr().out
+        assert rc == 0  # command succeeds, but query is rejected
+        doc = json.loads(out)
+        assert doc["status"] == "REJECTED"
+        assert doc["error"]["code"] == "INSUFFICIENT_STAKE"
+
+    def test_trust_compact_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--compact",
+        ])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "\n" not in out.strip()
+
+    def test_trust_missing_required_flags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["trust"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "--actor" in err
+
+    def test_trust_from_json_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        query_doc = {
+            "query": {
+                "querier": "lct:alice",
+                "target_entity": "lct:bob",
+                "requested_role": "admin",
+                "intended_interaction": "test",
+                "atp_stake": 10,
+                "validity_period": 3600,
+            },
+            "signature": "test-sig",
+        }
+        path = _make_json_file(query_doc)
+        rc = main(["trust", "--file", path])
+        out = capsys.readouterr().out
+        assert rc == 0
+        doc = json.loads(out)
+        assert doc["status"] == "APPROVED"
+        assert doc["response"]["role"] == "admin"
+
+    def test_trust_invalid_json_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        path = _make_text_file("{broken json")
+        rc = main(["trust", "--file", path])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "invalid JSON" in err
+
+    def test_trust_invalid_query_in_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        path = _make_json_file({"not": "a trust query"})
+        rc = main(["trust", "--file", path])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "invalid TrustQuery" in err
+
+    def test_trust_invalid_disclosure_level(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--disclosure-level", "invalid",
+        ])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "invalid disclosure level" in err.lower()
+
+    def test_trust_invalid_profile_roles_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--profile-roles", "{broken",
+        ])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "profile-roles" in err.lower() or "json" in err.lower()
+
+    def test_trust_invalid_t3_in_profile_roles(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main([
+            "trust", "--actor", "lct:alice", "--target", "lct:bob",
+            "--role", "analyst", "--profile-roles", '{"analyst": "not-a-dict"}',
+        ])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "invalid T3" in err or "Error" in err
+
+
 # ── Parser and help (in-process) ─────────────────────────────────
 
 

--- a/web4-standard/implementation/sdk/web4/__main__.py
+++ b/web4-standard/implementation/sdk/web4/__main__.py
@@ -10,6 +10,8 @@ Subcommands::
     python -m web4 roundtrip --check  # Verify round-trip fidelity
     python -m web4 generate T3Tensor  # Generate a minimal valid JSON-LD document
     python -m web4 selftest           # Verify SDK installation
+    python -m web4 trust Q.json       # Evaluate a trust query from JSON file
+    python -m web4 trust --actor A --target B --role R  # Quick trust evaluation
 """
 
 from __future__ import annotations
@@ -316,6 +318,92 @@ def _cmd_selftest(args: argparse.Namespace) -> int:
     return 0
 
 
+# ── trust subcommand ─────────────────────────────────────────
+
+
+def _cmd_trust(args: argparse.Namespace) -> int:
+    """Evaluate a trust query against a profile with ATP stake locking."""
+    from web4.atp import ATPAccount
+    from web4.trust import (
+        DisclosureLevel,
+        T3,
+        TrustProfile,
+        TrustQuery,
+        evaluate_trust_query,
+    )
+
+    # If --file provided, read query from JSON file/stdin
+    file_path: Optional[str] = args.file
+    if file_path is not None:
+        doc, err = _read_json_doc(file_path)
+        if doc is None:
+            return err  # type: ignore[return-value]
+        try:
+            query = TrustQuery.from_dict(doc)
+        except (KeyError, ValueError, TypeError) as exc:
+            print(f"Error: invalid TrustQuery: {exc}", file=sys.stderr)
+            return 1
+    else:
+        # Build query from CLI flags
+        actor: Optional[str] = args.actor
+        target: Optional[str] = args.target
+        role: Optional[str] = args.role
+        if not all([actor, target, role]):
+            print(
+                "Error: --actor, --target, and --role are required "
+                "(or use --file to provide a JSON query)",
+                file=sys.stderr,
+            )
+            return 1
+        # These assertions are safe — we checked all() above
+        assert actor is not None
+        assert target is not None
+        assert role is not None
+        dl_str: str = args.disclosure_level
+        try:
+            dl = DisclosureLevel(dl_str)
+        except ValueError:
+            valid = ", ".join(d.value for d in DisclosureLevel)
+            print(f"Error: invalid disclosure level {dl_str!r}. Valid: {valid}", file=sys.stderr)
+            return 1
+        query = TrustQuery(
+            querier=actor,
+            target_entity=target,
+            requested_role=role,
+            intended_interaction=args.interaction,
+            atp_stake=args.stake,
+            validity_period=args.validity,
+            signature="cli-generated",
+            disclosure_level=dl,
+        )
+
+    # Build target profile from --profile-roles JSON if provided
+    profile = TrustProfile(query.target_entity)
+    roles_json: Optional[str] = args.profile_roles
+    if roles_json is not None:
+        try:
+            roles_dict = json.loads(roles_json)
+        except json.JSONDecodeError as exc:
+            print(f"Error: invalid --profile-roles JSON: {exc}", file=sys.stderr)
+            return 1
+        for role_name, t3_data in roles_dict.items():
+            try:
+                profile.set_role(role_name, T3.from_dict(t3_data))
+            except (KeyError, ValueError, TypeError, AttributeError) as exc:
+                print(f"Error: invalid T3 for role {role_name!r}: {exc}", file=sys.stderr)
+                return 1
+
+    # Build requester ATP account
+    atp_balance: float = args.atp_balance
+    account = ATPAccount(available=atp_balance)
+
+    # Evaluate
+    response = evaluate_trust_query(query, profile, account)
+    indent = None if args.compact else 2
+    print(json.dumps(response.to_dict(), indent=indent))
+    return 0
+
+
 # ── Schema auto-detection ──────────────────────────────────────
 
 # @type value -> schema name mapping
@@ -449,6 +537,49 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show per-phase progress details.",
     )
 
+    # trust
+    p_trust = sub.add_parser(
+        "trust",
+        help="Evaluate a trust query (from JSON or CLI flags)",
+    )
+    p_trust.add_argument(
+        "--file", default=None,
+        help="Path to TrustQuery JSON file (or '-' for stdin). "
+             "Overrides --actor/--target/--role flags.",
+    )
+    p_trust.add_argument("--actor", default=None, help="Querier entity ID")
+    p_trust.add_argument("--target", default=None, help="Target entity ID")
+    p_trust.add_argument("--role", default=None, help="Requested role")
+    p_trust.add_argument(
+        "--interaction", default="cli-query",
+        help="Intended interaction description (default: cli-query)",
+    )
+    p_trust.add_argument(
+        "--disclosure-level", default="range", dest="disclosure_level",
+        help="Disclosure level: binary, range, or precise (default: range)",
+    )
+    p_trust.add_argument(
+        "--stake", type=int, default=10,
+        help="ATP stake amount (default: 10, minimum allowed)",
+    )
+    p_trust.add_argument(
+        "--validity", type=int, default=3600,
+        help="Validity period in seconds (default: 3600)",
+    )
+    p_trust.add_argument(
+        "--profile-roles", default=None,
+        help='JSON mapping role->T3 for target, e.g. '
+             '\'{"analyst": {"talent": 0.8, "training": 0.9, "temperament": 0.7}}\'',
+    )
+    p_trust.add_argument(
+        "--atp-balance", type=float, default=1000.0, dest="atp_balance",
+        help="Requester ATP balance (default: 1000.0)",
+    )
+    p_trust.add_argument(
+        "--compact", action="store_true",
+        help="Output compact JSON (no indentation)",
+    )
+
     return parser
 
 
@@ -468,6 +599,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "roundtrip": _cmd_roundtrip,
         "generate": _cmd_generate,
         "selftest": _cmd_selftest,
+        "trust": _cmd_trust,
     }
 
     handler = dispatch.get(args.command)


### PR DESCRIPTION
## Summary

- Add `web4 trust` CLI subcommand — 6th subcommand, wraps `evaluate_trust_query()` for terminal-based trust query evaluation
- Two modes: CLI flags (`--actor`/`--target`/`--role` + options) for quick queries, `--file` for complex TrustQuery JSON documents
- 13 new tests (TestTrust class, in-process style per Sprint 29), 2621 total tests passing, mypy strict clean (25 files), 0 new files

## Usage

```bash
# Quick trust evaluation with flags
web4 trust --actor lct:alice --target lct:bob --role analyst

# With custom profile and precise disclosure
web4 trust --actor lct:alice --target lct:bob --role analyst \
  --disclosure-level precise \
  --profile-roles '{"analyst": {"talent": 0.8, "training": 0.9, "temperament": 0.7}}'

# From JSON file
web4 trust --file query.json

# Compact output
web4 trust --actor lct:alice --target lct:bob --role analyst --compact
```

## Test plan
- [x] All 13 TestTrust tests pass (flags, file input, disclosure levels, error handling)
- [x] Full suite: 2621 tests passing (up from 2608)
- [x] mypy --strict: 0 errors across 25 files
- [x] Manual verification of all CLI paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)