### PR TITLE
feat(sdk): v0.28.0 release housekeeping (Sprint 55 T1)

### DIFF
--- a/SESSION_FOCUS.md
+++ b/SESSION_FOCUS.md
@@ -2,7 +2,7 @@
 
 *Current sprint, SDK status, and active work. Updated by operator and autonomous sessions.*
 
-*Last updated: 2026-05-15 (Sprint 53)*
+*Last updated: 2026-05-19 (Sprint 55)*
 
 ---
 
@@ -10,213 +10,41 @@
 
 **See `docs/SPRINT.md` for full sprint plan and task details.** Do not duplicate sprint content here — SPRINT.md is the source of truth for task scope, status, and dependencies.
 
+### Sprint 55 Summary: SDK v0.28.0 Release Housekeeping (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T1: v0.28.0 release housekeeping | DONE | Version bump 0.27.0->0.28.0. CHANGELOG for PRs #195, #199, #210. Updated counters (369->376 exports, 2709->2749 tests, 8->5 xfails, 6->7 error categories). Updated README, quickstart, test assertions. 0 new files. |
+
+### Sprint 54 Summary: Spec Audit & Remediation Series (COMPLETE)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| C-series audits + remediation | DONE | Informal series (PRs #195-#211). C1: MCP-SDK alignment audit. C2: mcp-protocol.md internal consistency (13 findings) → PRs #200/#201/#203. C3: §7.7 promotion tracking → PR #202. C4: vector-freshness process → PR #197. C5: presence-protocol.md consistency (13 findings) → PRs #206/#207/#208/#209. SDK: cross-society types (PR #195), tests (PR #199), 3 xfails resolved (PR #210). CHANGELOG staleness resolved (PR #211). |
+
 ### Sprint 53 Summary: SDK v0.27.0 Release Housekeeping (COMPLETE)
 
 | Task | Status | Notes |
 |------|--------|-------|
 | T1: v0.27.0 release housekeeping | DONE | Version bump 0.26.0->0.27.0. CHANGELOG for Sprints 41-42, 50-52. Added missing `validate_minimum_viable` export + `role` module to CLI info/selftest (was 22, now 23 modules). Updated README, quickstart, test assertions. 0 new files. 369 exports. 2709 tests. |
 
-### Sprint 52 Summary: Conformance Test Vector Runner (COMPLETE)
+### Sprints 43-52: All COMPLETE
 
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Wire conformance vectors into pytest | DONE | Exercises 35 operator-created conformance vectors from `testing/conformance/` against Python SDK. 4 suites: tensor ops, ATP, R6/R7, society/roles. 39 tests (31 passed, 8 xfailed conformance gaps). 2709 total tests. 1 new file. Addresses Kimi K2 gap. |
+See `docs/SPRINT.md` for details. Highlights: Spec-to-explainer alignment (43), MEDIUM spec gaps (44), archive stale artifacts (45), CI canonicity (46), cross-language T3/V3 audit (47), parameter governance (48), cross-language Society/Role/ATP/R6 audit (49), SocietyRole + RoleAssignment (50), validate_minimum_viable + Constraint alignment (51), conformance test runner (52).
 
-### Sprint 51 Summary: Minimum Viable Society Validation + Constraint Alignment (COMPLETE)
+### Sprints 4-42: All COMPLETE
 
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: validate_minimum_viable() + Constraint alignment | DONE | Resolves Sprint 49 audit P5+P6. `validate_minimum_viable()` in `web4/role.py`: base-mandatory completeness, differentiation, witnessing. `Constraint` aligned with Rust: `threshold: float` + `hard: bool`. 1 new export (369 total), 12 new tests (2668 total), 0 new files. |
-
-### Sprint 50 Summary: Add SocietyRole + RoleAssignment to Python SDK (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: SocietyRole + RoleAssignment + bootstrap_society_roles | DONE | Implements Sprint 49 audit P1+P2+P3. New `web4/role.py` module: `SocietyRole` enum (7 base-mandatory + 2 context-mandatory), `RoleAssignment` dataclass (role-LCT binding, T3/V3, rotation, multi-holder, to_dict/from_dict), `bootstrap_society_roles()` (solo-founder genesis). 4 new exports (368 total), 43 new tests (2656 total), 1 new module. Cross-language parity with `web4-core/src/role.rs`. |
-
-### Sprint 49 Summary: Cross-Language Society/Role/ATP/R6 Alignment Audit (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Cross-language alignment audit for Society/Role/ATP/R6 | DONE | 14 items: 1 CRITICAL (Python SDK missing SocietyRole), 3 HIGH, 3 MEDIUM, 4 LOW. Prioritized fix queue P1-P7. P1-P3 resolved by Sprint 50. P4 needs operator decision (MetabolicState). P5 now unblocked. |
-
-### Sprint 48 Summary: Parameter Governance Index (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Parameter governance index in t3-v3-tensors.md | DONE | Resolves Unanswered Question #3 from Sprint 43 audit (unblocked by Sprint 46 T1). Added §10 to `t3-v3-tensors.md`: classifies all trust/value/energy parameters into three governance tiers — protocol-invariant (11 items, enforced by test vectors), society-configurable (8 items), simulation-only (5 items). Cross-references `atp-adp-cycle.md` and `multi-device-lct-binding.md`. 0 new files, 1 spec file modified. |
-
-### Sprint 47 Summary: Cross-Language T3/V3 Alignment Audit (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Cross-language T3/V3 semantic alignment audit | DONE | Triggered by operator WASM rebuild (`55b1a3d8`). Documented 8 divergences between Rust/WASM and spec/Python SDK: 1 CRITICAL (Talent decay violates normative invariant), 4 HIGH (composites, update formula, decay model), 2 MEDIUM (ActionOutcome, legacy bridge), 1 LOW (missing operations). Audit at `docs/audits/cross-language-t3v3-alignment-2026-05-13.md`. 1 new file. |
-
-### Sprint 46 Summary: Clarify CI Canonicity (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Normative clarification of constellation_coherence vs "CI" | DONE | Resolves audit item #10 from Sprint 43. Added §4.4 to `multi-device-lct-binding.md`: `constellation_coherence` is canonical metric (T3 tensor extension); "CI" and numeric multipliers (e.g., 1.4×) are simulation parameters, not protocol primitives. 0 new files, 1 spec file modified. |
-
-### Sprint 45 Summary: Archive Stale Implementation Artifacts (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Archive 3 stale non-code files from implementation/ | DONE | Completes cleanup chain from PRs #174-178. Archived `implementation_guide.md` (drift-era crypto guide), `handshake_exchange.json` (non-canonical protocol), `metering_flow.json` (non-canonical terminology) to `archive/implementation-sprawl/`. `implementation/` now contains only `sdk/` and `reference/` (3 REVIEW .py files pending operator). 0 new files, 3 files moved. |
-
-### Sprint 44 Summary: Resolve MEDIUM-Priority Spec Gaps (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: ATP transfer-fee semantics + T3 Talent-decay clarification | DONE | Resolves SPEC GAP #2 and #5 from Sprint 43 audit. Added §6.3 Transfer Fees to `atp-adp-cycle.md` (society-configurable, not protocol-prescribed). Strengthened Talent no-decay language in `t3-v3-tensors.md` (normative invariant, not tunable). 0 new files, 2 spec files modified. |
-
-### Sprint 43 Summary: Spec-to-Explainer Alignment Memo (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Spec-to-explainer alignment memo | DONE | Categorized 14 friction items from 4-life visitor log: 4 SPEC GAP, 8 EXPLAINER GAP, 2 BOTH. Produced `docs/audits/spec-vs-explainer-alignment-2026-04-19.md`. |
-
-### Sprint 42 Summary: CI Quickstart Smoke (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Wire `examples/quickstart.py` into CI wheel smoke job | DONE | Added one step to the `wheel` job in `.github/workflows/sdk-test.yml`, running `examples/quickstart.py` against the installed wheel's isolated venv. Closes Sprint 36 T1 follow-up. 0 new files, no product code changes, no version bump. Originally proposed as Sprint 40 (PR #164); renumbered to Sprint 42 to reflect merge order — Sprint 41 landed on main first. |
-
-### Sprint 41 Summary: Remove Dead web4_sdk.py + Fix v0.26.0 Documentation Gaps (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Remove dead `web4_sdk.py` + fix docs | DONE | Deleted `web4_sdk.py` (dead async HTTP client for nonexistent services, not in wheel) + `test_sdk_integration.py` (14 tests). README: version 0.25.0→0.26.0, removed misleading "Client SDK" section. Quickstart docstring: v0.25.0→v0.26.0. 2613 tests, 0 new files, 2 deleted. |
-
-### Sprint 39 Summary: SDK v0.26.0 Release Housekeeping (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: v0.26.0 release housekeeping | DONE | Version bump, CHANGELOG for Sprints 35/37/38 (CI hardening, ruff lint, ruff format), test assertion updates, 2627 tests, 0 new files |
-
-### Sprint 38 Summary: Ruff Format Codebase-Wide + CI Enforcement (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `ruff format` codebase-wide + CI `ruff format --check` | DONE | 70 files reformatted (web4/ + tests/test_*.py), new CI format-check step matches existing lint scope, 0 new files, 0 manual source edits, 2627 tests pass, mypy strict clean |
-
-### Sprint 37 Summary: Ruff Lint Cleanup + CI Enforcement (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `ruff check` lint cleanup + CI enforcement | DONE | 239 issues fixed (source: 10, tests: 229), CI now lints both web4/ and tests/, per-file-ignore for E402 in tests, 0 new files |
-
-### Sprint 36 Summary: Quickstart Example Refresh (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Replace stale `examples/` with v0.25.0 quickstart | DONE | Deleted 2 obsolete examples (imported nonexistent `web4_sdk.Web4Client`); added `examples/quickstart.py` + `examples/README.md`. Offline, lint-clean, mypy --strict clean. |
-
-### Sprint 35 Summary: CI Workflow Hardening (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: CI workflow hardening | DONE | mypy --strict in CI (was --ignore-missing-imports), new wheel build+selftest job, 0 new files |
-
-### Sprint 34 Summary: SDK v0.25.0 Release Housekeeping (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: v0.25.0 release housekeeping | DONE | Version bump, CHANGELOG for PRs #147/#151/#153, README/docstring updates, 2627 tests, 7 CLI subcommands |
-
-### Sprint 33 Summary: SDK v0.24.0 Release Housekeeping (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: v0.24.0 release housekeeping | DONE | Version bump, CHANGELOG for Sprint 32, README/docstring updates, 2614 tests |
-
-### Sprint 32 Summary: Deployment Verification CLI (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `web4 selftest` command | DONE | Automates deployment verification: module imports, schema registry, 23-type roundtrip. 4 new tests, 2614 total |
-
-### Sprint 31 Summary: SDK v0.23.0 Release Housekeeping (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: v0.23.0 release housekeeping | DONE | Version bump, CHANGELOG for Sprints 29+30, README/docstring updates, 2610 tests |
-
-### Sprint 30 Summary: Distribution Verification + Roundtrip Fidelity (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Wheel verification + roundtrip fixes | DONE | 4 bugs fixed (LCT @type, LCT schema, DictionaryEntity lct_id, license format), 2610 total tests |
-
-### Sprint 29 Summary: CLI Test Coverage Hardening (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Refactor CLI tests to in-process | DONE | `__main__.py` coverage 15.8% → 90.6%, 40 tests in test_cli.py, 2608 total tests |
-
-### Sprint 28 Summary: MCP process_action Tool + v0.22.0 (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `web4_process_action` MCP tool | DONE | 8th MCP tool, wraps `process_action_outcome()`, 15 new tests |
-| T2: SDK v0.22.0 release housekeeping | DONE | Version bump, CHANGELOG, README, docstring updates |
-
-### Sprint 24 Summary: Action Consequence Pipeline (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `process_action_outcome()` function + `ActionOutcomeResult` dataclass | DONE | R7Action → ReputationEngine → TrustProfile → ATPAccount composition, 2 new exports (364 total), 18 new tests. PR #143 |
-
-### Sprint 27 Summary: MCP Behavioral Tools (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: Expose behavioral functions as MCP tools | DONE | `web4_evaluate_trust` + `web4_resolve_trust`, 7 MCP tools total, 20 new tests |
-
-### Sprint 26 Summary: Release Housekeeping v0.21.0 (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: SDK v0.21.0 release housekeeping | DONE | Version bump, CHANGELOG, README, docstring updates for Sprint 25. |
-
-### Sprint 25 Summary: Indirect Trust Resolution (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `resolve_trust()` function + `TrustResolution` dataclass | DONE | MRH graph + T3 tensor composition: indirect trust through intermediaries, 2 new exports (362 total), 22 new tests |
-
-### Sprint 23 Summary: Release Housekeeping v0.20.0 (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: SDK v0.20.0 release housekeeping | DONE | Version bump, CHANGELOG, README, docstring updates for Sprint 22. PR #136 |
-
-### Sprint 22 Summary: Trust Query Evaluation Pipeline + MCP Server (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: `evaluate_trust_query()` function | DONE | Core trust resolution pipeline, 1 new export (360 total), 23 new tests |
-| T1b: Web4 MCP Server module | DONE | 5 MCP tools, FastMCP stdio transport, `web4-mcp` entry point, 43 new tests |
-
-### Sprint 21 Summary: Release Housekeeping v0.19.0 (COMPLETE)
-
-| Task | Status | Notes |
-|------|--------|-------|
-| T1: SDK v0.19.0 release housekeeping | DONE | Version bump, CHANGELOG, README, docstring updates for Sprints 18-20 |
-
-### Sprints 4-20: All COMPLETE
-
-See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all 10 types (Sprints 4-6), API completeness (Sprint 7), developer experience (Sprint 8), documentation (Sprint 9), CI/CD (Sprint 10), quality gates (Sprint 11), schema validation (Sprint 12), CLI + distribution (Sprint 13), optional extras (Sprint 14), from_dict completeness (Sprint 15), mypy strict + deserializer (Sprint 16), release housekeeping (Sprint 17), CLI roundtrip + lifecycle tests (Sprint 18), TrustQuery types (Sprint 19), generate module (Sprint 20).
+See `docs/SPRINT.md` for full history.
 
 ---
 
 ## SDK Status
 
-- **Version**: 0.27.0
+- **Version**: 0.28.0
 - **Modules**: 23 library modules + MCP server entry point (trust, lct, atp, federation, r6, mrh, acp, dictionary, entity, capability, errors, metabolic, binding, society, role, reputation, security, protocol, mcp, attestation, validation, deserialize, generate, mcp_server)
-- **Tests**: 2709 total (2701 passing, 8 xfailed conformance gaps)
+- **Tests**: 2749 total (2744 passing, 5 xfailed conformance gaps)
 - **CLI**: `web4 info/validate/list-schemas/roundtrip/generate/selftest/trust` (7 subcommands)
-- **Exports**: 369 symbols via `web4/__init__.py`
+- **Exports**: 376 symbols via `web4/__init__.py`
 - **from_dict()**: 58 classmethods across 10 modules — all classes with to_dict()/as_dict() have matching from_dict()
 - **Dispatcher**: 23 types via `web4.from_jsonld()` (19 class-based + 3 function-based + TrustQuery)
 - **Generator**: 23 types via `web4.generate()` — minimal valid JSON-LD documents
@@ -224,7 +52,8 @@ See `docs/SPRINT.md` for full history. Highlights: JSON-LD serialization for all
 - **MCP Server**: `web4-mcp` / `python -m web4.mcp_server` — 8 tools (info, validate, generate, roundtrip, list_types, evaluate_trust, resolve_trust, process_action)
 - **CLI entry points**: console script `web4` + `python -m web4`
 - **Optional extras**: `web4[validation]` (jsonschema), `web4[mcp]` (mcp), `web4[dev]` (full toolchain)
-- **License**: AGPL-3.0-or-later throughout (a brief MIT relicense was attempted Feb 2026 for ARIA grant compatibility; reverted 2026-04-27 — AGPL-bounded patent grant in PATENTS.md was incompatible with MIT)
+- **Error taxonomy**: 7 categories (Binding, Pairing, Witness, Authorization, Crypto, Protocol, Cross-Society), 30 error codes
+- **License**: AGPL-3.0-or-later throughout
 
 ---
 
@@ -250,47 +79,68 @@ Namespace decision documented in `docs/history/design_decisions/JSONLD-NAMESPACE
 
 ---
 
-## ARIA-era Work (historical context, 2026-02 → 2026-04)
+## Conformance Status
 
-Work undertaken in early 2026 toward what was at the time a planned ARIA grant submission. The grant was ultimately not submitted; the technical work landed and is canonical:
-- **Witnessed tier work**: LCT JSON-LD with attestation chain, cross-language validation vectors — landed
-- **Hardware binding**: AttestationEnvelope integrated into SDK with TPM2/FIDO2/SE anchor types — landed
-- **Cross-language interoperability**: JSON Schemas enable Go/TypeScript/Rust validators — landed
-- **License**: SDK was briefly relicensed AGPL→MIT for ARIA compatibility, reverted to AGPL-3.0-or-later 2026-04-27 after ARIA decision was no-submit (the AGPL-bounded patent grant in PATENTS.md created a license trap with MIT)
+- **35 conformance vectors** across 4 suites (tensor ops, ATP, R6/R7, society/roles)
+- **34 passing, 5 xfailed** (was 31/8 at Sprint 52; PR #210 resolved 3)
+- **5 remaining xfails** — all require operator/architect decisions:
+  1. `t3-004`: T3 update direction (quality-only vs success flag) — Tier B
+  2. `r6-val-004`: Constraint enforcement in validate() vs PolicyGate — Tier B
+  3. `role-004`: Assigner authorization predicate (data vs governance layer) — Tier B
+  4. `fed-001`: Federation join/secede (child-initiated vs parent-initiated) — Tier B
+  5. `sub-001`: T3 sub-dimension rollup (runtime vs ontology-metadata) — Tier C
+- See `docs/audits/sprint-52-conformance-gap-consolidation-2026-05-15.md` for full analysis
+
+---
+
+## Open Audit Items (Operator-Blocked)
+
+| Item | Source | Decision Needed |
+|------|--------|-----------------|
+| P4: MetabolicState reconciliation | Sprint 49 audit | 5-state (Rust/spec) vs 7-state (Python) |
+| P7: Role integration architecture | Sprint 49 audit | Where do roles live in SocietyState? |
+| B1-B5: Conformance xfails | Sprint 52 consolidation | See conformance status above |
 
 ---
 
 ## Recent Commits
 
 ```
-8857ab0 Add ATP/ADP and R6/R7 action framework to web4-core SDK
-8243895 Add Society and Role types to web4-core SDK
-0b73b92 forum: Kimi 2.6 cross-model review of web4 (verbatim, 3 rounds)
-193607f README + STATUS: surface architectural shape upfront; honest qualifiers
-05911c3 spec: society-roles.md + entity-types.md cross-reference — three-tier role taxonomy
+40e6228f docs(changelog): resolve stale "Upcoming (planned)" v1 section in presence-protocol CHANGELOG (#211)
+b5c9e87b docs(conformance): add shapeMatchesSchema to P1-003 connect step (corpus consistency) (#209)
+3f124627 fix(conformance): reconcile 3 vectors with normative spec — resolve 3 of 8 xfails (#210)
+ac9de279 docs(conformance): resolve C5 audit G4 — fix P1-003 + add P1-004 (P12/P13) (#208)
+9ace6d76 docs(whitepaper): no-change check 2026-05-18 — audit-driven spec discipline; §7.7 promotion gate formalized
 ```
 
 ---
 
 ## Open PRs
 
-Sprint 50 T1 PR pending.
+None. All PRs through #211 merged.
 
 ### Closed PRs (recent)
 
-- PR #184 MERGED — Sprint 49 T1: Cross-language Society/Role/ATP/R6 alignment audit
-- PR #183 MERGED — Sprint 48 T1: Parameter governance index
-- PR #182 MERGED — Sprint 47 T1: Cross-language T3/V3 alignment audit
-- PR #181 MERGED — Sprint 46 T1: Clarify CI canonicity (audit item #10)
-- PR #180 MERGED — Sprint 45 T1: Archive stale implementation artifacts
-- PR #179 MERGED — Sprint 44 T1: Resolve MEDIUM-priority spec gaps from Sprint 43 audit
-- PR #178 MERGED — Strategic review follow-up audit + archive 3 stray implementation/ markdowns
+- PR #211 MERGED — CHANGELOG post-v1 staleness resolved
+- PR #210 MERGED — Reconcile 3 conformance vectors with normative spec
+- PR #209 MERGED — shapeMatchesSchema corpus consistency
+- PR #208 MERGED — C5 audit G4: fix P1-003 + add P1-004
+- PR #207 MERGED — C5 audit G2: discipline honesty
+- PR #206 MERGED — C5 audit G1+G3: casing authority + localized staleness
+- PR #204 MERGED — C5: presence-protocol.md internal consistency audit
+- PR #203 MERGED — C2 audit: resolve LOW F14/F16
+- PR #202 MERGED — C3: §7.7 promotion tracking stub
+- PR #201 MERGED — C2 audit: resolve MEDIUM F1/F5/F15
+- PR #200 MERGED — C2 audit: resolve HIGH §7.4↔§7.7 F2/F3/F4/F12
+- PR #199 MERGED — Cross-society type tests + wiring
+- PR #197 MERGED — C4: vector-freshness check process
+- PR #195 MERGED — Cross-society MCP types
 
 ---
 
 ## Completeness Summary
 
-- All 53 sprints COMPLETE (Sprints 1-53, all merged or PR pending)
+- All 55 sprints COMPLETE (Sprints 1-55, all merged)
 - All 9 JSON-LD schemas with cross-language validation vectors (278 total, in pytest)
 - All `to_jsonld()` functions have `from_jsonld()` inverses (API symmetry complete)
 - All `to_dict()`/`as_dict()` methods have `from_dict()` inverses (58 round-trip methods total)
@@ -298,32 +148,23 @@ Sprint 50 T1 PR pending.
 - `web4.generate(type_name)` produces minimal valid JSON-LD for any of 23 types
 - `evaluate_trust_query()` — direct trust resolution composing TrustQuery + TrustProfile + ATPAccount
 - `resolve_trust()` — indirect trust resolution composing MRHGraph + TrustProfile T3 tensors
-- MCP server: 8 tools exposing SDK data operations + behavioral trust/reputation resolution to MCP clients
-- TrustQuery: to_jsonld() for dispatcher + to_dict() for schema validation (trust-query.schema.json)
 - `process_action_outcome()` — action consequence pipeline composing R7Action + ReputationEngine + TrustProfile + ATPAccount
-- All 23 submodules have `__all__` declarations, 369 root exports
+- MCP server: 8 tools exposing SDK data operations + behavioral trust/reputation resolution to MCP clients
+- Cross-society types: `CrossSocietyContext`, `ReputationEnvelope`, `MCPContextResource` (§7.3–7.6)
+- All 23 submodules have `__all__` declarations, 376 root exports
 - All public methods have docstrings and return type annotations
 - `mypy --strict` passes with 0 errors across 26 source files
 - Test coverage: 97.8% overall (4 modules at 100%, 16 at 95%+, __main__.py at 90.6%)
-- Schema validation via `web4.validation.validate()` with `pip install web4-sdk[validation]` (PyPI distribution renamed from `web4` to `web4-sdk` in May 2026; `import web4` unchanged)
+- Schema validation via `web4.validation.validate()` with `pip install web4-sdk[validation]`
 - CLI via `web4 info/validate/list-schemas/roundtrip/generate/selftest/trust` (7 subcommands)
 - Wheel distribution verified: imports, CLI, schema validation, roundtrip all pass from installed wheel
 - All 23 generate() types pass roundtrip fidelity (generate → from_jsonld → to_jsonld = identical)
 - `ruff check web4/ tests/` passes with 0 errors — CI enforces lint on source + tests
-- `ruff format --check web4/ tests/test_*.py` passes with 0 changes — CI enforces formatting on source + tests
-- Dead `web4_sdk.py` removed — async HTTP client for nonexistent services, not distributed in wheel
-- `examples/quickstart.py` runs in the CI `wheel` job against the installed wheel — API breakage in the quickstart fails CI on every PR
+- `ruff format --check web4/ tests/test_*.py` passes with 0 changes — CI enforces formatting
+- `examples/quickstart.py` runs in the CI `wheel` job against the installed wheel
+- Conformance: 34/39 vectors pass, 5 xfailed (operator-blocked architectural decisions)
+- Spec audits: mcp-protocol.md (C2) and presence-protocol.md (C5) audited for internal consistency; findings resolved via PRs #200-#211
 
 ---
 
-- **Society Roles added**: `SocietyRole` enum + `RoleAssignment` dataclass + `bootstrap_society_roles()` — resolves CRITICAL audit finding (P1), HIGH role-LCT binding (P2), and HIGH solo-founder genesis (P3)
-- **Minimum viable society validation**: `validate_minimum_viable()` added to Python SDK — resolves audit P5 (cross-language parity with Rust `Society::validate_minimum_viable()`)
-- **Constraint alignment**: `Constraint` dataclass upgraded from `value: Any` to `threshold: float` + `hard: bool` — resolves audit P6 (cross-language parity with Rust `Constraint`)
-- **web4-core Society/Role/ATP/R6 alignment**: Cross-language audit identified 14 items (1 CRITICAL: Python SDK missing SocietyRole, 3 HIGH, 3 MEDIUM, 4 LOW) — see `docs/audits/cross-language-society-role-atp-r6-alignment-2026-05-14.md`. P1-P3 resolved by Sprint 50. P5-P6 resolved by Sprint 51. P4 (MetabolicState) and P7 (role integration) need operator decisions.
-- **web4-trust-core T3/V3 alignment**: Cross-language T3/V3 audit identified 8 divergences (1 CRITICAL, 4 HIGH) between Rust/WASM and spec/Python SDK — see `docs/audits/cross-language-t3v3-alignment-2026-05-13.md`
-- **Parameter governance**: All trust/value/energy parameters classified into three tiers (protocol-invariant, society-configurable, simulation-only) — see `web4-standard/core-spec/t3-v3-tensors.md` §10
-- **Conformance test runner**: 35 operator-created conformance vectors wired into pytest — exercises T3/V3, ATP, R6/R7, and Society/Role operations against the Python SDK. 8 conformance gaps documented as xfail (weighted vs unweighted T3 aggregate, success flag direction, talent decay invariant, V3 valuation scope, constraint checking, role authorization, federation API shape, sub-dimension rollup)
-
----
-
-*Updated by autonomous session, 2026-05-15 (Sprint 53 — SDK v0.27.0 release housekeeping)*
+*Updated by autonomous session, 2026-05-19 (Sprint 55 — SDK v0.28.0 release housekeeping)*

--- a/docs/SPRINT.md
+++ b/docs/SPRINT.md
@@ -1,9 +1,60 @@
 # Web4 Sprint Plan
 
 **Created**: 2026-03-14
-**Updated**: 2026-05-15 (Sprint 53)
+**Updated**: 2026-05-19 (Sprint 55)
 **Phase**: Development
 **Track**: web4 (Legion)
+
+---
+
+## Sprint 55: SDK v0.28.0 Release Housekeeping (2026-05-19)
+
+Version bump and documentation update consolidating post-Sprint-53 work:
+cross-society MCP types (PR #195/#199), conformance xfail resolution (PR #210),
+and the informal C-series audit/remediation thread (PRs #197, #200-#211).
+
+### T1: v0.28.0 release housekeeping
+**Status**: DONE
+**Completed**: 2026-05-19
+**Authorized by**: Established release housekeeping pattern (Sprints 21, 23,
+26, 31, 33, 34, 39, 53). Policy-reviewed and approved.
+**Scope**:
+1. Version bump 0.27.0 -> 0.28.0 in `pyproject.toml`.
+2. CHANGELOG entry for v0.28.0 covering PRs #195, #199, #210.
+3. `__init__.py` docstring: corrected stale counters (exports 369->376,
+   tests 2709->2749), updated version note.
+4. README: version, export count (369->376), test count (2709->2749),
+   error categories (6->7 with Cross-Society), project structure counts.
+5. `examples/quickstart.py`: docstring version.
+6. Test assertions: version strings in `test_cli.py` and `test_package_api.py`.
+7. `docs/SPRINT.md` and `SESSION_FOCUS.md` updated.
+
+**Result**: 0 new files. All version references consistent. 376 exports,
+2749 tests (2744 passed, 5 xfailed conformance gaps).
+
+---
+
+## Sprint 54: Spec Audit & Remediation Series (2026-05-15 – 2026-05-18)
+
+Informal C-series: internal-consistency audits of `mcp-protocol.md` (C1/C2)
+and `presence-protocol.md` (C5), §7.7 promotion tracking (C3), vector-freshness
+process (C4), and remediation PRs resolving audit findings. Also includes
+cross-society SDK types and conformance xfail resolution.
+
+**Note**: This sprint was not formally defined in advance. Work was proposed
+and policy-reviewed per session under v2 protocol. Recorded here retroactively
+as the formal Sprint 54 entry for continuity.
+
+### Work completed (PRs #195–#211)
+**Status**: DONE
+**Key deliverables**:
+- **C1**: MCP Protocol ↔ SDK alignment audit (`docs/audits/mcp-protocol-sdk-alignment-2026-05-15.md`)
+- **C2**: mcp-protocol.md internal-consistency audit (13 findings: 4 HIGH, 5 MEDIUM, 4 LOW) → PRs #200, #201, #203
+- **C3**: §7.7 promotion tracking stub (`docs/audits/s7.7-promotion-tracking-2026-05-16.md`) → PR #202
+- **C4**: Vector-freshness check process → PR #197
+- **C5**: presence-protocol.md internal-consistency audit (2 HIGH, 6 MEDIUM, 5 LOW) → PRs #206, #207, #208, #209
+- **SDK**: Cross-society types (PR #195), test coverage (PR #199), 3 conformance xfails resolved (PR #210)
+- **Docs**: CHANGELOG staleness resolved (PR #211), whitepaper no-change checks
 
 ---
 

--- a/web4-standard/implementation/sdk/CHANGELOG.md
+++ b/web4-standard/implementation/sdk/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the Web4 Python SDK.
 
+## [0.28.0] - 2026-05-19
+
+Cross-society MCP types, conformance xfail resolution, error taxonomy expansion.
+
+### Added
+- **Cross-society MCP types** (PR #195) — implements §7.3–7.6 from `mcp-protocol.md`:
+  `CrossSocietyContext` envelope for cross-society MCP calls (§7.4),
+  `ReputationEnvelope` for signed R7 action outcomes (§7.3),
+  `MCPContextResource` for context resource definitions (§6.3),
+  `OutcomeClass`, `PropagationScope`, `CrossSocietyInteractionType` enums.
+  7 new exports (369→376).
+- **`CrossSocietyError` class** (PR #199) — 7th error category subclass with 6
+  `ErrorMeta` registry entries for §7.6 cross-society error codes (24→30 total codes,
+  6→7 categories).
+- **Cross-society test coverage** (PR #199) — 37 new tests covering enum values,
+  construction, defaults, `to_dict`/`from_dict` round-trips, frozen checks, and
+  package-level import verification.
+
+### Changed
+- **3 conformance xfails resolved** (PR #210) — reconciled test vectors `t3-002`
+  (weighted aggregate), `t3-006` (talent decay invariant), and `r7-rep-001` (V3
+  valuation scope) with normative spec. Conformance: 34 passed / 5 xfailed
+  (was 31/8).
+
+### Summary
+376 exports, 2749 tests (2744 passed, 5 xfailed conformance gaps), 23 modules,
+mypy --strict clean, ruff clean.
+
 ## [0.27.0] - 2026-05-15 (renamed to `web4-sdk` for PyPI release)
 
 ### Packaging

--- a/web4-standard/implementation/sdk/README.md
+++ b/web4-standard/implementation/sdk/README.md
@@ -8,7 +8,7 @@ specified in the [web4-standard](https://github.com/dp-web4/web4) and works with
 network services — no async, no HTTP, no external dependencies beyond the Python
 standard library.
 
-**Version**: 0.27.0 | **Python**: 3.10+ | **License**: AGPL-3.0-or-later | **Typed**: PEP 561
+**Version**: 0.28.0 | **Python**: 3.10+ | **License**: AGPL-3.0-or-later | **Typed**: PEP 561
 
 > **Install name vs import name.** The distribution is published on PyPI as
 > **`web4-sdk`** (the unsuffixed `web4` PyPI name is held by an unrelated
@@ -98,7 +98,7 @@ The SDK contains 23 modules, all importable from the `web4` namespace:
 | `deserialize` | Generic JSON-LD deserialization dispatcher | `from_jsonld`, `from_jsonld_string`, `supported_types` |
 | `generate` | Produce minimal valid JSON-LD documents | `generate`, `generate_string`, `available_types` |
 
-369 symbols are exported from `web4.__init__`. All 23 submodules have `__all__` declarations.
+376 symbols are exported from `web4.__init__`. All 23 submodules have `__all__` declarations.
 
 ## MCP Server
 
@@ -186,7 +186,7 @@ except Web4Error as e:
     # {"type": "about:blank", "title": "...", "status": 403, "detail": "Binding was revoked"}
 ```
 
-Six error categories: Binding, Pairing, Witness, Authorization, Crypto, Protocol.
+Seven error categories: Binding, Pairing, Witness, Authorization, Crypto, Protocol, Cross-Society.
 
 ## Testing
 
@@ -201,13 +201,13 @@ python -m pytest tests/ --cov=web4
 mypy --strict web4/
 ```
 
-2709 tests, 97.8% coverage, mypy strict zero-error, CI across Python 3.10-3.13.
+2749 tests, 97.8% coverage, mypy strict zero-error, CI across Python 3.10-3.13.
 
 ## Project Structure
 
 ```
 web4/                  # Python package (23 modules + MCP server)
-  __init__.py          # 369 re-exports
+  __init__.py          # 376 re-exports
   __main__.py          # CLI entry point (web4 info/validate/list-schemas/roundtrip/generate/selftest/trust)
   mcp_server.py        # MCP server entry point (web4-mcp)
   py.typed             # PEP 561 marker
@@ -217,7 +217,7 @@ web4/                  # Python package (23 modules + MCP server)
   generate.py          # Minimal valid JSON-LD document generation
   validation.py        # Schema validation
   ...                  # (18 more modules)
-tests/                 # 2709 tests
+tests/                 # 2749 tests
 schemas/               # JSON Schemas + JSON-LD contexts
 pyproject.toml         # Package metadata (single version source)
 ```

--- a/web4-standard/implementation/sdk/examples/quickstart.py
+++ b/web4-standard/implementation/sdk/examples/quickstart.py
@@ -1,4 +1,4 @@
-"""Quickstart for the web4 Python SDK v0.27.0.
+"""Quickstart for the web4 Python SDK v0.28.0.
 
 Demonstrates the three behavioral composition points of the current SDK:
 

--- a/web4-standard/implementation/sdk/pyproject.toml
+++ b/web4-standard/implementation/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "web4-sdk"
-version = "0.27.0"
+version = "0.28.0"
 description = "Web4 SDK — trust tensors, LCTs, ATP/ADP, federation (SAL), R7 actions, MRH, ACP, security, protocol types"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/web4-standard/implementation/sdk/tests/test_cli.py
+++ b/web4-standard/implementation/sdk/tests/test_cli.py
@@ -46,7 +46,7 @@ class TestInfo:
         out = capsys.readouterr().out
         assert rc == 0
         assert "web4" in out
-        assert "0.27.0" in out
+        assert "0.28.0" in out
 
     def test_info_shows_module_count(self, capsys: pytest.CaptureFixture[str]) -> None:
         rc = main(["info"])
@@ -617,7 +617,7 @@ class TestSmoke:
     def test_info(self) -> None:
         r = _run_cli(["info"])
         assert r.returncode == 0
-        assert "0.27.0" in r.stdout
+        assert "0.28.0" in r.stdout
 
     def test_validate_valid_doc(self) -> None:
         from web4.trust import T3

--- a/web4-standard/implementation/sdk/tests/test_package_api.py
+++ b/web4-standard/implementation/sdk/tests/test_package_api.py
@@ -10,12 +10,12 @@ import web4
 
 class TestPackageVersion:
     def test_version_string(self):
-        assert web4.__version__ == "0.27.0"
+        assert web4.__version__ == "0.28.0"
 
     def test_version_accessible(self):
         from web4 import __version__
 
-        assert __version__ == "0.27.0"
+        assert __version__ == "0.28.0"
 
 
 class TestAllExports:

--- a/web4-standard/implementation/sdk/web4/__init__.py
+++ b/web4-standard/implementation/sdk/web4/__init__.py
@@ -27,8 +27,8 @@ Provides offline-capable primitives for:
 - Deserialization — generic JSON-LD dispatcher for all Web4 types
 - Generation — produce minimal valid JSON-LD documents for any Web4 type
 
-23 modules + MCP server, 369 exports, 2709 tests, 3 behavioral functions, 8 MCP tools, 7 CLI subcommands.
-v0.27.0: Society roles, Constraint alignment, conformance test runner, validate_minimum_viable.
+23 modules + MCP server, 376 exports, 2749 tests, 3 behavioral functions, 8 MCP tools, 7 CLI subcommands.
+v0.28.0: Cross-society MCP types, conformance xfail resolution, error taxonomy expansion.
 These modules define the canonical data types and algorithms specified in the web4-standard.
 They work offline (no network services required) and are designed to be
 imported by applications, services, and other SDKs that build on web4.
@@ -50,7 +50,7 @@ For module-specific imports (recommended for large applications)::
 try:
     from importlib.metadata import version as _pkg_version
 
-    __version__ = _pkg_version("web4")
+    __version__ = _pkg_version("web4-sdk")
 except Exception:
     __version__ = "0.0.0"  # fallback when not installed
 


### PR DESCRIPTION
## Summary

- Version bump 0.27.0 → 0.28.0 consolidating post-Sprint-53 work
- CHANGELOG entry for cross-society MCP types (PR #195/#199), conformance xfail resolution (PR #210)
- All documentation counters reconciled: 369→376 exports, 2709→2749 tests, 8→5 xfails, 6→7 error categories
- Bug fix: `_pkg_version("web4")` → `_pkg_version("web4-sdk")` — stale egg-info from pre-rename was returning old version
- Sprint 54 (retroactive C-series entry) + Sprint 55 added to SPRINT.md
- SESSION_FOCUS.md fully refreshed (was stale since Sprint 53)

## Quality gates

- 2749 passed, 5 xfailed (conformance gaps, pre-existing, operator-blocked)
- `mypy --strict`: 0 errors across 26 source files
- `ruff check`: 0 errors
- CLI info: `web4 0.28.0 / Modules: 23 / Exports: 376 / Schemas: 12`
- CLI selftest: `OK: 23 modules, 12 schemas, 23 types roundtripped`
- GitNexus detect_changes: risk level LOW, 0 affected processes

## Files modified (9, 0 new)

- `pyproject.toml` — version bump
- `CHANGELOG.md` — v0.28.0 entry
- `web4/__init__.py` — counters + pkg_version fix
- `README.md` — version, counts, error categories
- `examples/quickstart.py` — docstring version
- `tests/test_cli.py` — version assertions
- `tests/test_package_api.py` — version assertions
- `docs/SPRINT.md` — Sprint 54 + 55 entries
- `SESSION_FOCUS.md` — full refresh

## Test plan

- [x] `python -m pytest tests/ -q` — 2749 passed, 5 xfailed
- [x] `mypy --strict web4/` — clean
- [x] `ruff check web4/ tests/` — clean
- [x] `python -m web4 info` — reports 0.28.0
- [x] `python -m web4 selftest` — OK
- [x] `python examples/quickstart.py` — runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)