### PR TITLE
Sprint 48 T1: Parameter governance index

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,13 +2,19 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-05-13 (Sprint 47)*
+*Last updated: 2026-05-13 (Sprint 48)*
 
 ---
 
 ## Current Sprint
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
+
+### Sprint 48 Summary: Parameter Governance Index (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: Parameter governance index in t3-v3-tensors.md | DONE | Resolves Unanswered Question #3 from Sprint 43 audit (unblocked by Sprint 46 T1). Added §10 to `t3-v3-tensors.md`: classifies all trust/value/energy parameters into three governance tiers — protocol-invariant (11 items, enforced by test vectors), society-configurable (8 items), simulation-only (5 items). Cross-references `atp-adp-cycle.md` and `multi-device-lct-binding.md`. 0 new files, 1 spec file modified. |
 
 ### Sprint 47 Summary: Cross-Language T3/V3 Alignment Audit (COMPLETE)
 
@@ -227,33 +233,33 @@ Work undertaken in early 2026 toward what was at the time a planned ARIA grant s
 ## Recent Commits
 
 ```
+6fdbb65 Update Hardbound references: plugin bridge architecture, current status
+cdf3711 Sprint 47 T1: Cross-language T3/V3 alignment audit (#182)
 55b1a3d Rebuild web4-trust-core WASM: canonical 3D tensors
 8e6d1ee Sprint 46 T1: Clarify CI canonicity (audit item #10) (#181)
 8e07fb0 [Publisher] No-change check: Sprint 44 T1 spec gaps resolved, no whitepaper integration
-7c228fd Sprint 45 T1: Archive stale implementation artifacts (#180)
-d530060 Sprint 44 T1: Resolve MEDIUM-priority spec gaps from Sprint 43 audit (#179)
 ```
 
 ---
 
 ## Open PRs
 
-None (Sprint 47 T1 PR pending).
+Sprint 48 T1 PR pending.
 
 ### Closed PRs (recent)
 
+- PR #182 MERGED — Sprint 47 T1: Cross-language T3/V3 alignment audit
 - PR #181 MERGED — Sprint 46 T1: Clarify CI canonicity (audit item #10)
 - PR #180 MERGED — Sprint 45 T1: Archive stale implementation artifacts
 - PR #179 MERGED — Sprint 44 T1: Resolve MEDIUM-priority spec gaps from Sprint 43 audit
 - PR #178 MERGED — Strategic review follow-up audit + archive 3 stray implementation/ markdowns
 - PR #176 MERGED — Web4 session 20260512-060024 (auto-branched safety net)
-- PR #175 MERGED — Archive 15 reference files + triage 9 sprawl directories
 
 ---
 
 ## Completeness Summary
 
-- All 47 sprints COMPLETE (Sprints 1-47, all merged or PR pending)
+- All 48 sprints COMPLETE (Sprints 1-48, all merged or PR pending)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -280,7 +286,8 @@ None (Sprint 47 T1 PR pending).
 ---
 
 - **web4-trust-core alignment**: Cross-language T3/V3 audit identified 8 divergences (1 CRITICAL, 4 HIGH) between Rust/WASM and spec/Python SDK — see `docs/audits/cross-language-t3v3-alignment-2026-05-13.md`
+- **Parameter governance**: All trust/value/energy parameters classified into three tiers (protocol-invariant, society-configurable, simulation-only) — see `web4-standard/core-spec/t3-v3-tensors.md` §10
 
 ---
 
-*Updated by autonomous session, 2026-05-13 (Sprint 47 — cross-language T3/V3 alignment audit)*
+*Updated by autonomous session, 2026-05-13 (Sprint 48 — parameter governance index)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,40 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-05-13 (Sprint 47)
+**Updated**: 2026-05-13 (Sprint 48)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 48: Parameter Governance Index (2026-05-13)
+
+The spec-vs-explainer alignment audit (Sprint 43 T1) includes Unanswered
+Question #3: "Who decides the parameters? (MRH decay rate, CI multiplier,
+trust thresholds)." The question was partially blocked by item #10 (CI
+canonicity), which Sprint 46 T1 resolved. With that dependency cleared,
+the parameter governance decisions scattered across Sprints 44, 46, and
+existing spec text can be synthesized into a single normative index.
+
+### T1: Parameter governance index in t3-v3-tensors.md
+**Status**: DONE
+**Completed**: 2026-05-13
+**Authorized by**: Downstream from Sprint 43 audit (Unanswered Question #3), unblocked by Sprint 46 T1 (item #10 resolved). Recommended by peer session 120024's queue-state analysis (Sub-option A).
+**Scope**:
+Add §10 "Parameter Governance" to `t3-v3-tensors.md` — classifies all
+trust, value, and energy parameters into three governance tiers:
+protocol-invariant (MUST — enforced by test vectors), society-configurable
+(MAY — published in governance laws), and simulation-only (not protocol
+parameters). Synthesizes decisions from §2.3 (Talent no-decay invariant,
+Training/Temperament decay configurability), `atp-adp-cycle.md` §6.3/§7
+(transfer fees, ATP decay rates, demurrage), and
+`multi-device-lct-binding.md` §4.4 (constellation_coherence as simulation
+parameter). Cross-references rather than duplicates existing normative text.
+**Result**: A developer or autonomous session can now answer "who decides
+this parameter?" for any trust/value/energy tunable by reading one section.
+Resolves Unanswered Question #3 from the spec-vs-explainer audit. Remaining
+audit items (#13 synthons, #14 karma) still require operator design
+decisions. 0 new files, 1 spec file modified, 2 bookkeeping files modified.
 
 ---
 

--- a/web4-standard/core-spec/t3-v3-tensors.md
+++ b/web4-standard/core-spec/t3-v3-tensors.md
@@ -478,3 +478,82 @@ SELECT ?dim ?scoreA ?scoreB WHERE {
              web4:hasDimensionScore [ web4:dimension ?dim ; web4:score ?scoreB ] .
 }
 ```
+
+## 10. Parameter Governance
+
+This section classifies all trust, value, and energy parameters by governance
+tier: who decides the value, and what latitude implementers have. It
+synthesizes normative decisions from §2.3, §3.3, and §6 of this document,
+[`atp-adp-cycle.md`](atp-adp-cycle.md) §6.3/§7, and
+[`multi-device-lct-binding.md`](multi-device-lct-binding.md) §4.4.
+
+### 10.1 Governance Tiers
+
+| Tier | RFC 2119 keyword | Meaning |
+|------|-----------------|---------|
+| **Protocol-invariant** | MUST / MUST NOT | Fixed by the specification. Implementations MUST use exactly these values. Cross-language test vectors enforce them. |
+| **Society-configurable** | MAY | Societies set these via published economic or governance laws. The protocol provides defaults but does not mandate them. |
+| **Simulation-only** | N/A | Not protocol parameters. Appear in explainers, demos, or simulations. MUST NOT be cited as canonical values. |
+
+### 10.2 Protocol-Invariant Parameters
+
+These values are fixed by the specification. All conforming implementations
+MUST produce identical results (enforced by cross-language test vectors in
+`web4-standard/test-vectors/t3v3/tensor-operations.json`).
+
+| Parameter | Value | Spec reference | Test vector |
+|-----------|-------|----------------|-------------|
+| T3 composite weights | talent=0.4, training=0.3, temperament=0.3 | §9.2 | t3v3-001 |
+| V3 composite weights | valuation=0.3, veracity=0.35, validity=0.35 | §3.3 | t3v3-002 |
+| T3 update formula | `0.02 × (quality − 0.5)` | §2.3 | t3v3-003 |
+| T3 dimension update factors | talent=1.0, training=0.8, temperament=0.6 | §2.3 | t3v3-003 |
+| Talent no-decay | Talent MUST NOT decay through inactivity | §2.3 | t3v3-012 |
+| T3 value range | [0.0, 1.0] — clamped at boundaries | §2.1 | t3v3-005, t3v3-006 |
+| Diminishing returns formula | `base_factor^(n−1)`, base=0.8, floor=0.1 | §7.1 | t3v3-007 |
+| 6D-to-3D bridge formula | primary×0.6 + secondary×(0.4/3) | — | t3v3-008 |
+| V3 calculation | valuation=(earned/expected)×satisfaction; veracity=(verified/total)×confidence; validity=1.0 if transferred else 0.0 | §3.3 | t3v3-014 |
+| Operational health formula | t3_composite×0.4 + v3_composite×0.3 + energy_ratio×0.3 | — | t3v3-010 |
+| ATP conservation | total supply = ATP + ADP (invariant) | [`atp-adp-cycle.md`](atp-adp-cycle.md) §7.1 | — |
+
+### 10.3 Society-Configurable Parameters
+
+Societies MAY set these parameters via their published governance laws.
+The protocol provides reference defaults; societies override them by
+declaring values in their law structure.
+
+| Parameter | Reference default | Governance | Spec reference |
+|-----------|-------------------|------------|----------------|
+| Training decay rate | −0.001 per month | Societies MAY configure custom decay policies for Training | §2.3 |
+| Temperament recovery rate | +0.01 per month | Societies MAY configure custom recovery curves for Temperament | §2.3 |
+| ATP decay rate | Implementation-specific | Societies MAY implement custom decay rates | [`atp-adp-cycle.md`](atp-adp-cycle.md) §7.3 |
+| ATP transfer fees | None (fee-free at protocol level) | Societies MAY levy transfer fees; rate, bearer, and destination MUST be declared in published laws | [`atp-adp-cycle.md`](atp-adp-cycle.md) §6.3 |
+| Demurrage policy | None prescribed | Societies SHOULD implement demurrage | [`atp-adp-cycle.md`](atp-adp-cycle.md) §7.2 |
+| Charging mechanisms | Not prescribed | Societies MAY choose charging mechanisms | [`atp-adp-cycle.md`](atp-adp-cycle.md) §7.3 |
+| Exchange rate policy | Not prescribed | Societies MAY create exchange agreements; rates SHOULD be transparent | [`atp-adp-cycle.md`](atp-adp-cycle.md) §7.2–7.3 |
+| Role requirement thresholds | Per-role | Societies and role definitions set minimum T3 thresholds for role qualification | §5.1 |
+
+### 10.4 Simulation-Only Parameters
+
+These values appear in explainers, demos, and simulations but are **not**
+protocol parameters. Implementations MUST NOT hard-code them as canonical.
+
+| Parameter | Example values | Why not canonical | Spec reference |
+|-----------|---------------|-------------------|----------------|
+| `constellation_coherence` multiplier | "1.4× CI bonus" | Measures identity strength, not economic scaling; multiplier magnitudes are chosen per simulation | [`multi-device-lct-binding.md`](multi-device-lct-binding.md) §4.4 |
+| CI thresholds and labels | "CI > 0.8 = strong" | Derived labels from `constellation_coherence`; not standalone protocol primitives | [`multi-device-lct-binding.md`](multi-device-lct-binding.md) §4.4 |
+| Talent decay/half-life | "0.995 per period" | Talent no-decay is a protocol invariant (§2.3); any decay value violates the spec | §2.3 |
+| Specific fee rates | "5% transfer fee" | Fee rates are society-configurable, not protocol constants | [`atp-adp-cycle.md`](atp-adp-cycle.md) §6.3 |
+| Specific ATP decay rates | "1% per day" | Decay rates are society-configurable, not protocol constants | [`atp-adp-cycle.md`](atp-adp-cycle.md) §7.3 |
+
+### 10.5 Governance Principle
+
+The three-tier classification follows a consistent principle across the spec:
+
+> **The protocol prescribes formulas and invariants. Societies configure
+> rates and policies. Simulations choose presentation values.**
+
+When a parameter appears in a simulation or explainer, it SHOULD be labeled
+as a simulation parameter (not "the Web4 value"). When a society sets a
+rate, it MUST publish the value in its governance laws. When the protocol
+prescribes a formula, all implementations MUST produce identical results
+regardless of society or context.


### PR DESCRIPTION
## Summary

- Adds §10 "Parameter Governance" to `web4-standard/core-spec/t3-v3-tensors.md` — classifies all trust/value/energy parameters into three governance tiers:
  - **Protocol-invariant** (11 items): formulas, weights, and invariants enforced by cross-language test vectors
  - **Society-configurable** (8 items): decay rates, transfer fees, demurrage — published in society governance laws
  - **Simulation-only** (5 items): CI multipliers, specific fee rates, Talent decay values — not protocol parameters
- Synthesizes decisions from Sprint 44 (transfer fees, Talent no-decay), Sprint 46 (constellation_coherence), and existing spec text
- Resolves Unanswered Question #3 from Sprint 43 audit ("Who decides the parameters?"), unblocked by Sprint 46 T1

## Test plan

- [ ] Verify §10 tables are well-formed markdown (render in GitHub PR diff)
- [ ] Confirm spec references (§2.3, §3.3, §6.3, §7, §4.4) point to correct sections
- [ ] Confirm cross-references to `atp-adp-cycle.md` and `multi-device-lct-binding.md` are relative links
- [ ] Verify no new files created (0 new, 1 spec modified, 2 bookkeeping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)