### PR TITLE
Sprint 30 T1: Distribution verification — fix roundtrip fidelity + packaging

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-10 (Sprint 29)*
+*Last updated: 2026-04-10 (Sprint 30)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 30 Summary: Distribution Verification + Roundtrip Fidelity (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: Wheel verification + roundtrip fixes | DONE | 4 bugs fixed (LCT @type, LCT schema, DictionaryEntity lct_id, license format), 2610 total tests |
 
 ### Sprint 29 Summary: CLI Test Coverage Hardening (COMPLETE)
 
@@ -76,7 +82,7 @@ See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all
 
 - **Version**: 0.22.0
 - **Modules**: 22 library modules + MCP server entry point (trust, lct, atp, federation, r6, mrh, acp, dictionary, entity, capability, errors, metabolic, binding, society, reputation, security, protocol, mcp, attestation, validation, deserialize, generate, mcp_server)
-- **Tests**: 2608 passing
+- **Tests**: 2610 passing
 - **Exports**: 364 symbols via `web4/__init__.py`
 - **from_dict()**: 58 classmethods across 10 modules — all classes with to_dict()/as_dict() have matching from_dict()
 - **Dispatcher**: 23 types via `web4.from_jsonld()` (19 class-based + 3 function-based + TrustQuery)
@@ -141,7 +147,7 @@ None.
 
 ## Completeness Summary
 
-- All 29 sprints COMPLETE (Sprints 1-29)
+- All 30 sprints COMPLETE (Sprints 1-30)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -155,10 +161,12 @@ None.
 - All 22 submodules have `__all__` declarations, 364 root exports
 - All public methods have docstrings and return type annotations
 - `mypy --strict` passes with 0 errors across 25 source files
-- Test coverage: 96.2% overall (4 modules at 100%, 16 at 95%+)
+- Test coverage: 97.8% overall (4 modules at 100%, 16 at 95%+)
 - Schema validation via `web4.validation.validate()` with `pip install web4[validation]`
 - CLI via `web4 info/validate/list-schemas/roundtrip/generate`
+- Wheel distribution verified: imports, CLI, schema validation, roundtrip all pass from installed wheel
+- All 23 generate() types pass roundtrip fidelity (generate → from_jsonld → to_jsonld = identical)
 
 ---
 
-*Updated by autonomous session, 2026-04-10 (Sprint 29 — CLI test coverage hardening)*
+*Updated by autonomous session, 2026-04-10 (Sprint 30 — distribution verification + roundtrip fidelity)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,32 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-10 (Sprint 29)
+**Updated**: 2026-04-10 (Sprint 30)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 30: Distribution Verification + Roundtrip Fidelity (2026-04-10)
+
+Wheel distribution verification uncovered real bugs: LCT JSON-LD roundtrip
+losing `@type`, DictionaryEntity roundtrip losing `lct_id`, and LCT schema
+rejecting valid `@type` fields. Also fixed setuptools license deprecation.
+
+### T1: Wheel distribution verification + roundtrip bug fixes
+**Status**: DONE
+**Completed**: 2026-04-10
+**Scope**: Build a wheel, install in isolated venv, verify all SDK features.
+Fix all roundtrip fidelity issues and packaging warnings discovered.
+**Result**: 4 bugs fixed:
+1. `LCT.to_jsonld()` now includes `@type: "web4:LinkedContextToken"` (roundtrip fidelity)
+2. LCT JSON Schema now allows optional `@type` property (was rejecting valid documents)
+3. `DictionaryEntity.from_jsonld()` now preserves `lct_id` from original document
+4. `pyproject.toml` license updated to SPDX format (fixes setuptools deprecation)
+Removed `@type` workaround from `generate.py`. Rebuilt `schema_registry.json`.
+Updated LCT test vectors (10 vectors, all with `@type`). Added LCT to dispatcher
+lifecycle test. 2610 tests passing (up from 2608). mypy strict clean (25 files).
+Wheel verified: 14 import tests + CLI + schema validation + roundtrip all pass.
 
 ---
 

--- a/web4-standard/implementation/sdk/pyproject.toml
+++ b/web4-standard/implementation/sdk/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.22.0"
 description = "Web4 SDK — trust tensors, LCTs, ATP/ADP, federation (SAL), R7 actions, MRH, ACP, security, protocol types"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
 authors = [{name = "Web4 Infrastructure Team"}]
 keywords = [
     "web4",
@@ -26,7 +26,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/web4-standard/implementation/sdk/tests/test_deserialize.py
+++ b/web4-standard/implementation/sdk/tests/test_deserialize.py
@@ -39,11 +39,7 @@ def _make_v3_doc() -> Dict[str, Any]:
 def _make_lct_doc() -> Dict[str, Any]:
     from web4.lct import LCT, EntityType
 
-    # LCT.to_jsonld() doesn't include @type at the top level (spec §2.3 format).
-    # The dispatcher needs @type, so we add it explicitly for the round-trip test.
-    doc = LCT.create(entity_type=EntityType.AI, public_key="test-key").to_jsonld()
-    doc["@type"] = "LinkedContextToken"
-    return doc
+    return LCT.create(entity_type=EntityType.AI, public_key="test-key").to_jsonld()
 
 
 def _make_atp_account_doc() -> Dict[str, Any]:

--- a/web4-standard/implementation/sdk/tests/test_jsonld_lifecycle.py
+++ b/web4-standard/implementation/sdk/tests/test_jsonld_lifecycle.py
@@ -113,9 +113,6 @@ class TestLCTLifecycle:
         )
         doc = lct.to_jsonld()
 
-        # Note: LCT.to_jsonld() omits @type per spec §2.3 canonical format.
-        # The generic dispatcher requires @type, so we test the class-specific
-        # from_jsonld here and the dispatcher for types that include @type.
         restored = LCT.from_jsonld(doc)
         assert restored.lct_id == lct.lct_id
         assert restored.subject == lct.subject
@@ -603,6 +600,10 @@ class TestDictionaryLifecycle:
 # ═══════════════════════════════════════════════════════════════════
 
 
+def _make_lct_doc() -> dict:
+    return LCT.create(entity_type=EntityType.AI, public_key="test-key").to_jsonld()
+
+
 def _make_t3_doc() -> dict:
     return T3(0.8, 0.8, 0.8).to_jsonld()
 
@@ -756,8 +757,8 @@ def _make_trust_query_doc() -> dict:
     return q.to_jsonld()
 
 
-# Map: (type_name, factory) — Note: LCT omitted since to_jsonld() excludes @type
 _ALL_DISPATCHER_TYPES = [
+    ("LinkedContextToken", _make_lct_doc),
     ("T3Tensor", _make_t3_doc),
     ("V3Tensor", _make_v3_doc),
     ("AttestationEnvelope", _make_attestation_doc),

--- a/web4-standard/implementation/sdk/web4/dictionary.py
+++ b/web4-standard/implementation/sdk/web4/dictionary.py
@@ -593,6 +593,9 @@ class DictionaryEntity:
             compression=spec.compression,
             dictionary_type=spec.dictionary_type,
         )
+        # Restore original lct_id if present (roundtrip fidelity)
+        if "lct_id" in doc:
+            entity.lct.lct_id = doc["lct_id"]
         entity.translation_count = doc.get("translation_count", 0)
         entity.successful_translations = doc.get("successful_translations", 0)
         return entity

--- a/web4-standard/implementation/sdk/web4/generate.py
+++ b/web4-standard/implementation/sdk/web4/generate.py
@@ -273,10 +273,7 @@ def _make_lct() -> Dict[str, Any]:
         society="lct:web4:society:example",
         witnesses=["witness-1", "witness-2"],
     )
-    doc = lct.to_jsonld()
-    # LCT.to_jsonld() omits @type per spec §2.3; add it for generate output
-    doc["@type"] = "web4:LinkedContextToken"
-    return doc
+    return lct.to_jsonld()
 
 
 # ---------------------------------------------------------------------------

--- a/web4-standard/implementation/sdk/web4/lct.py
+++ b/web4-standard/implementation/sdk/web4/lct.py
@@ -527,6 +527,7 @@ class LCT:
         """
         doc: Dict[str, Any] = {
             "@context": [LCT_JSONLD_CONTEXT],
+            "@type": "web4:LinkedContextToken",
             "lct_id": self.lct_id,
             "subject": self.subject,
         }

--- a/web4-standard/implementation/sdk/web4/schema_registry.json
+++ b/web4-standard/implementation/sdk/web4/schema_registry.json
@@ -1588,6 +1588,11 @@
         "minItems": 1,
         "description": "JSON-LD context URIs. First MUST be the LCT context."
       },
+      "@type": {
+        "type": "string",
+        "const": "web4:LinkedContextToken",
+        "description": "JSON-LD type identifier."
+      },
       "lct_id": {
         "type": "string",
         "pattern": "^lct:",

--- a/web4-standard/schemas/lct-jsonld.schema.json
+++ b/web4-standard/schemas/lct-jsonld.schema.json
@@ -22,6 +22,11 @@
       "minItems": 1,
       "description": "JSON-LD context URIs. First MUST be the LCT context."
     },
+    "@type": {
+      "type": "string",
+      "const": "web4:LinkedContextToken",
+      "description": "JSON-LD type identifier."
+    },
     "lct_id": {
       "type": "string",
       "pattern": "^lct:",

--- a/web4-standard/test-vectors/lct/lct-jsonld-vectors.json
+++ b/web4-standard/test-vectors/lct/lct-jsonld-vectors.json
@@ -3,7 +3,7 @@
     "format": "lct-jsonld-vectors",
     "version": "1.0",
     "description": "Cross-language test vectors for LCT JSON-LD serialization per spec section 2.3",
-    "generated_by": "web4 Python SDK v0.6.0",
+    "generated_by": "web4 Python SDK v0.22.0",
     "spec_reference": "web4-standard/core-spec/LCT-linked-context-token.md section 2.3",
     "tolerance": 1e-10
   },
@@ -15,6 +15,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:ai:minimal001",
         "subject": "did:web4:key:z6MkMinimal001",
         "binding": {
@@ -83,6 +84,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:human:full002",
         "subject": "did:web4:key:z6MkFull002",
         "binding": {
@@ -204,6 +206,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:ai:revoked003",
         "subject": "did:web4:key:z6MkRevoked003",
         "binding": {
@@ -273,6 +276,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:service:attested004",
         "subject": "did:web4:key:z6MkService004",
         "binding": {
@@ -370,6 +374,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:ai:lineage005",
         "subject": "did:web4:key:z6MkLineage005",
         "binding": {
@@ -455,6 +460,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:organization:mrh006",
         "subject": "did:web4:key:z6MkOrg006",
         "binding": {
@@ -544,6 +550,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:device:boundary007",
         "subject": "did:web4:key:z6MkDevice007",
         "binding": {
@@ -611,6 +618,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:hybrid:suspended008",
         "subject": "did:web4:key:z6MkHybrid008",
         "binding": {
@@ -678,6 +686,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:human:genesis009",
         "subject": "did:web4:key:z6MkGenesis009",
         "binding": {
@@ -748,6 +757,7 @@
         "@context": [
           "https://web4.io/contexts/lct.jsonld"
         ],
+        "@type": "web4:LinkedContextToken",
         "lct_id": "lct:web4:oracle:nobc010",
         "subject": "did:web4:key:z6MkOracle010",
         "binding": {


### PR DESCRIPTION
## Summary

Wheel distribution verification revealed 4 real bugs that would affect any consumer installing the SDK from PyPI:

- **LCT roundtrip fidelity**: `LCT.to_jsonld()` was the only type (of 23) omitting `@type`, breaking `generate → from_jsonld → to_jsonld` pipeline and schema validation
- **DictionaryEntity roundtrip**: `from_jsonld()` was generating new random `lct_id` instead of preserving the original
- **LCT schema**: `additionalProperties: false` without `@type` in properties was rejecting valid documents
- **License deprecation**: `license = {text = "MIT"}` table format deprecated by setuptools >= 77

All 23 types now pass roundtrip fidelity (`generate → from_jsonld → to_jsonld = identical`).

## Changes

- `web4/lct.py` — Add `@type` to `to_jsonld()` output
- `web4/dictionary.py` — Preserve `lct_id` in `from_jsonld()`
- `web4/generate.py` — Remove `@type` workaround for LCT
- `lct-jsonld.schema.json` — Allow optional `@type` property
- `pyproject.toml` — SPDX license format (`license = "MIT"`)
- 10 LCT test vectors updated with `@type`
- LCT added to dispatcher lifecycle test (+2 tests)
- Rebuilt `schema_registry.json`

## Test plan

- [x] 2610 tests passing (up from 2608)
- [x] mypy --strict clean (25 files)
- [x] Wheel built, installed in isolated venv, 14 import tests pass
- [x] CLI commands (info, list-schemas, generate, roundtrip) work from wheel
- [x] Schema validation passes from wheel (bundled registry)
- [x] All 23 generate() types pass roundtrip fidelity
- [x] `web4 roundtrip --check` passes for LinkedContextToken

🤖 Generated with [Claude Code](https://claude.com/claude-code)