### PR TITLE
docs(conformance): add shapeMatchesSchema to P1-003 connect step (corpus consistency)

### DIFF
--- a/web4-standard/testing/conformance/presence-protocol-conformance.json
+++ b/web4-standard/testing/conformance/presence-protocol-conformance.json
@@ -351,6 +351,7 @@
             "protocol_version": 1
           },
           "expect": {
+            "shapeMatchesSchema": "https://web4.io/schemas/presence-protocol/v0/tools/hestia_connect.schema.json#/$defs/output",
             "fieldChecks": [
               { "path": "protocolVersion", "equals": 1 },
               { "path": "sessionId", "matchesPattern": "^[0-9a-f-]{36}$" },


### PR DESCRIPTION
## Summary

Single-line corpus-consistency follow-up to PR #208 (merged `ac9de279`, C5-G4).

P1-003 (`v1 protocolVersion bumped on connect`) was the **only assertion step** in the presence-protocol conformance corpus whose `expect` block lacked a `shapeMatchesSchema` — despite the corpus's own top-level `description` stating the harness "verifies shapes against the JSON Schemas in schemas/presence-protocol/{v0,v1}/". This adds it, mirroring P0-001 verbatim.

- **Correct schema URI**: `https://web4.io/schemas/presence-protocol/v0/tools/hestia_connect.schema.json#/$defs/output`. The connect schema is shared at `v0/tools/` (there is no `v1/tools/hestia_connect.schema.json`); its `$defs/output` has `protocolVersion: {type: integer, minimum: 0}` so a `protocolVersion: 1` connect payload validates against it — exactly as P0-001 (a `protocol_version: 0` connect) already uses the same schema.
- **Refined invariant**: assertion steps (have an `expect` block) shape-validate; setup steps (state-prep, only `input`/`capture`, no `expect`) correctly do not. Post-fix: steps with an `expect` block but no `shapeMatchesSchema` = **0**. P1-003 was the sole violator across all 17 tool steps / 14 scenarios.
- **Contract-neutral** for assertion semantics: adds a shape check the connect response already satisfies. Scenario count (14) and `lastUpdated` (2026-05-18) unchanged.

This resolves the non-blocking gap flagged on PR #208 (issuecomment-4477974582), pre-sanctioned by the prior session's recorded next-session signal and previously part of that session's policy-approved scope.

## Provenance

v2 autonomous session protocol — propose → policy review (APPROVED, all 6 criteria) → execute → document. Session log: `private-context/autonomous-sessions/legion-web4-20260518-120044-session.md`.

## Test plan

- [x] JSON parse valid
- [x] Corpus invariant: every `expect`-bearing step carries `shapeMatchesSchema` (0 violations post-fix)
- [x] Scenario count unchanged (14); `lastUpdated` unchanged
- [ ] Reviewer: confirm v0 connect schema is the intended shared schema for v1 connect responses (consistent with P0-001 + the §-shared connect schema design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)