### PR TITLE
Sprint 42 T1: Wire examples/quickstart.py into CI wheel smoke job

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -95,3 +95,6 @@ jobs:
 
       - name: Verify CLI entry point
         run: /tmp/web4-wheel-test/bin/web4 info
+
+      - name: Run quickstart example against installed wheel
+        run: /tmp/web4-wheel-test/bin/python examples/quickstart.py

--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-17 (Sprint 41)*
+*Last updated: 2026-04-18 (Sprint 42)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 42 Summary: CI Quickstart Smoke (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: Wire `examples/quickstart.py` into CI wheel smoke job | DONE | Added one step to the `wheel` job in `.github/workflows/sdk-test.yml`, running `examples/quickstart.py` against the installed wheel's isolated venv. Closes Sprint 36 T1 follow-up. 0 new files, no product code changes, no version bump. Originally proposed as Sprint 40 (PR #164); renumbered to Sprint 42 to reflect merge order — Sprint 41 landed on main first. |
 
 ### Sprint 41 Summary: Remove Dead web4_sdk.py + Fix v0.26.0 Documentation Gaps (COMPLETE)
 
@@ -191,21 +197,22 @@ Web4 SDK development aligns with ARIA grant requirements:
 ## Recent Commits
 
 ```
+0e0383e Sprint 41 T1: Remove dead web4_sdk.py + fix v0.26.0 documentation gaps (#165)
 91ed230 Sprint 36 T1: Replace stale examples with v0.25.0 quickstart (#160)
 64add4c Sprint 39 T1: SDK v0.26.0 release housekeeping (#163)
 759eaef Sprint 38 T1: ruff format codebase-wide + CI enforcement (#162)
 e355a19 Sprint 37 T1: ruff check lint cleanup + CI enforcement (#161)
-4a97ff7 Sprint 35 T1: CI workflow hardening — strict mypy + wheel verification (#158)
 ```
 
 ---
 
 ## Open PRs
 
-- PR #164: Sprint 40 T1 — Wire examples/quickstart.py into CI wheel smoke job (pending review)
+- PR #164: Sprint 42 T1 — Wire examples/quickstart.py into CI wheel smoke job (rebased onto post-Sprint-41 main, renumbered from Sprint 40, pending review)
 
 ### Closed PRs (recent)
 
+- PR #165 MERGED — Sprint 41 T1: Remove dead web4_sdk.py + fix v0.26.0 documentation gaps
 - PR #163 MERGED — Sprint 39 T1: SDK v0.26.0 release housekeeping
 - PR #160 MERGED — Sprint 36 T1: Replace stale examples with v0.25.0 quickstart
 - PR #159 CLOSED (superseded) — attempted `ruff format` sweep; intent addressed in Sprint 38
@@ -214,7 +221,7 @@ e355a19 Sprint 37 T1: ruff check lint cleanup + CI enforcement (#161)
 
 ## Completeness Summary
 
-- All 41 sprints COMPLETE (Sprints 1-41)
+- All 42 sprints COMPLETE (Sprints 1-42; Sprint 42 pending merge via PR #164)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -236,7 +243,8 @@ e355a19 Sprint 37 T1: ruff check lint cleanup + CI enforcement (#161)
 - `ruff check web4/ tests/` passes with 0 errors — CI enforces lint on source + tests
 - `ruff format --check web4/ tests/test_*.py` passes with 0 changes — CI enforces formatting on source + tests
 - Dead `web4_sdk.py` removed — async HTTP client for nonexistent services, not distributed in wheel
+- `examples/quickstart.py` runs in the CI `wheel` job against the installed wheel — API breakage in the quickstart fails CI on every PR
 
 ---
 
-*Updated by autonomous session, 2026-04-17 (Sprint 41 — Remove dead web4_sdk.py + fix v0.26.0 docs)*
+*Updated by autonomous session, 2026-04-18 (Sprint 42 — CI quickstart smoke; renumbered from Sprint 40 per reviewer directive on PR #164)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,39 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-17 (Sprint 41)
+**Updated**: 2026-04-18 (Sprint 42)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 42: CI Quickstart Smoke (2026-04-18)
+
+Sprint 36 T1 introduced `examples/quickstart.py` as a minimal, offline composition
+of the three SDK behavioral functions (`generate`/`from_jsonld` roundtrip,
+`evaluate_trust_query`, `process_action_outcome`). Sprint 36 left one follow-up
+open: wire the quickstart into CI so a breaking API change surfaces in the
+wheel-install smoke job, not just in the editable-install test matrix. This sprint
+was originally proposed as Sprint 40 (PR #164 opened 2026-04-17) but is renumbered
+to Sprint 42 to reflect merge order — Sprint 41 (PR #165) landed on main first.
+
+### T1: Wire `examples/quickstart.py` into CI wheel smoke job
+**Status**: DONE
+**Completed**: 2026-04-18
+**Scope**:
+(1) Add one step to the `wheel` job in `.github/workflows/sdk-test.yml`, immediately
+after `Verify CLI entry point`, running
+`/tmp/web4-wheel-test/bin/python examples/quickstart.py`. The working directory
+is already `web4-standard/implementation/sdk`, so the relative path resolves.
+(2) The step uses the interpreter from the isolated venv already created by the
+`Install from wheel in fresh environment` step, so it exercises the packaged
+wheel — not the editable-install source tree used by the matrix `test` job.
+(3) No changes to `examples/quickstart.py`, `web4/`, `pyproject.toml`, or tests.
+(4) Update `docs/SPRINT.md` (this section) and `SESSION_FOCUS.md`.
+**Result**: A breaking change to the quickstart's public API surface now fails
+CI on every PR. Verified locally by reproducing the full CI chain: build wheel,
+install in fresh venv, `web4 selftest`, `web4 info`, then
+`python examples/quickstart.py` — all succeed against v0.26.0. 0 new files.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the **Sprint 36 T1 follow-up**: run `examples/quickstart.py` in CI
against the installed wheel, not only via the editable-install test matrix.
A breaking change to the SDK's public API surface now fails the wheel smoke job
on every PR.

## Changes

- `.github/workflows/sdk-test.yml`: one new step in the `wheel` job, immediately
  after `Verify CLI entry point`, running
  `/tmp/web4-wheel-test/bin/python examples/quickstart.py`. The isolated venv
  already exists from the prior `Install from wheel in fresh environment` step;
  working-directory is already `web4-standard/implementation/sdk`, so the
  relative path resolves.
- `docs/SPRINT.md`: new Sprint 40 section; Sprint 36 T1 follow-up line marked
  ADDRESSED.
- `SESSION_FOCUS.md`: Sprint 40 summary row; header bumped to Sprint 40;
  completeness-summary bullet added; recent-commits block refreshed.

## Out of scope

- No `web4/` package changes.
- No `pyproject.toml` changes.
- No version bump (CI hardening, not a release).
- No changes to `examples/quickstart.py` content.
- No matrix expansion (quickstart runs only on the 3.12 `wheel` job).

## Test plan

- [x] Local reproduction of the full CI chain on v0.26.0:
  - `python -m build` → wheel built
  - `python -m venv /tmp/web4-wheel-test && pip install dist/web4-*.whl` → installed
  - `/tmp/web4-wheel-test/bin/web4 selftest` → OK: 22 modules, 12 schemas, 23 types
  - `/tmp/web4-wheel-test/bin/web4 info` → web4 0.26.0
  - `/tmp/web4-wheel-test/bin/python examples/quickstart.py` → "Quickstart complete."
- [ ] CI `wheel` job green on this PR
- [ ] CI `lint` and `test` jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)