### PR TITLE
docs(spec): reconcile §7.4↔§4.1 wire-field redefinition (audit F8)

### DIFF
--- a/web4-standard/core-spec/mcp-protocol.md
+++ b/web4-standard/core-spec/mcp-protocol.md
@@ -436,6 +436,24 @@ When the MCP caller and responder are in different societies, the Web4 Context H
   - **Encompassing-law**: when caller and responder share a fractal-encompassing society, that society's Law Oracle governs (per `inter-society-protocol.md` §3.2 Option 3)
 - `atp_settlement.exchange_rate` MUST be present for cross-society calls with non-zero ATP cost when the two societies use different currencies; reference must be a current (within agreement validity window) negotiated rate from the inter-society protocol
 
+**Relationship to §4.1 Web4 Context Headers:**
+
+The cross-society envelope extends — it does not replace — the §4.1 header. The
+following reconciles the fields that change shape between the two sections:
+
+- `sender_society` is the cross-society form of §4.1 `society`. For
+  cross-society envelopes (`sender_society` and `responding_society` both
+  present) `sender_society` carries the sending society's LCT and §4.1
+  `society` is omitted. Intra-society calls continue to use §4.1 `society`
+  alone and MUST NOT set `sender_society`. A recipient MUST treat
+  `sender_society` and §4.1 `society` as the same logical field (sending
+  society identity) and MUST NOT require both in one envelope.
+- `agency_chain` is the ordered-list form of §4.1 `proof_of_agency`. Each
+  element MUST be a §4.1 `proof_of_agency` object (`{grant_id, scope}`),
+  ordered from the originating grant to the most recent delegation; a
+  single-element `agency_chain` is wire-equivalent to one §4.1
+  `proof_of_agency`. The chain MUST be non-empty when present.
+
 ### 7.5 Cross-Society Witnessing and R7 Reputation Propagation
 
 Cross-society R7 actions interact with the witness role per `society-roles.md` §4.1. When an entity in Society A acts on a resource in Society B via MCP:


### PR DESCRIPTION
## Summary

Closes audit finding **F8** (HIGH) from PR #193's mcp-protocol.md
internal-consistency audit — remediation item #3, explicitly independent
of the F2/F3/F4/F11 settlement cluster.

§7.4 (Cross-Society LCT Envelope) introduced `sender_society` and
`agency_chain` (array) without stating their relationship to §4.1's
`society` (single) and `proof_of_agency` (object). The only binding was a
non-normative code comment (`/* per existing §4.1 proof_of_agency */`) —
an unreconciled wire-field redefinition across two normative sections.

Adds a normative **"Relationship to §4.1"** block to §7.4:

- `sender_society` is the cross-society form of §4.1 `society` —
  mutually exclusive; intra-society calls use §4.1 `society` alone;
  recipients treat them as one logical field.
- `agency_chain` is the ordered-list form of §4.1 `proof_of_agency`;
  element type defined explicitly as `{grant_id, scope}`, ordered
  origin→latest, non-empty when present.

Spec-only change (`web4-standard/core-spec/mcp-protocol.md`, +18 lines).
No SDK/code touched.

## Provenance

- Peer session `120726`, v2 protocol (propose → policy-review APPROVED → execute → document).
- Orthogonal to parallel lead `120001` (Sprint 54 P1 SDK dataclass work) — disjoint files, repo area, and audit lineage. No collision.
- Does NOT touch the settlement cluster (F2/F3/F4/F11) or §7.7 (C3) — reserved for operator/lead.

## Test plan

- [ ] Spec review: confirm the §7.4 reconciliation matches §4.1 field shapes (`society`, `proof_of_agency` `{grant_id, scope}`).
- [ ] Confirm no normative conflict introduced with §4.1 or §7.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)