### PR TITLE
style(sdk): fix ruff format drift on 2 files

### DIFF
--- a/web4-standard/implementation/sdk/tests/test_conformance.py
+++ b/web4-standard/implementation/sdk/tests/test_conformance.py
@@ -108,8 +108,7 @@ class TestTensorConformance:
         t3 = T3(talent=inp["talent"], training=inp["training"], temperament=inp["temperament"])
         expected_aggregate = vec["expected"]["aggregate"]
         assert abs(t3.composite - expected_aggregate) < 1e-10, (
-            f"T3 weighted composite: SDK={t3.composite:.6f} vs "
-            f"vector={expected_aggregate:.6f}"
+            f"T3 weighted composite: SDK={t3.composite:.6f} vs vector={expected_aggregate:.6f}"
         )
 
     # ── t3-003: Positive outcome update ────────────────────────
@@ -201,8 +200,7 @@ class TestTensorConformance:
         # Talent MUST NOT decay (protocol invariant, §2.3 + §10.2)
         if vec["expected"].get("talent_unchanged"):
             assert decayed.talent == initial.talent, (
-                f"Talent must not decay (protocol invariant): "
-                f"initial={initial.talent}, decayed={decayed.talent}"
+                f"Talent must not decay (protocol invariant): initial={initial.talent}, decayed={decayed.talent}"
             )
 
         # Training should decrease (decay toward 0.5 from above)
@@ -212,8 +210,7 @@ class TestTensorConformance:
         # Recovery is a fixed positive increment, not move-toward-neutral
         if vec["expected"].get("temperament_recovers"):
             assert decayed.temperament > initial.temperament, (
-                f"Temperament should recover (increase): "
-                f"initial={initial.temperament}, decayed={decayed.temperament}"
+                f"Temperament should recover (increase): initial={initial.temperament}, decayed={decayed.temperament}"
             )
 
     # ── v3-001: Neutral V3 ─────────────────────────────────────

--- a/web4-standard/implementation/sdk/web4/mcp.py
+++ b/web4-standard/implementation/sdk/web4/mcp.py
@@ -723,9 +723,7 @@ class CrossSocietyContext:
     sender_lct: str
     sender_society: str
     responding_society: str
-    interaction_type: CrossSocietyInteractionType = (
-        CrossSocietyInteractionType.ESTABLISHED
-    )
+    interaction_type: CrossSocietyInteractionType = CrossSocietyInteractionType.ESTABLISHED
     sender_role: str = ""
     responding_role_expected: str = ""
     applicable_law_oracle: str = ""
@@ -764,9 +762,7 @@ class CrossSocietyContext:
             if self.atp_settlement_amount:
                 settlement["amount"] = self.atp_settlement_amount
             if self.atp_settlement_exchange_rate:
-                settlement["exchange_rate"] = dict(
-                    self.atp_settlement_exchange_rate
-                )
+                settlement["exchange_rate"] = dict(self.atp_settlement_exchange_rate)
             cross["atp_settlement"] = settlement
         d["cross_society"] = cross
         d["trust_context"] = self.trust_context.to_dict()
@@ -800,14 +796,10 @@ class CrossSocietyContext:
             atp_settlement_currency=settlement.get("currency", ""),
             atp_settlement_amount=settlement.get("amount", 0),
             atp_settlement_exchange_rate=settlement.get("exchange_rate"),
-            trust_context=TrustContext.from_dict(
-                d.get("trust_context", {})
-            ),
+            trust_context=TrustContext.from_dict(d.get("trust_context", {})),
             mrh_depth=d.get("mrh_depth", 1),
             law_hash=d.get("law_hash", ""),
-            proof_of_agency=(
-                ProofOfAgency.from_dict(poa) if poa else None
-            ),
+            proof_of_agency=(ProofOfAgency.from_dict(poa) if poa else None),
         )
 
 
@@ -844,13 +836,9 @@ class ReputationEnvelope:
         if self.responding_society:
             d["responding_society"] = self.responding_society
         if self.responding_society_signature:
-            d["responding_society_signature"] = (
-                self.responding_society_signature
-            )
+            d["responding_society_signature"] = self.responding_society_signature
         if self.trust_dimension_updates:
-            d["trust_dimension_updates"] = dict(
-                self.trust_dimension_updates
-            )
+            d["trust_dimension_updates"] = dict(self.trust_dimension_updates)
         if self.witness_signatures:
             d["witness_signatures"] = list(self.witness_signatures)
         if self.timestamp:
@@ -865,13 +853,9 @@ class ReputationEnvelope:
             outcome_class=OutcomeClass(d["outcome_class"]),
             outcome_quality=d.get("outcome_quality", 0.5),
             responding_society=d.get("responding_society", ""),
-            responding_society_signature=d.get(
-                "responding_society_signature", ""
-            ),
+            responding_society_signature=d.get("responding_society_signature", ""),
             trust_dimension_updates=d.get("trust_dimension_updates", {}),
-            propagation_scope=PropagationScope(
-                d.get("propagation_scope", "responding_society")
-            ),
+            propagation_scope=PropagationScope(d.get("propagation_scope", "responding_society")),
             witness_signatures=d.get("witness_signatures", []),
             timestamp=d.get("timestamp", ""),
         )
@@ -892,9 +876,7 @@ class MCPContextResource:
     name: str
     context_type: str = "session_state"
     description: str = ""
-    trust_requirements: TrustRequirements = field(
-        default_factory=TrustRequirements
-    )
+    trust_requirements: TrustRequirements = field(default_factory=TrustRequirements)
     atp_cost: int = 1
     ttl: int = 3600
     snapshot: Dict[str, Any] = field(default_factory=dict)
@@ -922,9 +904,7 @@ class MCPContextResource:
             name=d["name"],
             context_type=d.get("context_type", "session_state"),
             description=d.get("description", ""),
-            trust_requirements=TrustRequirements.from_dict(
-                d.get("trust_requirements", {})
-            ),
+            trust_requirements=TrustRequirements.from_dict(d.get("trust_requirements", {})),
             atp_cost=d.get("atp_cost", 1),
             ttl=d.get("ttl", 3600),
             snapshot=d.get("snapshot", {}),


### PR DESCRIPTION
## Summary
- Applied `ruff format` to `tests/test_conformance.py` and `web4/mcp.py` — the only 2 SDK files with pre-existing format drift
- Format-only changes (no semantic diff): ruff collapsed unnecessary line wraps
- Makes the SESSION_FOCUS.md assertion "ruff format --check passes with 0 changes" factually correct

## Context
Session 000009 (Sprint 55 v0.28.0 housekeeping) identified these 2 files as having format drift but explicitly deferred the fix as out-of-scope. This PR addresses that deferred gap.

## Quality gates
- `ruff format --check`: 73 files, 0 changes needed ✓
- `ruff check`: all checks passed ✓
- `mypy --strict`: 0 issues in 26 source files ✓
- `pytest`: 2749 passed, 5 xfailed (pre-existing, operator-blocked) ✓

## Test plan
- [x] `ruff format --check web4/ tests/test_*.py` returns 0 reformats
- [x] Full test suite passes (2749/2749 + 5 xfailed)
- [x] mypy strict clean
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)