### PR TITLE
test(sdk): add coverage for #195-landed cross-society types

### DIFF
--- a/web4-standard/implementation/sdk/tests/test_errors.py
+++ b/web4-standard/implementation/sdk/tests/test_errors.py
@@ -2,13 +2,14 @@
 Tests for web4.errors — error taxonomy, RFC 9457 serialization.
 
 Tests cover:
-1. Registry completeness (all 24 codes, 6 categories)
+1. Registry completeness (all 30 codes, 7 categories)
 2. Error code metadata (title, status, description)
 3. Web4Error construction and fields
-4. Category subclass dispatch
+4. Category subclass dispatch (including CrossSocietyError)
 5. RFC 9457 Problem Details serialization round-trips
 6. make_error convenience constructor
 7. Test vector validation
+8. Cross-society error metadata (§7.6)
 """
 
 import json
@@ -19,6 +20,7 @@ import pytest
 from web4.errors import (
     AuthzError,
     BindingError,
+    CrossSocietyError,
     CryptoError,
     ErrorCategory,
     ErrorCode,
@@ -37,21 +39,30 @@ from web4.errors import (
 class TestRegistryCompleteness:
     """Every ErrorCode must have metadata in the registry."""
 
-    def test_all_24_codes_registered(self):
+    def test_all_30_codes_registered(self):
         for code in ErrorCode:
             meta = get_error_meta(code)
             assert meta.code == code
 
-    def test_exactly_24_codes(self):
-        assert len(ErrorCode) == 24
+    def test_exactly_30_codes(self):
+        assert len(ErrorCode) == 30
 
-    def test_exactly_6_categories(self):
-        assert len(ErrorCategory) == 6
+    def test_exactly_7_categories(self):
+        assert len(ErrorCategory) == 7
 
-    def test_4_codes_per_category(self):
+    def test_codes_per_category(self):
+        expected = {
+            ErrorCategory.BINDING: 4,
+            ErrorCategory.PAIRING: 4,
+            ErrorCategory.WITNESS: 4,
+            ErrorCategory.AUTHZ: 4,
+            ErrorCategory.CRYPTO: 4,
+            ErrorCategory.PROTO: 4,
+            ErrorCategory.CROSS_SOCIETY: 6,
+        }
         for cat in ErrorCategory:
             codes = codes_for_category(cat)
-            assert len(codes) == 4, f"{cat} has {len(codes)} codes, expected 4"
+            assert len(codes) == expected[cat], f"{cat} has {len(codes)} codes, expected {expected[cat]}"
 
     def test_all_codes_have_title(self):
         for code in ErrorCode:
@@ -105,6 +116,24 @@ class TestErrorMetadata:
         assert meta.category == ErrorCategory.PROTO
         assert meta.title == "Replay Detected"
         assert meta.status == 409
+
+    def test_cross_society_unrecognized_lct(self):
+        meta = get_error_meta(ErrorCode.CROSS_SOCIETY_UNRECOGNIZED_LCT)
+        assert meta.category == ErrorCategory.CROSS_SOCIETY
+        assert meta.title == "Unrecognized Cross-Society LCT"
+        assert meta.status == 404
+
+    def test_cross_society_law_conflict(self):
+        meta = get_error_meta(ErrorCode.CROSS_SOCIETY_LAW_CONFLICT)
+        assert meta.category == ErrorCategory.CROSS_SOCIETY
+        assert meta.title == "Law Oracle Conflict"
+        assert meta.status == 409
+
+    def test_r7_reputation_invalid(self):
+        meta = get_error_meta(ErrorCode.R7_REPUTATION_INVALID)
+        assert meta.category == ErrorCategory.CROSS_SOCIETY
+        assert meta.title == "Invalid R7 Reputation"
+        assert meta.status == 400
 
 
 # ── Web4Error Construction ────────────────────────────────────────
@@ -166,6 +195,7 @@ class TestCategorySubclasses:
             (AuthzError, ErrorCode.AUTHZ_DENIED),
             (CryptoError, ErrorCode.CRYPTO_SUITE),
             (ProtoError, ErrorCode.PROTO_VERSION),
+            (CrossSocietyError, ErrorCode.CROSS_SOCIETY_UNRECOGNIZED_LCT),
         ],
     )
     def test_subclass_is_web4error(self, cls, code):
@@ -180,6 +210,14 @@ class TestCategorySubclasses:
     def test_catch_by_base(self):
         with pytest.raises(Web4Error):
             raise CryptoError(ErrorCode.CRYPTO_KEY)
+
+    def test_catch_cross_society_by_category(self):
+        with pytest.raises(CrossSocietyError):
+            raise CrossSocietyError(ErrorCode.CROSS_SOCIETY_LAW_CONFLICT)
+
+    def test_catch_cross_society_by_base(self):
+        with pytest.raises(Web4Error):
+            raise CrossSocietyError(ErrorCode.R7_REPUTATION_INVALID)
 
 
 # ── RFC 9457 Serialization ────────────────────────────────────────
@@ -268,6 +306,22 @@ class TestMakeError:
         )
         assert isinstance(err, ProtoError)
         assert err.instance == "web4://node-1/handshake/99"
+
+    def test_returns_cross_society_error(self):
+        err = make_error(ErrorCode.CROSS_SOCIETY_WITNESS_REQUIRED)
+        assert isinstance(err, CrossSocietyError)
+        assert err.category == ErrorCategory.CROSS_SOCIETY
+
+    def test_cross_society_round_trip(self):
+        original = CrossSocietyError(
+            ErrorCode.CROSS_SOCIETY_EXCHANGE_INVALID,
+            detail="Exchange rate expired 2h ago",
+        )
+        pj = original.to_problem_json()
+        restored = Web4Error.from_problem_json(pj)
+        assert isinstance(restored, CrossSocietyError)
+        assert restored.code == ErrorCode.CROSS_SOCIETY_EXCHANGE_INVALID
+        assert restored.detail == "Exchange rate expired 2h ago"
 
 
 # ── Test Vectors ──────────────────────────────────────────────────

--- a/web4-standard/implementation/sdk/tests/test_mcp_cross_society.py
+++ b/web4-standard/implementation/sdk/tests/test_mcp_cross_society.py
@@ -1,0 +1,443 @@
+"""
+Tests for cross-society MCP types landed via PR #195.
+
+Covers the 6 types added to web4.mcp implementing mcp-protocol.md §7.3–7.6:
+OutcomeClass, PropagationScope, CrossSocietyInteractionType,
+CrossSocietyContext, ReputationEnvelope, MCPContextResource.
+
+Tests: enum values, construction, defaults, to_dict/from_dict round-trips.
+"""
+
+from web4.mcp import (
+    CrossSocietyContext,
+    CrossSocietyInteractionType,
+    MCPContextResource,
+    MCPResourceType,
+    OutcomeClass,
+    ProofOfAgency,
+    PropagationScope,
+    ReputationEnvelope,
+    TrustRequirements,
+)
+
+# ── OutcomeClass (§7.3) ──────────────────────────────────────────
+
+
+class TestOutcomeClass:
+    def test_enum_values(self):
+        assert OutcomeClass.SUCCESS.value == "success"
+        assert OutcomeClass.PARTIAL.value == "partial"
+        assert OutcomeClass.FAILURE.value == "failure"
+        assert OutcomeClass.VIOLATION.value == "violation"
+
+    def test_count(self):
+        assert len(OutcomeClass) == 4
+
+    def test_str_roundtrip(self):
+        for oc in OutcomeClass:
+            assert OutcomeClass(oc.value) is oc
+
+
+# ── PropagationScope (§7.3, §7.5) ────────────────────────────────
+
+
+class TestPropagationScope:
+    def test_enum_values(self):
+        assert PropagationScope.RESPONDING_SOCIETY.value == "responding_society"
+        assert PropagationScope.CALLER_SOCIETY.value == "caller_society"
+        assert PropagationScope.BOTH.value == "both"
+        assert PropagationScope.ENCOMPASSING_SOCIETY.value == "encompassing_society"
+
+    def test_count(self):
+        assert len(PropagationScope) == 4
+
+    def test_str_roundtrip(self):
+        for ps in PropagationScope:
+            assert PropagationScope(ps.value) is ps
+
+
+# ── CrossSocietyInteractionType (§7.4) ───────────────────────────
+
+
+class TestCrossSocietyInteractionType:
+    def test_enum_values(self):
+        assert CrossSocietyInteractionType.FIRST_CONTACT.value == "first_contact"
+        assert CrossSocietyInteractionType.ESTABLISHED.value == "established"
+        assert CrossSocietyInteractionType.FEDERATED.value == "federated"
+
+    def test_count(self):
+        assert len(CrossSocietyInteractionType) == 3
+
+    def test_str_roundtrip(self):
+        for it in CrossSocietyInteractionType:
+            assert CrossSocietyInteractionType(it.value) is it
+
+
+# ── CrossSocietyContext (§7.4) ────────────────────────────────────
+
+
+class TestCrossSocietyContext:
+    def test_minimal_construction(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:alice",
+            sender_society="society:alpha",
+            responding_society="society:beta",
+        )
+        assert ctx.sender_lct == "lct:alice"
+        assert ctx.sender_society == "society:alpha"
+        assert ctx.responding_society == "society:beta"
+        assert ctx.interaction_type == CrossSocietyInteractionType.ESTABLISHED
+
+    def test_defaults(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:x",
+            sender_society="s:a",
+            responding_society="s:b",
+        )
+        assert ctx.sender_role == ""
+        assert ctx.responding_role_expected == ""
+        assert ctx.applicable_law_oracle == ""
+        assert ctx.exchange_agreement_hash == ""
+        assert ctx.atp_settlement_currency == ""
+        assert ctx.atp_settlement_amount == 0
+        assert ctx.atp_settlement_exchange_rate is None
+        assert ctx.mrh_depth == 1
+        assert ctx.law_hash == ""
+        assert ctx.proof_of_agency is None
+
+    def test_full_construction(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:alice",
+            sender_society="society:alpha",
+            responding_society="society:beta",
+            interaction_type=CrossSocietyInteractionType.FIRST_CONTACT,
+            sender_role="Trader",
+            responding_role_expected="Merchant",
+            applicable_law_oracle="oracle:encompassing",
+            exchange_agreement_hash="sha256:abc123",
+            atp_settlement_currency="ATP-ALPHA",
+            atp_settlement_amount=100,
+            atp_settlement_exchange_rate={"ATP-ALPHA": 1.0, "ATP-BETA": 0.85},
+            mrh_depth=3,
+            law_hash="sha256:law",
+            proof_of_agency=ProofOfAgency(
+                grant_id="grant:alice-trade",
+                scope="cross_society_trade",
+            ),
+        )
+        assert ctx.interaction_type == CrossSocietyInteractionType.FIRST_CONTACT
+        assert ctx.atp_settlement_amount == 100
+
+    def test_to_dict_minimal(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:a",
+            sender_society="s:alpha",
+            responding_society="s:beta",
+        )
+        d = ctx.to_dict()
+        assert d["sender_lct"] == "lct:a"
+        assert d["sender_society"] == "s:alpha"
+        assert d["responding_society"] == "s:beta"
+        assert d["interaction_type"] == "established"
+        assert "cross_society" in d
+        assert d["cross_society"]["interaction_type"] == "established"
+
+    def test_to_dict_with_settlement(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:a",
+            sender_society="s:alpha",
+            responding_society="s:beta",
+            atp_settlement_currency="ATP-A",
+            atp_settlement_amount=50,
+            atp_settlement_exchange_rate={"rate": 0.9},
+        )
+        d = ctx.to_dict()
+        settlement = d["cross_society"]["atp_settlement"]
+        assert settlement["currency"] == "ATP-A"
+        assert settlement["amount"] == 50
+        assert settlement["exchange_rate"] == {"rate": 0.9}
+
+    def test_roundtrip(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:alice",
+            sender_society="society:alpha",
+            responding_society="society:beta",
+            interaction_type=CrossSocietyInteractionType.FEDERATED,
+            sender_role="Diplomat",
+            applicable_law_oracle="oracle:encompassing",
+            atp_settlement_currency="ATP-ALPHA",
+            atp_settlement_amount=200,
+            mrh_depth=2,
+            law_hash="sha256:lawdigest",
+        )
+        d = ctx.to_dict()
+        restored = CrossSocietyContext.from_dict(d)
+        assert restored.sender_lct == ctx.sender_lct
+        assert restored.sender_society == ctx.sender_society
+        assert restored.responding_society == ctx.responding_society
+        assert restored.interaction_type == ctx.interaction_type
+        assert restored.sender_role == ctx.sender_role
+        assert restored.applicable_law_oracle == ctx.applicable_law_oracle
+        assert restored.atp_settlement_currency == ctx.atp_settlement_currency
+        assert restored.atp_settlement_amount == ctx.atp_settlement_amount
+        assert restored.mrh_depth == ctx.mrh_depth
+        assert restored.law_hash == ctx.law_hash
+
+    def test_roundtrip_with_proof_of_agency(self):
+        poa = ProofOfAgency(
+            grant_id="grant:agent-trade",
+            scope="cross_society_trade",
+        )
+        ctx = CrossSocietyContext(
+            sender_lct="lct:agent",
+            sender_society="s:a",
+            responding_society="s:b",
+            proof_of_agency=poa,
+        )
+        d = ctx.to_dict()
+        restored = CrossSocietyContext.from_dict(d)
+        assert restored.proof_of_agency is not None
+        assert restored.proof_of_agency.grant_id == "grant:agent-trade"
+        assert restored.proof_of_agency.scope == "cross_society_trade"
+
+    def test_frozen(self):
+        ctx = CrossSocietyContext(
+            sender_lct="lct:x",
+            sender_society="s:a",
+            responding_society="s:b",
+        )
+        try:
+            ctx.sender_lct = "lct:y"  # type: ignore[misc]
+            assert False, "Should raise FrozenInstanceError"
+        except AttributeError:
+            pass
+
+
+# ── ReputationEnvelope (§7.3) ─────────────────────────────────────
+
+
+class TestReputationEnvelope:
+    def test_minimal_construction(self):
+        env = ReputationEnvelope(
+            action_id="action:001",
+            outcome_class=OutcomeClass.SUCCESS,
+        )
+        assert env.action_id == "action:001"
+        assert env.outcome_class == OutcomeClass.SUCCESS
+        assert env.outcome_quality == 0.5
+        assert env.propagation_scope == PropagationScope.RESPONDING_SOCIETY
+
+    def test_defaults(self):
+        env = ReputationEnvelope(
+            action_id="a:1",
+            outcome_class=OutcomeClass.FAILURE,
+        )
+        assert env.responding_society == ""
+        assert env.responding_society_signature == ""
+        assert env.trust_dimension_updates == {}
+        assert env.witness_signatures == []
+        assert env.timestamp == ""
+
+    def test_full_construction(self):
+        env = ReputationEnvelope(
+            action_id="action:trade-42",
+            outcome_class=OutcomeClass.PARTIAL,
+            outcome_quality=0.7,
+            responding_society="society:beta",
+            responding_society_signature="sig:beta-policy",
+            trust_dimension_updates={"talent": 0.1, "temperament": -0.05},
+            propagation_scope=PropagationScope.BOTH,
+            witness_signatures=["sig:witness-1", "sig:witness-2"],
+            timestamp="2026-05-16T00:00:00Z",
+        )
+        assert env.outcome_quality == 0.7
+        assert len(env.trust_dimension_updates) == 2
+        assert len(env.witness_signatures) == 2
+
+    def test_to_dict_minimal(self):
+        env = ReputationEnvelope(
+            action_id="a:1",
+            outcome_class=OutcomeClass.SUCCESS,
+        )
+        d = env.to_dict()
+        assert d["action_id"] == "a:1"
+        assert d["outcome_class"] == "success"
+        assert d["outcome_quality"] == 0.5
+        assert d["propagation_scope"] == "responding_society"
+
+    def test_to_dict_with_updates(self):
+        env = ReputationEnvelope(
+            action_id="a:2",
+            outcome_class=OutcomeClass.VIOLATION,
+            trust_dimension_updates={"talent": -0.3},
+            witness_signatures=["sig:w1"],
+            responding_society="s:beta",
+        )
+        d = env.to_dict()
+        assert d["trust_dimension_updates"] == {"talent": -0.3}
+        assert d["witness_signatures"] == ["sig:w1"]
+        assert d["responding_society"] == "s:beta"
+
+    def test_roundtrip(self):
+        env = ReputationEnvelope(
+            action_id="action:trade-99",
+            outcome_class=OutcomeClass.PARTIAL,
+            outcome_quality=0.65,
+            responding_society="society:gamma",
+            responding_society_signature="sig:gamma",
+            trust_dimension_updates={"talent": 0.05, "training": 0.1},
+            propagation_scope=PropagationScope.ENCOMPASSING_SOCIETY,
+            witness_signatures=["sig:w1"],
+            timestamp="2026-05-16T12:00:00Z",
+        )
+        d = env.to_dict()
+        restored = ReputationEnvelope.from_dict(d)
+        assert restored.action_id == env.action_id
+        assert restored.outcome_class == env.outcome_class
+        assert restored.outcome_quality == env.outcome_quality
+        assert restored.responding_society == env.responding_society
+        assert restored.propagation_scope == env.propagation_scope
+        assert restored.trust_dimension_updates == env.trust_dimension_updates
+        assert restored.witness_signatures == env.witness_signatures
+        assert restored.timestamp == env.timestamp
+
+    def test_frozen(self):
+        env = ReputationEnvelope(
+            action_id="a:1",
+            outcome_class=OutcomeClass.SUCCESS,
+        )
+        try:
+            env.action_id = "a:2"  # type: ignore[misc]
+            assert False, "Should raise FrozenInstanceError"
+        except AttributeError:
+            pass
+
+
+# ── MCPContextResource (§6.3) ─────────────────────────────────────
+
+
+class TestMCPContextResource:
+    def test_minimal_construction(self):
+        res = MCPContextResource(name="session-state")
+        assert res.name == "session-state"
+        assert res.context_type == "session_state"
+
+    def test_defaults(self):
+        res = MCPContextResource(name="ctx")
+        assert res.description == ""
+        assert res.atp_cost == 1
+        assert res.ttl == 3600
+        assert res.snapshot == {}
+
+    def test_full_construction(self):
+        res = MCPContextResource(
+            name="trust-evolution",
+            context_type="trust_snapshot",
+            description="Current trust tensor snapshot",
+            trust_requirements=TrustRequirements(minimum_t3={"talent": 0.5}),
+            atp_cost=10,
+            ttl=1800,
+            snapshot={"t3": {"talent": 0.8, "training": 0.6, "temperament": 0.7}},
+        )
+        assert res.context_type == "trust_snapshot"
+        assert res.atp_cost == 10
+        assert res.snapshot["t3"]["talent"] == 0.8
+
+    def test_to_dict(self):
+        res = MCPContextResource(
+            name="mrh-graph",
+            context_type="mrh_snapshot",
+            description="MRH graph for current session",
+            atp_cost=5,
+        )
+        d = res.to_dict()
+        assert d["resource_type"] == MCPResourceType.CONTEXT.value
+        assert d["name"] == "mrh-graph"
+        assert d["context_type"] == "mrh_snapshot"
+        assert d["description"] == "MRH graph for current session"
+        assert d["atp_cost"] == 5
+
+    def test_roundtrip(self):
+        res = MCPContextResource(
+            name="trust-evolution",
+            context_type="trust_snapshot",
+            description="Snapshot",
+            atp_cost=10,
+            ttl=900,
+            snapshot={"version": 2, "data": [1, 2, 3]},
+        )
+        d = res.to_dict()
+        restored = MCPContextResource.from_dict(d)
+        assert restored.name == res.name
+        assert restored.context_type == res.context_type
+        assert restored.description == res.description
+        assert restored.atp_cost == res.atp_cost
+        assert restored.ttl == res.ttl
+        assert restored.snapshot == res.snapshot
+
+    def test_frozen(self):
+        res = MCPContextResource(name="x")
+        try:
+            res.name = "y"  # type: ignore[misc]
+            assert False, "Should raise FrozenInstanceError"
+        except AttributeError:
+            pass
+
+
+# ── Package-level imports ─────────────────────────────────────────
+
+
+class TestPackageExports:
+    """Verify cross-society types are accessible from the web4 package."""
+
+    def test_outcome_class_from_package(self):
+        import web4
+
+        assert hasattr(web4, "OutcomeClass")
+        assert web4.OutcomeClass.SUCCESS.value == "success"
+
+    def test_propagation_scope_from_package(self):
+        import web4
+
+        assert hasattr(web4, "PropagationScope")
+        assert web4.PropagationScope.BOTH.value == "both"
+
+    def test_cross_society_interaction_type_from_package(self):
+        import web4
+
+        assert hasattr(web4, "CrossSocietyInteractionType")
+        assert web4.CrossSocietyInteractionType.FEDERATED.value == "federated"
+
+    def test_cross_society_context_from_package(self):
+        import web4
+
+        assert hasattr(web4, "CrossSocietyContext")
+        ctx = web4.CrossSocietyContext(
+            sender_lct="lct:test",
+            sender_society="s:a",
+            responding_society="s:b",
+        )
+        assert ctx.sender_lct == "lct:test"
+
+    def test_reputation_envelope_from_package(self):
+        import web4
+
+        assert hasattr(web4, "ReputationEnvelope")
+        env = web4.ReputationEnvelope(
+            action_id="a:1",
+            outcome_class=web4.OutcomeClass.SUCCESS,
+        )
+        assert env.action_id == "a:1"
+
+    def test_mcp_context_resource_from_package(self):
+        import web4
+
+        assert hasattr(web4, "MCPContextResource")
+        res = web4.MCPContextResource(name="test")
+        assert res.name == "test"
+
+    def test_cross_society_error_from_package(self):
+        import web4
+
+        assert hasattr(web4, "CrossSocietyError")
+        assert issubclass(web4.CrossSocietyError, web4.Web4Error)

--- a/web4-standard/implementation/sdk/web4/__init__.py
+++ b/web4-standard/implementation/sdk/web4/__init__.py
@@ -306,6 +306,7 @@ from .errors import (
     AuthzError,
     CryptoError,
     ProtoError,
+    CrossSocietyError,
     get_error_meta,
     codes_for_category,
     make_error,
@@ -486,6 +487,13 @@ from .mcp import (
     MCPErrorContext,
     web4_context_to_json,
     web4_context_from_json,
+    # Cross-society types (§7.3–7.6, landed via PR #195)
+    OutcomeClass,
+    PropagationScope,
+    CrossSocietyInteractionType,
+    CrossSocietyContext,
+    ReputationEnvelope,
+    MCPContextResource,
 )
 
 # Aliases for disambiguation with r6 types
@@ -741,6 +749,7 @@ __all__ = [
     "AuthzError",
     "CryptoError",
     "ProtoError",
+    "CrossSocietyError",
     "get_error_meta",
     "codes_for_category",
     "make_error",
@@ -897,6 +906,13 @@ __all__ = [
     "MCPErrorContext",
     "web4_context_to_json",
     "web4_context_from_json",
+    # mcp cross-society (§7.3–7.6)
+    "OutcomeClass",
+    "PropagationScope",
+    "CrossSocietyInteractionType",
+    "CrossSocietyContext",
+    "ReputationEnvelope",
+    "MCPContextResource",
     # validation
     "ValidationResult",
     "ValidationError",

--- a/web4-standard/implementation/sdk/web4/errors.py
+++ b/web4-standard/implementation/sdk/web4/errors.py
@@ -297,6 +297,49 @@ _ERROR_REGISTRY: Dict[ErrorCode, ErrorMeta] = {
         400,
         "Protocol downgrade attack detected",
     ),
+    # mcp-protocol.md §7.6 — Cross-Society MCP Errors
+    ErrorCode.CROSS_SOCIETY_UNRECOGNIZED_LCT: ErrorMeta(
+        ErrorCode.CROSS_SOCIETY_UNRECOGNIZED_LCT,
+        ErrorCategory.CROSS_SOCIETY,
+        "Unrecognized Cross-Society LCT",
+        404,
+        "Responding society does not recognize the caller's LCT",
+    ),
+    ErrorCode.CROSS_SOCIETY_EXCHANGE_INVALID: ErrorMeta(
+        ErrorCode.CROSS_SOCIETY_EXCHANGE_INVALID,
+        ErrorCategory.CROSS_SOCIETY,
+        "Invalid Exchange Rate",
+        400,
+        "Cross-society ATP exchange rate is invalid or expired",
+    ),
+    ErrorCode.CROSS_SOCIETY_LAW_CONFLICT: ErrorMeta(
+        ErrorCode.CROSS_SOCIETY_LAW_CONFLICT,
+        ErrorCategory.CROSS_SOCIETY,
+        "Law Oracle Conflict",
+        409,
+        "Sender and responding societies have conflicting law oracles",
+    ),
+    ErrorCode.CROSS_SOCIETY_WITNESS_REQUIRED: ErrorMeta(
+        ErrorCode.CROSS_SOCIETY_WITNESS_REQUIRED,
+        ErrorCategory.CROSS_SOCIETY,
+        "Witness Required",
+        403,
+        "Cross-society action requires a witness but none is available",
+    ),
+    ErrorCode.R7_REPUTATION_INVALID: ErrorMeta(
+        ErrorCode.R7_REPUTATION_INVALID,
+        ErrorCategory.CROSS_SOCIETY,
+        "Invalid R7 Reputation",
+        400,
+        "R7 reputation envelope is malformed or signature invalid",
+    ),
+    ErrorCode.PROPAGATION_SCOPE_UNSUPPORTED: ErrorMeta(
+        ErrorCode.PROPAGATION_SCOPE_UNSUPPORTED,
+        ErrorCategory.CROSS_SOCIETY,
+        "Unsupported Propagation Scope",
+        400,
+        "Responding society does not support the requested propagation scope",
+    ),
 }
 
 
@@ -415,6 +458,12 @@ class ProtoError(Web4Error):
     pass
 
 
+class CrossSocietyError(Web4Error):
+    """Error related to cross-society MCP operations (mcp-protocol.md §7.6)."""
+
+    pass
+
+
 # Map categories to their subclass for from_problem_json dispatch
 _CATEGORY_SUBCLASS: Dict[ErrorCategory, type[Web4Error]] = {
     ErrorCategory.BINDING: BindingError,
@@ -423,6 +472,7 @@ _CATEGORY_SUBCLASS: Dict[ErrorCategory, type[Web4Error]] = {
     ErrorCategory.AUTHZ: AuthzError,
     ErrorCategory.CRYPTO: CryptoError,
     ErrorCategory.PROTO: ProtoError,
+    ErrorCategory.CROSS_SOCIETY: CrossSocietyError,
 }
 
 


### PR DESCRIPTION
## Summary

Completes integration wiring + test coverage for the cross-society MCP types
that landed on main via PR #195 but lacked tests, error registry entries, and
package exports. Re-scoped per PR #196 rejection directive.

- **errors.py**: `CrossSocietyError` class (was in `__all__` but undefined), 6 ErrorMeta
  registry entries for §7.6 cross-society codes, `_CATEGORY_SUBCLASS` dispatch
- **__init__.py**: Export 6 cross-society MCP types + `CrossSocietyError` (369→376 exports)
- **test_mcp_cross_society.py** (NEW, 37 tests): enum values, construction, defaults,
  `to_dict`/`from_dict` round-trips, frozen checks, package-level import verification
- **test_errors.py**: Updated assertions (24→30 codes, 6→7 categories), cross-society
  subclass/metadata/serialization tests

No `mcp.py` formatting churn. No version bump. No CLI changes.

## Quality gates

- 2746 passed, 8 xfailed (conformance gaps, pre-existing)
- `mypy --strict`: 0 errors across 26 source files
- `ruff check`: 0 errors
- `ruff format --check` (changed files): 0 changes
- GitNexus `detect_changes`: risk level LOW, 0 affected processes

## Test plan

- [x] `python -m pytest tests/test_errors.py tests/test_mcp_cross_society.py -v` — 87 passed
- [x] `python -m pytest tests/ -q` — full suite 2746 passed, 8 xfailed
- [x] `python -m mypy --strict web4/` — clean
- [x] `python -m ruff check web4/ tests/` — clean
- [x] Package exports verified: `import web4; len(web4.__all__) == 376`

🤖 Generated with [Claude Code](https://claude.com/claude-code)