### PR TITLE
Sprint 39 T1: SDK v0.26.0 release housekeeping

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-17 (Sprint 38)*
+*Last updated: 2026-04-17 (Sprint 39)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 39 Summary: SDK v0.26.0 Release Housekeeping (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: v0.26.0 release housekeeping | DONE | Version bump, CHANGELOG for Sprints 35/37/38 (CI hardening, ruff lint, ruff format), test assertion updates, 2627 tests, 0 new files |
 
 ### Sprint 38 Summary: Ruff Format Codebase-Wide + CI Enforcement (COMPLETE)
 
@@ -122,7 +128,7 @@ See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all
 
 ## SDK Status
 
-- **Version**: 0.25.0
+- **Version**: 0.26.0
 - **Modules**: 22 library modules + MCP server entry point (trust, lct, atp, federation, r6, mrh, acp, dictionary, entity, capability, errors, metabolic, binding, society, reputation, security, protocol, mcp, attestation, validation, deserialize, generate, mcp_server)
 - **Tests**: 2627 passing (97.8% coverage)
 - **CLI**: `web4 info/validate/list-schemas/roundtrip/generate/selftest/trust` (7 subcommands)
@@ -173,11 +179,11 @@ Web4 SDK development aligns with ARIA grant requirements:
 ## Recent Commits
 
 ```
+759eaef Sprint 38 T1: ruff format codebase-wide + CI enforcement (#162)
+e355a19 Sprint 37 T1: ruff check lint cleanup + CI enforcement (#161)
 3e6ca32 [Publisher] Fix PDF date (February→April 2026), rebuild artifacts
 4a97ff7 Sprint 35 T1: CI workflow hardening — strict mypy + wheel verification (#158)
-503ed7f docs: update SESSION_FOCUS.md — correct stale PR status, add recent commits (#157)
 2b5292f Sprint 34 T1: SDK v0.25.0 release housekeeping (#156)
-77d6f2a Sprint 33 T1: Archive remaining implementation/ session sprawl (#153)
 ```
 
 ---
@@ -194,7 +200,7 @@ Web4 SDK development aligns with ARIA grant requirements:
 
 ## Completeness Summary
 
-- All 38 sprints COMPLETE (Sprints 1-38)
+- All 39 sprints COMPLETE (Sprints 1-39)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -218,4 +224,4 @@ Web4 SDK development aligns with ARIA grant requirements:
 
 ---
 
-*Updated by autonomous session, 2026-04-17 (Sprint 38 — ruff format codebase-wide + CI enforcement)*
+*Updated by autonomous session, 2026-04-17 (Sprint 39 — SDK v0.26.0 release housekeeping)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,29 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-17 (Sprint 38)
+**Updated**: 2026-04-17 (Sprint 39)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 39: SDK v0.26.0 Release Housekeeping (2026-04-17)
+
+Three quality-improvement PRs merged since v0.25.0: CI workflow hardening (#158),
+ruff lint cleanup + CI enforcement (#161), ruff format codebase-wide + CI enforcement
+(#162). Sprint 39 brings all SDK metadata into alignment with the current state.
+
+### T1: SDK v0.26.0 release housekeeping
+**Status**: DONE
+**Completed**: 2026-04-17
+**Scope**:
+(1) Version bump 0.25.0 → 0.26.0 in `pyproject.toml`.
+(2) CHANGELOG v0.26.0 entry documenting Sprints 35, 37, 38.
+(3) Update `web4/__init__.py` docstring with v0.26.0 note.
+(4) Update test version assertions in `test_cli.py` and `test_package_api.py`.
+(5) Update `docs/SPRINT.md` and `SESSION_FOCUS.md`.
+**Result**: SDK version metadata reflects the 3 CI/quality merges since v0.25.0.
+All 2627 tests pass. mypy --strict clean. ruff check + format clean. 0 new files.
 
 ---
 

--- a/web4-standard/implementation/sdk/CHANGELOG.md
+++ b/web4-standard/implementation/sdk/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the Web4 Python SDK.
 
+## [0.26.0] - 2026-04-17
+
+Sprints 35, 37, 38: CI quality gate hardening — strict mypy, ruff lint, ruff format.
+
+### Changed
+- **CI workflow hardening** (Sprint 35 T1, PR #158) — `mypy --strict` in CI now
+  matches local pyproject.toml config (was `--ignore-missing-imports`). New wheel
+  verification job: builds wheel, installs in isolated venv, runs `web4 selftest`
+  and `web4 info`. Catches packaging regressions like Sprint 30's 4 bugs automatically.
+- **Ruff lint cleanup + CI enforcement** (Sprint 37 T1, PR #161) — fixed 239 lint
+  issues (source: 10, tests: 229). CI now enforces `ruff check web4/ tests/test_*.py`
+  on every PR. Per-file-ignore E402 for test files.
+- **Ruff format codebase-wide + CI enforcement** (Sprint 38 T1, PR #162) — applied
+  `ruff format` to 70 files (web4/ + tests/). CI now enforces `ruff format --check`
+  on every PR, matching the same path scope as `ruff check`.
+- Version bumped from 0.25.0 to 0.26.0.
+- 2627 tests passing. 364 exports. 22 modules + MCP server.
+- CI now enforces three quality gates on every PR: `mypy --strict`, `ruff check`,
+  `ruff format --check`, plus wheel build + selftest verification.
+
 ## [0.25.0] - 2026-04-12
 
 Sprint 30 T1a: Trust CLI subcommand. Sprints 32-33: Archive cleanup.

--- a/web4-standard/implementation/sdk/pyproject.toml
+++ b/web4-standard/implementation/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "web4"
-version = "0.25.0"
+version = "0.26.0"
 description = "Web4 SDK — trust tensors, LCTs, ATP/ADP, federation (SAL), R7 actions, MRH, ACP, security, protocol types"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/web4-standard/implementation/sdk/tests/test_cli.py
+++ b/web4-standard/implementation/sdk/tests/test_cli.py
@@ -46,7 +46,7 @@ class TestInfo:
         out = capsys.readouterr().out
         assert rc == 0
         assert "web4" in out
-        assert "0.25.0" in out
+        assert "0.26.0" in out
 
     def test_info_shows_module_count(self, capsys: pytest.CaptureFixture[str]) -> None:
         rc = main(["info"])
@@ -617,7 +617,7 @@ class TestSmoke:
     def test_info(self) -> None:
         r = _run_cli(["info"])
         assert r.returncode == 0
-        assert "0.25.0" in r.stdout
+        assert "0.26.0" in r.stdout
 
     def test_validate_valid_doc(self) -> None:
         from web4.trust import T3

--- a/web4-standard/implementation/sdk/tests/test_package_api.py
+++ b/web4-standard/implementation/sdk/tests/test_package_api.py
@@ -10,12 +10,12 @@ import web4
 
 class TestPackageVersion:
     def test_version_string(self):
-        assert web4.__version__ == "0.25.0"
+        assert web4.__version__ == "0.26.0"
 
     def test_version_accessible(self):
         from web4 import __version__
 
-        assert __version__ == "0.25.0"
+        assert __version__ == "0.26.0"
 
 
 class TestAllExports:

--- a/web4-standard/implementation/sdk/web4/__init__.py
+++ b/web4-standard/implementation/sdk/web4/__init__.py
@@ -27,6 +27,7 @@ Provides offline-capable primitives for:
 - Generation — produce minimal valid JSON-LD documents for any Web4 type
 
 22 modules + MCP server, 364 exports, 2627 tests, 3 behavioral functions, 8 MCP tools, 7 CLI subcommands.
+v0.26.0: CI quality gates (strict mypy, ruff lint, ruff format) enforced on every PR.
 These modules define the canonical data types and algorithms specified in the web4-standard.
 They work offline (no network services required) and are designed to be
 imported by applications, services, and other SDKs that build on web4.


### PR DESCRIPTION
## Summary

- Version bump 0.25.0 → 0.26.0
- CHANGELOG v0.26.0 entry documenting Sprints 35, 37, 38 (CI workflow hardening, ruff lint cleanup + CI enforcement, ruff format codebase-wide + CI enforcement)
- Test version assertions updated (`test_cli.py`, `test_package_api.py`)
- `__init__.py` docstring updated with v0.26.0 note
- `SPRINT.md` + `SESSION_FOCUS.md` aligned to Sprint 39

### Scope discipline

- 7 files modified, 0 new files
- No changes under `web4/` package (except `__init__.py` docstring)
- No new features, modules, exports, or behavioral changes
- No new tests
- 2627 tests passing, mypy --strict clean, ruff check + format clean

## Test plan

- [x] `python -m pytest tests/` — 2627 passed
- [x] `python -m mypy --strict web4/` — 0 errors, 25 files
- [x] `python -m ruff check web4/ tests/test_*.py` — all passed
- [x] `python -m ruff format --check web4/ tests/test_*.py` — 70 files already formatted
- [x] `python -c "import web4; print(web4.__version__)"` — prints 0.26.0

### Session

- Track: legion-web4, autonomous session 2026-04-17T06:00:00
- Protocol: v2 (understand → propose → review → execute → document)
- Policy review: APPROVED by subagent reviewer
- Session log: `private-context/autonomous-sessions/legion-web4-20260417-060000-session.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)