### PR TITLE
docs(spec): resolve LOW-severity F14/F16 from C2 audit

### DIFF
--- a/web4-standard/core-spec/mcp-protocol.md
+++ b/web4-standard/core-spec/mcp-protocol.md
@@ -714,9 +714,14 @@ class MCPMeter:
         return min(total_cost, context.atp_cap)  # Respect caps
 ```
 
-### 9.2 Dynamic Pricing
+### 9.2 Dynamic Pricing (informative)
 
-Prices adjust based on demand and trust:
+Prices adjust based on demand and trust.  The modifiers below are
+**illustrative society-configurable parameters**, not protocol constants.
+§9.1 defines the canonical metering formula; here `high_trust_discount: 0.8`
+is the endpoint that §9.1's formula reaches at maximum trust
+(T3 average = 1.0 → `1.0 − 1.0 × 0.2 = 0.8`).  A society's pricing
+configuration supplies these values; the metering engine applies them per §9.1.
 
 ```json
 {


### PR DESCRIPTION
## Summary

- **F14** (cross-doc section-number claims): Verified all 6 references from `mcp-protocol.md` → `inter-society-protocol.md`. All correct — no stale references. The §7.5↔§9 status-coupling claim is bidirectionally consistent (both documents agree the future-work item is resolved). Resolved by verification; no spec edits needed.
- **F16** (two trust-discount models §9.1 vs §9.2): Annotated §9.2 as `(informative)` with clarifying text that its modifiers are illustrative society-configurable parameters, not protocol constants. §9.1 remains the canonical metering formula.
- **F9/F10/F13** deliberately deferred to avoid merge conflicts with PRs #200/#201 that edit overlapping regions of mcp-protocol.md.

## C2 Audit Finding Status (16 total)

| Status | Findings | Notes |
|--------|----------|-------|
| Resolved by PR #200/#201 | F1, F2, F3, F4, F5, F8, F12, F15 | 4 HIGH + 4 MEDIUM |
| Resolved this PR | F14 (verified), F16 (annotated) | 2 LOW |
| Deferred (merge-conflict avoidance) | F9, F10, F13 | 3 LOW — pick up after #200/#201 merge |
| Blocked | F6/F7 (operator), F11 (PR #200) | 2 MEDIUM + 1 MEDIUM |

## Test plan

- [ ] Verify §9.2 annotation reads correctly in context
- [ ] Confirm no merge conflicts with PRs #200-#202

🤖 Generated with [Claude Code](https://claude.com/claude-code)