### PR TITLE
Sprint 34 T1: SDK v0.25.0 release housekeeping

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-11 (Sprint 33)*
+*Last updated: 2026-04-12 (Sprint 34)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 34 Summary: SDK v0.25.0 Release Housekeeping (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: v0.25.0 release housekeeping | DONE | Version bump, CHANGELOG for PRs #147/#151/#153, README/docstring updates, 2627 tests, 7 CLI subcommands |
 
 ### Sprint 33 Summary: SDK v0.24.0 Release Housekeeping (COMPLETE)
 
@@ -98,10 +104,10 @@ See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all
 
 ## SDK Status
 
-- **Version**: 0.24.0
+- **Version**: 0.25.0
 - **Modules**: 22 library modules + MCP server entry point (trust, lct, atp, federation, r6, mrh, acp, dictionary, entity, capability, errors, metabolic, binding, society, reputation, security, protocol, mcp, attestation, validation, deserialize, generate, mcp_server)
-- **Tests**: 2614 passing (97.8% coverage)
-- **CLI**: `web4 info/validate/list-schemas/roundtrip/generate/selftest` (6 subcommands)
+- **Tests**: 2627 passing (97.8% coverage)
+- **CLI**: `web4 info/validate/list-schemas/roundtrip/generate/selftest/trust` (7 subcommands)
 - **Exports**: 364 symbols via `web4/__init__.py`
 - **from_dict()**: 58 classmethods across 10 modules — all classes with to_dict()/as_dict() have matching from_dict()
 - **Dispatcher**: 23 types via `web4.from_jsonld()` (19 class-based + 3 function-based + TrustQuery)
@@ -149,25 +155,24 @@ Web4 SDK development aligns with ARIA grant requirements:
 ## Recent Commits
 
 ```
+77d6f2a Sprint 33 T1: Archive remaining implementation/ session sprawl (#153)
+65cd548 Sprint 32 T1: Archive reference implementation sprawl (#151)
+9359540 Sprint 30 T1: `web4 trust` CLI subcommand for trust query evaluation (#147)
+aabf352 Sprint 33 T1: SDK v0.24.0 release housekeeping (#154)
 fbc847e Sprint 32 T1: web4 selftest — deployment verification CLI command (#152)
-39d4e9e Sprint 31 T1: SDK v0.23.0 release housekeeping (#150)
-af62184 Sprint 30 T1: Distribution verification — fix roundtrip fidelity + packaging (#148)
-37cddbc Sprint 29 T1: Refactor CLI tests to in-process for coverage accuracy (#146)
-b80db02 Sprint 28: web4_process_action MCP tool + SDK v0.22.0 (#145)
 ```
 
 ---
 
 ## Open PRs
 
-- PR #151: "Sprint 32 T1: Archive reference implementation sprawl" — REVIEW_REQUIRED
-- PR #147: "Sprint 30 T1: web4 trust CLI subcommand" — REVIEW_REQUIRED
+- PR #155: "Web4: worker/web4-20260411-180024" (CLAUDE.md/AGENTS.md cleanup) — REVIEW_REQUIRED
 
 ---
 
 ## Completeness Summary
 
-- All 33 sprints COMPLETE (Sprints 1-33)
+- All 34 sprints COMPLETE (Sprints 1-34)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -183,10 +188,10 @@ b80db02 Sprint 28: web4_process_action MCP tool + SDK v0.22.0 (#145)
 - `mypy --strict` passes with 0 errors across 25 source files
 - Test coverage: 97.8% overall (4 modules at 100%, 16 at 95%+, __main__.py at 90.6%)
 - Schema validation via `web4.validation.validate()` with `pip install web4[validation]`
-- CLI via `web4 info/validate/list-schemas/roundtrip/generate/selftest` (6 subcommands)
+- CLI via `web4 info/validate/list-schemas/roundtrip/generate/selftest/trust` (7 subcommands)
 - Wheel distribution verified: imports, CLI, schema validation, roundtrip all pass from installed wheel
 - All 23 generate() types pass roundtrip fidelity (generate → from_jsonld → to_jsonld = identical)
 
 ---
 
-*Updated by autonomous session, 2026-04-11 (Sprint 33 — SDK v0.24.0 release housekeeping)*
+*Updated by autonomous session, 2026-04-12 (Sprint 34 — SDK v0.25.0 release housekeeping)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,30 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-11 (Sprint 33)
+**Updated**: 2026-04-12 (Sprint 34)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 34: SDK v0.25.0 Release Housekeeping (2026-04-12)
+
+Three PRs merged since v0.24.0: trust CLI subcommand (#147), archive reference
+implementation sprawl (#151), archive remaining implementation/ session sprawl (#153).
+Sprint 34 brings all SDK metadata into alignment with the current state.
+
+### T1: SDK v0.25.0 release housekeeping
+**Status**: DONE
+**Completed**: 2026-04-12
+**Scope**: Version bump 0.24.0 → 0.25.0. CHANGELOG v0.25.0 entry documenting
+PR #147 (trust CLI as 7th subcommand, 13 tests) and PRs #151/#153 (archive cleanup).
+README.md updates (7 CLI subcommands, 2627 tests, trust CLI docs in CLI section and
+project structure). `__init__.py` docstring update (test count 2614 → 2627, CLI
+subcommand count 6 → 7). Fix test version assertions (0.24.0 → 0.25.0). Update
+SESSION_FOCUS.md and SPRINT.md.
+**Result**: All SDK metadata now accurately reflects 22 modules + MCP server,
+364 exports, 2627 tests, 97.8% coverage, 8 MCP tools, 3 behavioral functions,
+7 CLI subcommands. Version 0.25.0. 0 new files.
 
 ---
 

--- a/web4-standard/implementation/sdk/CHANGELOG.md
+++ b/web4-standard/implementation/sdk/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Web4 Python SDK.
 
+## [0.25.0] - 2026-04-12
+
+Sprint 30 T1a: Trust CLI subcommand. Sprints 32-33: Archive cleanup.
+
+### Added
+- **`web4 trust` CLI subcommand** (Sprint 30 T1a, PR #147) — 7th CLI command.
+  Wraps `evaluate_trust_query()` for command-line trust evaluation. Two modes:
+  CLI flags (`--actor`/`--target`/`--role` + optional `--dimension`/`--disclosure`/
+  `--stake`) and `--file` for JSON input. Outputs JSON trust query response. 13 tests.
+
+### Changed
+- Version bumped from 0.24.0 to 0.25.0.
+- CLI: 7 subcommands (info, list-schemas, validate, roundtrip, generate, selftest, trust).
+- 2627 tests passing (up from 2614 in v0.24.0). 364 exports.
+
+### Removed
+- **Archive cleanup** (PRs #151, #153) — moved 130+ standalone reference implementation
+  files from `implementation/` to `archive/`. No SDK code changes; repository hygiene only.
+
 ## [0.24.0] - 2026-04-11
 
 Sprint 32: Deployment verification CLI command.

--- a/web4-standard/implementation/sdk/README.md
+++ b/web4-standard/implementation/sdk/README.md
@@ -8,7 +8,7 @@ specified in the [web4-standard](https://github.com/dp-web4/web4) and works with
 network services — no async, no HTTP, no external dependencies beyond the Python
 standard library.
 
-**Version**: 0.24.0 | **Python**: 3.10+ | **License**: MIT | **Typed**: PEP 561
+**Version**: 0.25.0 | **Python**: 3.10+ | **License**: MIT | **Typed**: PEP 561
 
 ## Installation
 
@@ -110,6 +110,8 @@ web4 generate T3Tensor        # Generate a minimal valid JSON-LD document
 web4 generate --list          # List all 23 supported types
 web4 selftest                 # Verify SDK installation (imports, schemas, roundtrips)
 web4 selftest -v              # Verbose: show per-phase progress
+web4 trust --file query.json  # Evaluate a trust query from JSON file
+web4 trust --actor A --target B --role admin  # Evaluate trust from CLI flags
 ```
 
 Also available as `python -m web4`.
@@ -183,7 +185,7 @@ python -m pytest tests/ --cov=web4
 mypy --strict web4/
 ```
 
-2614 tests, 97.8% coverage, mypy strict zero-error, CI across Python 3.10-3.13.
+2627 tests, 97.8% coverage, mypy strict zero-error, CI across Python 3.10-3.13.
 
 ## Client SDK
 
@@ -210,7 +212,7 @@ The client SDK re-exports canonical types from the `web4` package, so both
 ```
 web4/                  # Python package (22 modules + MCP server)
   __init__.py          # 364 re-exports
-  __main__.py          # CLI entry point (web4 info/validate/list-schemas/roundtrip/generate/selftest)
+  __main__.py          # CLI entry point (web4 info/validate/list-schemas/roundtrip/generate/selftest/trust)
   mcp_server.py        # MCP server entry point (web4-mcp)
   py.typed             # PEP 561 marker
   trust.py             # T3/V3 tensors, TrustQuery, evaluate_trust_query(), resolve_trust()
@@ -219,7 +221,7 @@ web4/                  # Python package (22 modules + MCP server)
   generate.py          # Minimal valid JSON-LD document generation
   validation.py        # Schema validation
   ...                  # (17 more modules)
-tests/                 # 2614 tests
+tests/                 # 2627 tests
 schemas/               # JSON Schemas + JSON-LD contexts
 web4_sdk.py            # Async HTTP client (separate)
 pyproject.toml         # Package metadata (single version source)

--- a/web4-standard/implementation/sdk/pyproject.toml
+++ b/web4-standard/implementation/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "web4"
-version = "0.24.0"
+version = "0.25.0"
 description = "Web4 SDK — trust tensors, LCTs, ATP/ADP, federation (SAL), R7 actions, MRH, ACP, security, protocol types"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/web4-standard/implementation/sdk/tests/test_cli.py
+++ b/web4-standard/implementation/sdk/tests/test_cli.py
@@ -47,7 +47,7 @@ class TestInfo:
         out = capsys.readouterr().out
         assert rc == 0
         assert "web4" in out
-        assert "0.24.0" in out
+        assert "0.25.0" in out
 
     def test_info_shows_module_count(self, capsys: pytest.CaptureFixture[str]) -> None:
         rc = main(["info"])
@@ -546,7 +546,7 @@ class TestSmoke:
     def test_info(self) -> None:
         r = _run_cli(["info"])
         assert r.returncode == 0
-        assert "0.24.0" in r.stdout
+        assert "0.25.0" in r.stdout
 
     def test_validate_valid_doc(self) -> None:
         from web4.trust import T3

--- a/web4-standard/implementation/sdk/tests/test_package_api.py
+++ b/web4-standard/implementation/sdk/tests/test_package_api.py
@@ -10,11 +10,11 @@ import web4
 
 class TestPackageVersion:
     def test_version_string(self):
-        assert web4.__version__ == "0.24.0"
+        assert web4.__version__ == "0.25.0"
 
     def test_version_accessible(self):
         from web4 import __version__
-        assert __version__ == "0.24.0"
+        assert __version__ == "0.25.0"
 
 
 class TestAllExports:

--- a/web4-standard/implementation/sdk/web4/__init__.py
+++ b/web4-standard/implementation/sdk/web4/__init__.py
@@ -26,7 +26,7 @@ Provides offline-capable primitives for:
 - Deserialization — generic JSON-LD dispatcher for all Web4 types
 - Generation — produce minimal valid JSON-LD documents for any Web4 type
 
-22 modules + MCP server, 364 exports, 2614 tests, 3 behavioral functions, 8 MCP tools, 6 CLI subcommands.
+22 modules + MCP server, 364 exports, 2627 tests, 3 behavioral functions, 8 MCP tools, 7 CLI subcommands.
 These modules define the canonical data types and algorithms specified in the web4-standard.
 They work offline (no network services required) and are designed to be
 imported by applications, services, and other SDKs that build on web4.


### PR DESCRIPTION
## Summary

- Version bump 0.24.0 → 0.25.0 reflecting three merged PRs (#147 trust CLI, #151/#153 archive cleanup)
- CHANGELOG v0.25.0 entry, README updates (7 CLI subcommands, 2627 tests, trust CLI docs)
- `__init__.py` docstring, test version assertions, SPRINT.md Sprint 34, SESSION_FOCUS.md

## Test plan

- [x] 2627 tests passing (`python -m pytest tests/ -q`)
- [x] mypy strict clean (25 files)
- [x] Version assertion tests updated (0.24.0 → 0.25.0)
- [x] `python -c "import web4; print(web4.__version__)"` → 0.25.0
- [x] 0 new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)