### PR TITLE
docs(conformance): resolve C5 audit G4 — fix P1-003 + add P1-004

### DIFF
--- a/web4-standard/testing/conformance/presence-protocol-conformance.json
+++ b/web4-standard/testing/conformance/presence-protocol-conformance.json
@@ -4,7 +4,7 @@
   "description": "Test scenarios that a conforming presence-layer implementation MUST pass. The conformance harness at web4-standard/testing/conformance/ runs these against a live daemon and verifies shapes against the JSON Schemas in schemas/presence-protocol/{v0,v1}/. v0 scenarios (P0-*) still pass on v1+ daemons by design; v1 scenarios (P1-*) test the new fields and the engine semantics.",
   "specVersion": "presence-protocol v1",
   "protocolVersion": 1,
-  "lastUpdated": "2026-05-16",
+  "lastUpdated": "2026-05-18",
   "scenarios": [
     {
       "id": "P0-001",
@@ -338,14 +338,58 @@
     {
       "id": "P1-003",
       "name": "v1 protocolVersion bumped on connect",
-      "description": "A v1 daemon advertises protocolVersion: 1 in its hestia_connect response. (P0-001 already ran on connect; this scenario re-checks the captured field.)",
-      "preconditions": ["P0-001"],
+      "description": "A v1 daemon advertises protocolVersion: 1 in its hestia_connect response. Connects with protocol_version: 1 and verifies the returned protocolVersion field.",
       "steps": [
         {
-          "resource": "hestia://society/state",
+          "tool": "hestia_connect",
+          "input": {
+            "plugin_id": "conformance-v1-check",
+            "plugin_version": "0.0.1",
+            "host_agent": "conformance-runner",
+            "host_agent_version": "0.0.1",
+            "requested_role": "citizen",
+            "protocol_version": 1
+          },
           "expect": {
             "fieldChecks": [
-              { "path": "sovereign_lct", "startsWith": "lct:" }
+              { "path": "protocolVersion", "equals": 1 },
+              { "path": "sessionId", "matchesPattern": "^[0-9a-f-]{36}$" },
+              { "path": "softLct", "startsWith": "lct:" },
+              { "path": "assignedRole", "equals": "citizen" }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "P1-004",
+      "name": "v1 query_policy returns wait-protocol default values",
+      "description": "§3.4.1 mandates orchestrators MUST support both branches of the wait protocol today. v1 daemons currently return status='decided' and nextPollMs=null (the defaults per the v1 schema). This vector verifies those default values are present.",
+      "preconditions": ["P0-001"],
+      "setup": [
+        {
+          "tool": "hestia_begin_action",
+          "input": {
+            "tool_name": "Read",
+            "target": "/tmp/p1-004-wait-check",
+            "session_id": "{{P0-001.sessionId}}"
+          },
+          "capture": { "actionId": "$.actionId" }
+        }
+      ],
+      "steps": [
+        {
+          "tool": "hestia_query_policy",
+          "input": {
+            "action_id": "{{P1-004.actionId}}",
+            "session_id": "{{P0-001.sessionId}}"
+          },
+          "expect": {
+            "shapeMatchesSchema": "https://web4.io/schemas/presence-protocol/v1/tools/hestia_query_policy.schema.json#/$defs/output",
+            "fieldChecks": [
+              { "path": "decision", "isIn": ["allow", "deny", "warn"] },
+              { "path": "status", "equals": "decided" },
+              { "path": "nextPollMs", "equals": null }
             ]
           }
         }


### PR DESCRIPTION
## Summary

- **P12 (P1-003 fix)**: Vector was named "v1 protocolVersion bumped on connect" but only read `hestia://society/state` — never verified `protocolVersion`. Now does a fresh `hestia_connect` with `protocol_version: 1` and asserts `protocolVersion == 1` in the response.
- **P13 (P1-004 new)**: New vector verifies wait-protocol default values per §3.4.1: `status == "decided"` and `nextPollMs == null` on a v1 `query_policy` response.
- Bumped `lastUpdated` to `2026-05-18`.

Completes C5 audit remediation: G1+G3 (#206), G2 (#207), G4 (this PR). All 13 findings resolved.

**Audit**: `docs/audits/presence-protocol-internal-consistency-2026-05-17.md`

## Changes

- 1 file modified: `web4-standard/testing/conformance/presence-protocol-conformance.json`
- 0 new files
- 14 conformance scenarios (was 13)
- JSON validated, GitNexus detect_changes: LOW risk, 0 code symbols affected

## Test plan

- [ ] Verify JSON parses without error
- [ ] Verify P1-003 now tests what its name claims (hestia_connect with protocol_version: 1 → protocolVersion == 1)
- [ ] Verify P1-004 checks status == "decided" and nextPollMs == null per §3.4.1 and v1 schema defaults
- [ ] Confirm no spec-prose, schema, or SDK changes (artifact-only edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)