### PR TITLE
Sprint 31 T1: SDK v0.23.0 release housekeeping

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-10 (Sprint 30)*
+*Last updated: 2026-04-11 (Sprint 31)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 31 Summary: SDK v0.23.0 Release Housekeeping (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: v0.23.0 release housekeeping | DONE | Version bump, CHANGELOG for Sprints 29+30, README/docstring updates, 2610 tests |
 
 ### Sprint 30 Summary: Distribution Verification + Roundtrip Fidelity (COMPLETE)
 
@@ -80,9 +86,9 @@ See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all
 
 ## SDK Status
 
-- **Version**: 0.22.0
+- **Version**: 0.23.0
 - **Modules**: 22 library modules + MCP server entry point (trust, lct, atp, federation, r6, mrh, acp, dictionary, entity, capability, errors, metabolic, binding, society, reputation, security, protocol, mcp, attestation, validation, deserialize, generate, mcp_server)
-- **Tests**: 2610 passing
+- **Tests**: 2610 passing (97.8% coverage)
 - **Exports**: 364 symbols via `web4/__init__.py`
 - **from_dict()**: 58 classmethods across 10 modules — all classes with to_dict()/as_dict() have matching from_dict()
 - **Dispatcher**: 23 types via `web4.from_jsonld()` (19 class-based + 3 function-based + TrustQuery)
@@ -130,24 +136,24 @@ Web4 SDK development aligns with ARIA grant requirements:
 ## Recent Commits
 
 ```
+af62184 Sprint 30 T1: Distribution verification — fix roundtrip fidelity + packaging (#148)
+37cddbc Sprint 29 T1: Refactor CLI tests to in-process for coverage accuracy (#146)
+b80db02 Sprint 28: web4_process_action MCP tool + SDK v0.22.0 (#145)
 45ee7fe Sprint 24 T1: process_action_outcome() — action consequence pipeline (#143)
 16b4d96 Sprint 27 T1: Expose behavioral functions as MCP tools (#140)
-0fc2545 Sprint 26 T1: SDK v0.21.0 release housekeeping (#139)
-4c2585f Sprint 25 T1: resolve_trust() — indirect trust resolution through MRH graphs (#138)
-3a36de3 Sprint 23 T1: SDK v0.20.0 release housekeeping (#136)
 ```
 
 ---
 
 ## Open PRs
 
-None.
+- PR #147: "Sprint 30 T1: web4 trust CLI subcommand" — REVIEW_REQUIRED
 
 ---
 
 ## Completeness Summary
 
-- All 30 sprints COMPLETE (Sprints 1-30)
+- All 31 sprints COMPLETE (Sprints 1-31)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -161,7 +167,7 @@ None.
 - All 22 submodules have `__all__` declarations, 364 root exports
 - All public methods have docstrings and return type annotations
 - `mypy --strict` passes with 0 errors across 25 source files
-- Test coverage: 97.8% overall (4 modules at 100%, 16 at 95%+)
+- Test coverage: 97.8% overall (4 modules at 100%, 16 at 95%+, __main__.py at 90.6%)
 - Schema validation via `web4.validation.validate()` with `pip install web4[validation]`
 - CLI via `web4 info/validate/list-schemas/roundtrip/generate`
 - Wheel distribution verified: imports, CLI, schema validation, roundtrip all pass from installed wheel
@@ -169,4 +175,4 @@ None.
 
 ---
 
-*Updated by autonomous session, 2026-04-10 (Sprint 30 — distribution verification + roundtrip fidelity)*
+*Updated by autonomous session, 2026-04-11 (Sprint 31 — v0.23.0 release housekeeping)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,31 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-10 (Sprint 30)
+**Updated**: 2026-04-11 (Sprint 31)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 31: SDK v0.23.0 Release Housekeeping (2026-04-11)
+
+Sprints 29 and 30 landed significant changes on main (CLI test refactoring for
+coverage accuracy, 4 roundtrip fidelity bug fixes) without a version bump.
+Sprint 31 brings all SDK metadata into alignment with the current state.
+
+### T1: SDK v0.23.0 release housekeeping
+**Status**: DONE
+**Completed**: 2026-04-11
+**Scope**: Version bump 0.22.0 → 0.23.0. CHANGELOG v0.23.0 entry documenting
+Sprint 29 (CLI test refactoring, `__main__.py` coverage 15.8% → 90.6%) and
+Sprint 30 T1b (4 bug fixes: LCT `@type` roundtrip, LCT schema `@type` rejection,
+DictionaryEntity `lct_id` loss, `pyproject.toml` license deprecation). Update
+README.md (2610 tests, 97.8% coverage). Update `__init__.py` docstring. Update
+SESSION_FOCUS.md (correct Open PRs, test count, coverage). Fix test version
+assertions (0.22.0 → 0.23.0).
+**Result**: All SDK metadata now accurately reflects 22 modules + MCP server,
+364 exports, 2610 tests, 97.8% coverage, 8 MCP tools, 3 behavioral functions.
+Version 0.23.0. 0 new files.
 
 ---
 

--- a/web4-standard/implementation/sdk/CHANGELOG.md
+++ b/web4-standard/implementation/sdk/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the Web4 Python SDK.
 
+## [0.23.0] - 2026-04-11
+
+Sprint 29: CLI test coverage hardening. Sprint 30: Distribution verification and
+roundtrip fidelity bug fixes.
+
+### Fixed
+- **LCT `to_jsonld()` roundtrip fidelity** (Sprint 30 T1b) — `to_jsonld()` now
+  includes `@type: "web4:LinkedContextToken"` so that `from_jsonld()` can dispatch
+  correctly. Previously omitted per spec §2.3, but broke roundtrip fidelity.
+- **LCT JSON Schema `@type` rejection** (Sprint 30 T1b) — schema now allows
+  optional `@type` property instead of rejecting valid documents that include it.
+- **DictionaryEntity `from_jsonld()` lct_id loss** (Sprint 30 T1b) — `from_jsonld()`
+  now preserves `lct_id` from the original document instead of silently dropping it.
+- **`pyproject.toml` license deprecation** (Sprint 30 T1b) — license field updated
+  to SPDX format (`"MIT"` string), fixing setuptools deprecation warning.
+
+### Changed
+- Version bumped from 0.22.0 to 0.23.0.
+- **CLI test coverage** (Sprint 29 T1) — refactored `test_cli.py` from subprocess-only
+  to in-process `main(argv)` + `capsys`, making coverage visible to pytest-cov.
+  `__main__.py` coverage: 15.8% → 90.6%. Overall SDK coverage: 96.2% → 97.8%.
+- 2610 tests passing (up from 2600 in v0.22.0). 364 exports.
+- All 23 `generate()` types now pass roundtrip fidelity (generate → from_jsonld →
+  to_jsonld = identical). Verified from installed wheel in isolated venv.
+- LCT test vectors updated (10 vectors, all with `@type`). `schema_registry.json` rebuilt.
+
 ## [0.22.0] - 2026-04-08
 
 Sprint 28: MCP process_action tool and v0.22.0 release housekeeping.

--- a/web4-standard/implementation/sdk/README.md
+++ b/web4-standard/implementation/sdk/README.md
@@ -8,7 +8,7 @@ specified in the [web4-standard](https://github.com/dp-web4/web4) and works with
 network services — no async, no HTTP, no external dependencies beyond the Python
 standard library.
 
-**Version**: 0.22.0 | **Python**: 3.10+ | **License**: MIT | **Typed**: PEP 561
+**Version**: 0.23.0 | **Python**: 3.10+ | **License**: MIT | **Typed**: PEP 561
 
 ## Installation
 
@@ -181,7 +181,7 @@ python -m pytest tests/ --cov=web4
 mypy --strict web4/
 ```
 
-2600 tests, 96% coverage, mypy strict zero-error, CI across Python 3.10-3.13.
+2610 tests, 97.8% coverage, mypy strict zero-error, CI across Python 3.10-3.13.
 
 ## Client SDK
 
@@ -217,7 +217,7 @@ web4/                  # Python package (22 modules + MCP server)
   generate.py          # Minimal valid JSON-LD document generation
   validation.py        # Schema validation
   ...                  # (17 more modules)
-tests/                 # 2600 tests
+tests/                 # 2610 tests
 schemas/               # JSON Schemas + JSON-LD contexts
 web4_sdk.py            # Async HTTP client (separate)
 pyproject.toml         # Package metadata (single version source)

--- a/web4-standard/implementation/sdk/pyproject.toml
+++ b/web4-standard/implementation/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "web4"
-version = "0.22.0"
+version = "0.23.0"
 description = "Web4 SDK — trust tensors, LCTs, ATP/ADP, federation (SAL), R7 actions, MRH, ACP, security, protocol types"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/web4-standard/implementation/sdk/tests/test_cli.py
+++ b/web4-standard/implementation/sdk/tests/test_cli.py
@@ -47,7 +47,7 @@ class TestInfo:
         out = capsys.readouterr().out
         assert rc == 0
         assert "web4" in out
-        assert "0.22.0" in out
+        assert "0.23.0" in out
 
     def test_info_shows_module_count(self, capsys: pytest.CaptureFixture[str]) -> None:
         rc = main(["info"])
@@ -357,7 +357,7 @@ class TestSmoke:
     def test_info(self) -> None:
         r = _run_cli(["info"])
         assert r.returncode == 0
-        assert "0.22.0" in r.stdout
+        assert "0.23.0" in r.stdout
 
     def test_validate_valid_doc(self) -> None:
         from web4.trust import T3

--- a/web4-standard/implementation/sdk/tests/test_package_api.py
+++ b/web4-standard/implementation/sdk/tests/test_package_api.py
@@ -10,11 +10,11 @@ import web4
 
 class TestPackageVersion:
     def test_version_string(self):
-        assert web4.__version__ == "0.22.0"
+        assert web4.__version__ == "0.23.0"
 
     def test_version_accessible(self):
         from web4 import __version__
-        assert __version__ == "0.22.0"
+        assert __version__ == "0.23.0"
 
 
 class TestAllExports:

--- a/web4-standard/implementation/sdk/web4/__init__.py
+++ b/web4-standard/implementation/sdk/web4/__init__.py
@@ -26,8 +26,8 @@ Provides offline-capable primitives for:
 - Deserialization — generic JSON-LD dispatcher for all Web4 types
 - Generation — produce minimal valid JSON-LD documents for any Web4 type
 
-22 modules + MCP server, 364 exports, 3 behavioral functions, 8 MCP tools. These modules
-define the canonical data types and algorithms specified in the web4-standard.
+22 modules + MCP server, 364 exports, 2610 tests, 3 behavioral functions, 8 MCP tools.
+These modules define the canonical data types and algorithms specified in the web4-standard.
 They work offline (no network services required) and are designed to be
 imported by applications, services, and other SDKs that build on web4.
 


### PR DESCRIPTION
## Summary

- Version bump 0.22.0 → 0.23.0 for Sprint 29 (CLI test refactoring) and Sprint 30 T1b (4 roundtrip fidelity bug fixes) now on main
- CHANGELOG v0.23.0 documents: CLI coverage improvement (15.8% → 90.6%), LCT `@type` roundtrip fix, LCT schema `@type` rejection fix, DictionaryEntity `lct_id` preservation fix, `pyproject.toml` license SPDX format
- README updated: 2610 tests, 97.8% coverage
- SESSION_FOCUS corrected: Open PRs (PR #147 pending), Sprint 31 entry, updated stats
- SPRINT.md: Sprint 31 entry added
- Test version assertions: 0.22.0 → 0.23.0

## Test plan

- [x] 2610 tests passing (`python -m pytest tests/ -q`)
- [x] mypy --strict 0 errors (25 files)
- [x] Version reads as 0.23.0 (`python -c "import web4; print(web4.__version__)"`)
- [x] 0 new files, 8 files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)