### PR TITLE
Sprint 44 T1: Resolve MEDIUM-priority spec gaps from Sprint 43 audit

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,25 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-04-18 (Sprint 42)*
+*Last updated: 2026-05-12 (Sprint 44)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 44 Summary: Resolve MEDIUM-Priority Spec Gaps (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: ATP transfer-fee semantics + T3 Talent-decay clarification | DONE | Resolves SPEC GAP #2 and #5 from Sprint 43 audit. Added §6.3 Transfer Fees to `atp-adp-cycle.md` (society-configurable, not protocol-prescribed). Strengthened Talent no-decay language in `t3-v3-tensors.md` (normative invariant, not tunable). 0 new files, 2 spec files modified. |
+
+### Sprint 43 Summary: Spec-to-Explainer Alignment Memo (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: Spec-to-explainer alignment memo | DONE | Categorized 14 friction items from 4-life visitor log: 4 SPEC GAP, 8 EXPLAINER GAP, 2 BOTH. Produced `docs/audits/spec-vs-explainer-alignment-2026-04-19.md`. |
 
 ### Sprint 42 Summary: CI Quickstart Smoke (COMPLETE)
 
@@ -197,11 +209,11 @@ Work undertaken in early 2026 toward what was at the time a planned ARIA grant s
 ## Recent Commits
 
 ```
+372b06a Strategic review follow-up audit + archive 3 stray implementation/ markdowns (#178)
+12ee197 Autonomous web4 session 20260512-060024 (safety net) (#176)
+cbc951a Archive 15 reference files + triage 9 sprawl directories (#175)
+485eb4f Reference implementation triage: classify 31 files for archive/keep (#174)
 0e0383e Sprint 41 T1: Remove dead web4_sdk.py + fix v0.26.0 documentation gaps (#165)
-91ed230 Sprint 36 T1: Replace stale examples with v0.25.0 quickstart (#160)
-64add4c Sprint 39 T1: SDK v0.26.0 release housekeeping (#163)
-759eaef Sprint 38 T1: ruff format codebase-wide + CI enforcement (#162)
-e355a19 Sprint 37 T1: ruff check lint cleanup + CI enforcement (#161)
 ```
 
 ---
@@ -212,17 +224,19 @@ None.
 
 ### Closed PRs (recent)
 
+- PR #178 MERGED — Strategic review follow-up audit + archive 3 stray implementation/ markdowns
+- PR #176 MERGED — Web4 session 20260512-060024 (auto-branched safety net)
+- PR #175 MERGED — Archive 15 reference files + triage 9 sprawl directories
+- PR #174 MERGED — Reference implementation triage: classify 31 files for archive/keep
+- PR #168 MERGED — Sprint 43 T1: Spec-to-explainer alignment memo
 - PR #164 MERGED — Sprint 42 T1: Wire examples/quickstart.py into CI wheel smoke job
 - PR #165 MERGED — Sprint 41 T1: Remove dead web4_sdk.py + fix v0.26.0 documentation gaps
-- PR #163 MERGED — Sprint 39 T1: SDK v0.26.0 release housekeeping
-- PR #160 MERGED — Sprint 36 T1: Replace stale examples with v0.25.0 quickstart
-- PR #159 CLOSED (superseded) — attempted `ruff format` sweep; intent addressed in Sprint 38
 
 ---
 
 ## Completeness Summary
 
-- All 42 sprints COMPLETE (Sprints 1-42, all merged)
+- All 44 sprints COMPLETE (Sprints 1-44, all merged)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -248,4 +262,4 @@ None.
 
 ---
 
-*Updated by autonomous session, 2026-04-18 (Sprint 42 — CI quickstart smoke; renumbered from Sprint 40 per reviewer directive on PR #164)*
+*Updated by autonomous session, 2026-05-12 (Sprint 44 — resolve MEDIUM-priority spec gaps from Sprint 43 audit)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,37 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-04-19 (Sprint 43)
+**Updated**: 2026-05-12 (Sprint 44)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 44: Resolve MEDIUM-Priority Spec Gaps (2026-05-12)
+
+The spec-to-explainer alignment audit (Sprint 43 T1) identified 4 SPEC GAPs
+and 2 BOTH items. Sprint 44 resolves the two MEDIUM-priority spec gaps —
+the natural downstream step in the audit → fix pipeline.
+
+### T1: ATP transfer-fee semantics + T3 Talent-decay clarification
+**Status**: DONE
+**Completed**: 2026-05-12
+**Authorized by**: Downstream from Sprint 43 audit (spec-vs-explainer-alignment-2026-04-19.md items #2 and #5)
+**Scope**:
+(1) Add §6.3 "Transfer Fees" to `atp-adp-cycle.md`: transfer fees are not
+prescribed by the protocol; societies MAY levy them as economic law. Fee rate,
+bearer, and destination must be declared in published laws. Fees recycled to
+society pool. Specific rates in simulations/explainers are simulation parameters.
+Added MAY requirement #6 to §7.3.
+(2) Strengthen "Talent Stability" in `t3-v3-tensors.md` §2.3: Talent's no-decay
+property is normative and invariant, not tunable. Societies MAY configure custom
+decay for Training and Temperament but not Talent. Half-life values for Talent in
+simulations/explainers are simulation parameters, not canonical.
+(3) Update `docs/SPRINT.md` (this section) and `SESSION_FOCUS.md`.
+**Result**: Two MEDIUM-priority SPEC GAPs from the Sprint 43 audit are resolved.
+4-life team has unambiguous canonical language to reference. Remaining spec gaps
+(#10 CI, #13 synthons, #14 karma) are LOW-priority and deferred to future sprints.
+0 new files, 2 spec files modified, 2 bookkeeping files modified.
 
 ---
 

--- a/web4-standard/core-spec/atp-adp-cycle.md
+++ b/web4-standard/core-spec/atp-adp-cycle.md
@@ -506,7 +506,33 @@ economic_laws:
     false_claim: "100 ATP"
     service_failure: "50 ATP"
     law_violation: "500 ATP"
+
+  transfer_policy:
+    intra_society_fee: "none"        # Or society-defined rate
+    cross_society_fee: "none"        # Or society-defined rate
+    fee_bearer: "sender"             # "sender" | "receiver" | "split"
+    fee_destination: "society_pool"  # Recycled, not destroyed
 ```
+
+### 6.3 Transfer Fees
+
+The core protocol does **not** prescribe transfer fees. Peer-to-peer ATP
+transfers within a society and cross-society exchanges (§5) are fee-free
+at the protocol level.
+
+Societies **MAY** implement transfer fees as economic law. When a society
+chooses to levy fees:
+
+- The fee rate, bearer (sender, receiver, or split), and destination MUST
+  be declared in the society's published economic laws.
+- Fees SHOULD be recycled into the society's pool (not destroyed), preserving
+  total supply.
+- Fee rates MUST NOT exceed society-defined caps.
+
+Any specific fee rates appearing in simulations, explainers, or demos
+(e.g., "5% transfer fee") are **simulation parameters**, not protocol
+constants. Implementations MUST NOT hard-code fee rates; they MUST read
+them from the governing society's published laws.
 
 ## 7. Implementation Requirements
 
@@ -534,6 +560,7 @@ economic_laws:
 3. Societies MAY create exchange agreements
 4. Societies MAY delegate monetary authority
 5. Societies MAY implement emergency measures
+6. Societies MAY levy transfer fees on ATP transfers (§6.3)
 
 ## 8. Security Considerations
 

--- a/web4-standard/core-spec/t3-v3-tensors.md
+++ b/web4-standard/core-spec/t3-v3-tensors.md
@@ -107,7 +107,15 @@ T3 scores evolve based on R6 action outcomes:
 
 - **Training Decay**: -0.001 per month without practice
 - **Temperament Recovery**: +0.01 per month of good behavior
-- **Talent Stability**: No decay, represents inherent capability
+- **Talent Stability**: No decay — Talent represents inherent capability and
+  does not diminish through inactivity. This is a normative protocol property,
+  not a tunable parameter.
+
+Societies **MAY** configure custom decay policies for Training and Temperament
+(e.g., different decay rates or recovery curves), but Talent's no-decay
+property is invariant at the protocol level. Any half-life or decay values
+for Talent appearing in simulations or explainers are simulation parameters,
+not canonical specification.
 
 ### 2.4 Fractal Sub-Dimensions
 


### PR DESCRIPTION
## Summary

- **SPEC GAP #2 resolved**: Added §6.3 Transfer Fees to `atp-adp-cycle.md` — the core protocol does not prescribe transfer fees; societies MAY levy them as economic law with declared rate, bearer, and destination. Simulation-specific rates (e.g., 4-life's "5%") are not canonical.
- **SPEC GAP #5 resolved**: Strengthened Talent no-decay language in `t3-v3-tensors.md` — Talent's no-decay property is a normative protocol invariant, not tunable. Societies MAY configure Training/Temperament decay but not Talent. Simulation half-life values for Talent are not canonical.

Both gaps were identified by the Sprint 43 spec-to-explainer alignment audit (`docs/audits/spec-vs-explainer-alignment-2026-04-19.md` items #2 and #5, both MEDIUM priority). Changes follow the established spec pattern of society-configurable MAY requirements.

## Files changed

- `web4-standard/core-spec/atp-adp-cycle.md` — new §6.3 + transfer_policy in YAML + MAY requirement #6
- `web4-standard/core-spec/t3-v3-tensors.md` — strengthened Talent Stability + society-configurable decay note
- `docs/SPRINT.md` — Sprint 44 entry
- `SESSION_FOCUS.md` — Sprint 44 summary + housekeeping updates

## Test plan

- [ ] Spec language is clear and internally consistent
- [ ] Transfer fee semantics follow existing MAY/SHOULD/MUST pattern
- [ ] Talent no-decay is unambiguous and marked as normative invariant
- [ ] No SDK code changes — 2613 existing tests unaffected
- [ ] Sprint/session bookkeeping is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)