### PR TITLE
fix(spec): C6 audit remediation — resolve 12 of 13 inter-society-protocol.md findings

### DIFF
--- a/docs/audits/inter-society-protocol-internal-consistency-2026-05-21.md
+++ b/docs/audits/inter-society-protocol-internal-consistency-2026-05-21.md
@@ -255,3 +255,28 @@ Analogy precision and readability notes. Fix when convenient.
 ---
 
 *Audit classifies; it does not remediate. Downstream PRs consume this classification.*
+
+---
+
+## Remediation Status
+
+**Remediated by**: PR #215 (worker/web4-20260521-060015)
+**Date**: 2026-05-21
+
+| Finding | Status | Resolution |
+|---------|--------|------------|
+| H1 | RESOLVED | §4 renumbered §4.1–§4.7; `society-roles.md` §4.4→§4.6 ref updated |
+| H2 | RESOLVED | Header updated to v0.1.2; §9 "v0.1.0" reference generalized to "this draft" |
+| H3 | RESOLVED | `mcp-protocol.md` row added to §8 table |
+| M1 | RESOLVED | Line 72: §6→§7; Line 75: §4→§6 |
+| M2 | RESOLVED | All three RESOLVED items now read "RESOLVED — `mcp-protocol.md` v0.1.x" |
+| M3 | RESOLVED | `society-roles.md` row added to §8 table |
+| M4 | RESOLVED | Changed to "`LCT-linked-context-token.md` requires ≥3 birth witnesses" |
+| M5 | RESOLVED | Reference changed to cite schema + SDK paths |
+| L1 | RESOLVED | Eurozone parenthetical corrected (removed misleading Greece/Brexit examples) |
+| L2 | DEFERRED | Informational; Gesellian terminology is technically accurate, left as-is |
+| L3 | RESOLVED | Diplomat role reference added in §2.2 federation genesis |
+| L4 | RESOLVED | "birth certificates" → "mint constituent-society LCTs" (aligned with §2.1) |
+| L5 | RESOLVED | "ANCHORED" → "SHALL be … anchored" (proper RFC 2119 phrasing) |
+
+**12 of 13 findings resolved. 1 deferred (L2 — informational, no action needed).**

--- a/web4-standard/core-spec/inter-society-protocol.md
+++ b/web4-standard/core-spec/inter-society-protocol.md
@@ -1,6 +1,6 @@
 # Inter-Society Protocol Specification
 
-**Status**: Core Specification v0.1.0 (DRAFT)
+**Status**: Core Specification v0.1.2 (DRAFT)
 **Date**: 2026-05-13
 **Category**: Society & Federation
 **Extends**: `SOCIETY_SPECIFICATION.md` (single-society semantics), `atp-adp-cycle.md` (ATP form)
@@ -39,7 +39,7 @@ This is a normative architectural property:
 
 Higher-order societies exist by accumulated consent of constituents. They can mint, can witness, can mediate, but they cannot compel. A constituent society can always exit (per §5). This is structurally analogous to:
 
-- Eurozone (members chose to join EUR; can theoretically exit, see Greek debt crisis 2015, Brexit 2020)
+- Eurozone (members chose to join EUR; can theoretically exit, though no member has yet done so — the right exists but is untested)
 - NATO (members commit to collective defense; commitments are mutual, not commanded)
 - UN (members confer specific authorities; sovereignty retained for unconferred matters)
 - International standards bodies (IETF, W3C — participating organizations retain all authority not explicitly delegated to working groups)
@@ -69,10 +69,10 @@ A single entity MAY found a society. The process:
    - ATP reification policy (what resources are accounted, in what units, with what charge/discharge rules)
 4. Founder SHALL initialize the society treasury (initial ADP allocation, MAY be zero)
 5. Founder SHALL mint the society LCT with:
-   - genesis_block_hash anchored to a ledger of the founder's choice (per §6)
+   - genesis_block_hash anchored to a ledger of the founder's choice (per §7)
    - Society LCT public key from step 2
    - Charter hash from step 3
-   - Birth witnesses (MAY be ≥3 entities under founder's control; see §4 on minimum viable society)
+   - Birth witnesses (MAY be ≥3 entities under founder's control; see §6 on minimum viable society)
 6. The society is now sovereign and MAY:
    - Admit citizens per its charter
    - Issue ATP per its reification policy
@@ -80,7 +80,7 @@ A single entity MAY found a society. The process:
    - Initiate first-contact with other societies (per §3)
 ```
 
-**Note on the witness quorum**: The existing spec requires ≥3 birth witnesses. A self-bootstrapped genesis where all three witnesses are under the founder's control satisfies the structural requirement but provides minimal external trust. The society's T3 trust will be self-issued-low until it accumulates witnessed interactions with other societies.
+**Note on the witness quorum**: `LCT-linked-context-token.md` requires ≥3 birth witnesses. A self-bootstrapped genesis where all three witnesses are under the founder's control satisfies the structural requirement but provides minimal external trust. The society's T3 trust will be self-issued-low until it accumulates witnessed interactions with other societies.
 
 ### 2.2 Federation-Based Genesis (Higher-Order Society)
 
@@ -88,8 +88,9 @@ Two or more existing sovereign societies MAY agree to form a higher-order societ
 
 ```
 1. Existing societies A, B, [C, ...] SHALL each delegate a representative entity
-   to participate in genesis. The representative MUST hold a valid LCT
-   issued by or recognized in the delegating society.
+   to participate in genesis (the Diplomat role per `society-roles.md`).
+   The representative MUST hold a valid LCT issued by or recognized in
+   the delegating society.
 2. The delegated representatives SHALL collectively:
    - Generate or select an Ed25519 keypair for the new society D
    - Negotiate and publish a charter (RDF graph) including:
@@ -101,7 +102,7 @@ Two or more existing sovereign societies MAY agree to form a higher-order societ
        MAY retain their own currencies and use D's only for inter-constituent exchange;
        see §4 on Eurozone-style federation)
      * Exit conditions (per §5)
-3. D SHALL issue birth certificates to A, B, [C, ...] as constituent societies
+3. D SHALL mint constituent-society LCTs for A, B, [C, ...] as constituent societies
 4. A, B, [C, ...] SHALL update their own LCTs to record citizenship in D
    (this is voluntary at any time; constituents can decline if charter changes)
 5. D's society LCT genesis is anchored:
@@ -138,7 +139,7 @@ The exchange rate MAY be:
   - Fixed (renegotiated periodically)
   - Market-derived (continuous price discovery via repeated exchanges)
   - Pegged (one anchors to the other's policy)
-Exchange transactions are witnessed by both societies and ANCHORED in both ledgers.
+Exchange transactions SHALL be witnessed by both societies and anchored in both ledgers.
 Neither society's sovereignty is impaired.
 ```
 
@@ -219,13 +220,13 @@ Most real ATP policies combine both: commitments are pledged forward, records tr
 
 Societies SHOULD make explicit in their charter which uses are in force and how they are distinguished in the ledger. Implementations MAY use separate ATP type-tags (e.g., `atp:commit`, `atp:record`) within the same accounting framework. The protocol does not mandate the distinction but acknowledges that conflating commitment and record is a common source of accounting confusion.
 
-### 4.2 Implication for Cross-Society Exchange
+### 4.4 Implication for Cross-Society Exchange
 
 Because substance varies, two societies' ATP units are NOT directly comparable until they negotiate an exchange rate (per §3.2 Option 1) or pool into a shared currency (per §3.2 Option 3).
 
 This is structurally similar to national currencies: a US dollar and a Japanese yen are not directly comparable; the foreign exchange market discovers their relationship. There is no "true value" of either currency independent of what it can be exchanged for.
 
-### 4.3 "First ATP" Resolution
+### 4.5 "First ATP" Resolution
 
 A common question (raised in 2026-05-13 review feedback): "How does a brand-new society calculate its initial resource inventory? What prevents a society from over-reporting compute capacity to mint excessive ATP?"
 
@@ -233,7 +234,7 @@ A common question (raised in 2026-05-13 review feedback): "How does a brand-new 
 
 **This is intentional**. A protocol-level constraint on initial issuance would require a universal measurement protocol, which would in turn require a universal authority — directly contradicting the anti-hierarchical-by-design property (§1.3).
 
-### 4.4 Resource Measurement and Attestation
+### 4.6 Resource Measurement and Attestation
 
 A society's ATP issuance is bound by its policy to measurements of the underlying reified resource. While the *substance* of the resource is society-sovereign, the *protocol of measurement* benefits from cross-platform consistency at the attestation layer so that exchange counterparties can evaluate measurement credibility independent of the society's self-report.
 
@@ -242,11 +243,11 @@ This spec establishes the following as RECOMMENDED practice:
 1. **Resource measurement SHOULD be witnessed.** A society's own attestation of its compute capacity, attention budget, or other reified resource SHOULD be co-signed by independent witnesses (other entities within the society at minimum; ideally entities outside the society with no stake in the over-reporting). Self-attestation without witnessing is permitted but limits the credibility of the society's ATP at exchange time.
 2. **Measurement frequency SHOULD match resource volatility.** Hardware capacity might be measured at genesis and on hardware change. Attention budget might be measured per-period (daily, hourly). The society's charter SHOULD specify measurement cadence.
 3. **Dispute resolution mechanism SHOULD be defined.** When society B's witnesses disagree with society A's self-report (e.g., A claims 10,000 compute units, B's witnesses measure 8,000), the spec does NOT specify how the dispute resolves — this is per-pair-relationship policy negotiated at first contact (per §3). But the existence of a dispute resolution mechanism SHOULD be documented in the society's charter.
-4. **Hardware attestation (TPM 2.0, FIDO2, Apple Secure Enclave, etc.) SHOULD be used where available** to anchor resource measurement to verifiable hardware presence. The `AttestationEnvelope` primitive (see related work) provides one cross-platform interface; implementations are free to use others, but SHOULD document the chosen mechanism in their charter so cross-platform exchange counterparties can evaluate trust.
+4. **Hardware attestation (TPM 2.0, FIDO2, Apple Secure Enclave, etc.) SHOULD be used where available** to anchor resource measurement to verifiable hardware presence. The `AttestationEnvelope` primitive (see `schemas/attestation-envelope.schema.json` and the SDK's `web4/attestation.py`) provides one cross-platform interface; implementations are free to use others, but SHOULD document the chosen mechanism in their charter so cross-platform exchange counterparties can evaluate trust.
 
 Note that none of these are protocol-level enforcement. They are RECOMMENDED practices that affect the credibility of a society's ATP at exchange time. A society that over-reports without witnessing will find its ATP discounted heavily by exchange counterparties — the market for the society's ATP is the audit mechanism, not the protocol.
 
-### 4.5 ATP/ADP Policy Examples (informative, not normative)
+### 4.7 ATP/ADP Policy Examples (informative, not normative)
 
 To illustrate the breadth of valid substance choices:
 
@@ -355,14 +356,16 @@ The choice is per-society policy. The Web4 protocol does not mandate any specifi
 | `t3-v3-tensors.md` | Society-society trust tensors may be computed; this spec leaves the computation policy society-sovereign |
 | `r6-framework.md` | R6 (Rules+Role+Request+Reference+Resource→Result) is the action grammar for routine, low-consequence inter-society transactions (e.g., read-only resource access) |
 | `r7-framework.md` | R7 (R6 + Reputation back-propagation to T3/V3) is the action grammar for consequential inter-society actions where the outcome should feed inter-society trust evolution. Most inter-society actions are R7 because crossing sovereignty boundaries typically justifies the bookkeeping cost. R6 and R7 are both canonical; the choice is per-action or per-role based on consequence tier. |
+| `mcp-protocol.md` | MCP is the inter-society action protocol per the canonical Web4 equation. This spec defines genesis/first-contact/secession; `mcp-protocol.md` §7.3–§7.6 specifies R6/R7 actions between societies via MCP. §7.7 (WIP) specifies referent-grounded exchange rate negotiation. |
+| `society-roles.md` | Defines roles (including Diplomat) that inter-society interactions require. This spec's §6.2 defines semantic viability criteria that constrain role composition. Bidirectional dependency. |
 
 ## 9. Future Work
 
-The following remain open and are explicitly NOT addressed by this v0.1.0 draft:
+The following remain open and are explicitly NOT addressed by this draft:
 
-- ~~**Cross-society R6/R7 action protocol**~~ — **RESOLVED v0.1.3 (2026-05-14)**: cross-society R6/R7 actions are realized via MCP per the canonical Web4 equation (`Web4 = MCP + RDF + LCT + T3/V3*MRH + ATP/ADP`). See `mcp-protocol.md` §1.1 (MCP as inter-society interface), §7.3 (MCP Actions as R7 Transactions), §7.4 (Cross-Society LCT Envelope), §7.5 (Cross-Society Witnessing and R7 Reputation Propagation), and §7.6 (cross-society R7 failure modes). The "cross-society action protocol" was never a missing spec — it was already specified by MCP's position in the equation; the v0.1.3 mcp-protocol.md amendment made the binding explicit.
-- ~~**Society-society trust tensors**~~ — **RESOLVED v0.1.3 (2026-05-14)**: society-society trust tensors emerge as the accumulated R7-Reputation projection at the encompassing society's scope, per `mcp-protocol.md` §7.5. Each society maintains its own bilateral view; the encompassing-society projection (when one exists) provides the canonical reference. Specified there rather than as a separate trust-tensor doc.
-- ~~**Exchange-rate discovery mechanisms**~~ — **RESOLVED v0.1.4 (2026-05-14, WIP)**: see `mcp-protocol.md` §7.7 (WIP) for the referent-grounded negotiation protocol. Key architectural insight: rates are not abstract floating bilateral exchange rates; they are grounded in a common referent both societies can independently value (kilowatt-hours, GPU-time, attention-hours, etc.). Per-transaction scoping is ideal (each R6/R7 carries its own rate against its specific referent); standing-agreement and oracle-reference are practical fallbacks. The protocol specifies message format (form); negotiation strategy (substance) is society-sovereign. The §7.7 section is currently WIP pending fleet review.
+- ~~**Cross-society R6/R7 action protocol**~~ — **RESOLVED — `mcp-protocol.md` v0.1.3 (2026-05-14)**: cross-society R6/R7 actions are realized via MCP per the canonical Web4 equation (`Web4 = MCP + RDF + LCT + T3/V3*MRH + ATP/ADP`). See `mcp-protocol.md` §1.1 (MCP as inter-society interface), §7.3 (MCP Actions as R7 Transactions), §7.4 (Cross-Society LCT Envelope), §7.5 (Cross-Society Witnessing and R7 Reputation Propagation), and §7.6 (cross-society R7 failure modes). The "cross-society action protocol" was never a missing spec — it was already specified by MCP's position in the equation; the v0.1.3 mcp-protocol.md amendment made the binding explicit.
+- ~~**Society-society trust tensors**~~ — **RESOLVED — `mcp-protocol.md` v0.1.3 (2026-05-14)**: society-society trust tensors emerge as the accumulated R7-Reputation projection at the encompassing society's scope, per `mcp-protocol.md` §7.5. Each society maintains its own bilateral view; the encompassing-society projection (when one exists) provides the canonical reference. Specified there rather than as a separate trust-tensor doc.
+- ~~**Exchange-rate discovery mechanisms**~~ — **RESOLVED — `mcp-protocol.md` v0.1.4 (2026-05-14, WIP)**: see `mcp-protocol.md` §7.7 (WIP) for the referent-grounded negotiation protocol. Key architectural insight: rates are not abstract floating bilateral exchange rates; they are grounded in a common referent both societies can independently value (kilowatt-hours, GPU-time, attention-hours, etc.). Per-transaction scoping is ideal (each R6/R7 carries its own rate against its specific referent); standing-agreement and oracle-reference are practical fallbacks. The protocol specifies message format (form); negotiation strategy (substance) is society-sovereign. The §7.7 section is currently WIP pending fleet review.
 - **Federation-of-federations** — when D itself federates with E into higher-order F. Protocol-wise this is recursive application of §2.2 and §3.2 Option 3, but operational guidance for multi-level federations is needed.
 - **Cross-federation citizenship conflicts** — when entity X is citizen of A (which is constituent of D) and B (which is constituent of E), and D and E are in opposition. Likely society-policy not protocol, but worth documenting patterns.
 - **Trust transitivity vs. trust attenuation across federation levels** — whether T3 in society A propagates to D's level and at what discount. The existing SOCIETY_SPECIFICATION.md §3.2.2 mentions "indirect relationship"; this spec leaves the trust math society-sovereign.

--- a/web4-standard/core-spec/society-roles.md
+++ b/web4-standard/core-spec/society-roles.md
@@ -203,7 +203,7 @@ The following are commonly defined when needed. The list is illustrative, not ex
 
 **Function**: Neutral attester for transactions; signs ledger entries to provide independent confirmation.
 
-**Note**: At federation depth, Witness becomes structurally necessary even when optional at single-society level. See `inter-society-protocol.md` §4.4 for inter-society witnessing.
+**Note**: At federation depth, Witness becomes structurally necessary even when optional at single-society level. See `inter-society-protocol.md` §4.6 for inter-society witnessing.
 
 **Example filling entities**: Human, AI, Society (a witness-services society), Oracle (specialized for witnessing)
 


### PR DESCRIPTION
## Summary

- Resolves 12 of 13 findings from the C6 internal consistency audit of `inter-society-protocol.md`
- Fixes structural numbering (duplicate §4.2/§4.3 → sequential §4.1–§4.7), two wrong cross-references in §2.1, stale header version, missing §8 table entries, dangling references, misleading analogy, and RFC 2119 capitalization issues
- Updates one external cross-reference in `society-roles.md` (§4.4→§4.6)
- L2 (Gesellian terminology) deferred — informational and technically accurate

## Files Modified

- `web4-standard/core-spec/inter-society-protocol.md` — all 12 spec fixes
- `web4-standard/core-spec/society-roles.md` — 1 line external ref update
- `docs/audits/inter-society-protocol-internal-consistency-2026-05-21.md` — remediation status table added

## Test plan

- [ ] Verify §4 subsections are numbered §4.1–§4.7 with no duplicates
- [ ] Verify §2.1 cross-references: line 72 → §7 (ledger anchoring), line 75 → §6 (minimum viable society)
- [ ] Verify §8 table now includes `mcp-protocol.md` and `society-roles.md`
- [ ] Verify header reads v0.1.2
- [ ] Verify `society-roles.md` line 206 references §4.6 (not §4.4)
- [ ] Verify `mcp-protocol.md` §4 references (lines 523, 646) are unaffected (they reference §4 generically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)