### PR TITLE
Sprint 35 T1: CI workflow hardening — strict mypy + wheel verification

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Lint with ruff
         run: ruff check web4/
 
-      - name: Type check with mypy
-        run: mypy web4/ --ignore-missing-imports
+      - name: Type check with mypy (strict)
+        run: mypy web4/
 
   test:
     runs-on: ubuntu-latest
@@ -63,3 +63,32 @@ jobs:
 
       - name: Run tests with coverage
         run: pytest tests/ -v --tb=short --cov=web4 --cov-report=term-missing
+
+  wheel:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web4-standard/implementation/sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Install from wheel in fresh environment
+        run: |
+          python -m venv /tmp/web4-wheel-test
+          /tmp/web4-wheel-test/bin/pip install dist/web4-*.whl
+
+      - name: Run selftest from installed wheel
+        run: /tmp/web4-wheel-test/bin/web4 selftest
+
+      - name: Verify CLI entry point
+        run: /tmp/web4-wheel-test/bin/web4 info

--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-12 (Sprint 34)*
+*Last updated: 2026-04-13 (Sprint 35)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 35 Summary: CI Workflow Hardening (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: CI workflow hardening | DONE | mypy --strict in CI (was --ignore-missing-imports), new wheel build+selftest job, 0 new files |
 
 ### Sprint 34 Summary: SDK v0.25.0 Release Housekeeping (COMPLETE)
 
@@ -172,7 +178,7 @@ None. All PRs merged or closed as of 2026-04-12.
 
 ## Completeness Summary
 
-- All 34 sprints COMPLETE (Sprints 1-34)
+- All 35 sprints COMPLETE (Sprints 1-35)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,35 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-12 (Sprint 34)
+**Updated**: 2026-04-13 (Sprint 35)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 35: CI Workflow Hardening (2026-04-13)
+
+CI quality gates were weaker than local development standards. Sprint 35 aligns
+them: strict mypy in CI (matching pyproject.toml), and a new wheel verification
+job that builds a wheel, installs in an isolated venv, and runs `web4 selftest`.
+Sprint 30 found 4 real packaging bugs via manual wheel testing — this automates
+that verification for every PR.
+
+### T1: CI workflow hardening
+**Status**: DONE
+**Completed**: 2026-04-13
+**Scope**: Update `.github/workflows/sdk-test.yml`:
+(1) mypy job now uses `mypy web4/` (picks up `strict = true` from pyproject.toml)
+instead of `mypy web4/ --ignore-missing-imports` (which was weaker than local).
+(2) New `wheel` job: builds wheel via `python -m build`, installs in isolated
+venv (`python -m venv`), runs `web4 selftest` and `web4 info` from installed wheel.
+(3) Dropped planned `ruff format --check` — 70 files need reformatting, deferred
+to avoid scope expansion.
+**Result**: CI now matches local quality gates for type checking. Packaging
+regressions (like Sprint 30's 4 bugs) will be caught automatically. 0 new files.
+
+### Follow-up (not this sprint)
+- `ruff format` codebase-wide (70 files) + `ruff format --check` in CI
 
 ---
 


### PR DESCRIPTION
## Summary
- **mypy --strict in CI**: Replaced `mypy web4/ --ignore-missing-imports` with `mypy web4/` (picks up `strict = true` from pyproject.toml), matching local development standards
- **New `wheel` job**: Builds wheel via `python -m build`, installs in an isolated venv, runs `web4 selftest` and `web4 info` — automates the manual verification from Sprint 30 that found 4 packaging bugs
- Updated SPRINT.md (Sprint 35) and SESSION_FOCUS.md

## Rationale
CI was running a weaker mypy check than local dev (`--ignore-missing-imports` vs `--strict`). Type errors caught locally could slip through PRs. The wheel job catches packaging regressions (missing files, broken entry points, schema registry issues) that editable installs mask.

## Test plan
- [ ] CI `lint` job passes with `mypy web4/` (strict mode)
- [ ] CI `wheel` job builds wheel, installs in isolated venv, `web4 selftest` passes
- [ ] CI `test` job unchanged — 2627 tests across Python 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)