### PR TITLE
fix(spec): resolve C7 residual cross-reference defects in society-roles.md (#220)

### DIFF
--- a/web4-standard/core-spec/society-roles.md
+++ b/web4-standard/core-spec/society-roles.md
@@ -209,7 +209,7 @@ The following are commonly defined when needed. The list is illustrative, not ex
 
 **Function**: Neutral attester for transactions; signs ledger entries to provide independent confirmation.
 
-**Note**: At federation depth, Witness becomes structurally necessary even when optional at single-society level. See `inter-society-protocol.md` §4.6 for inter-society witnessing.
+**Note**: At federation depth, Witness becomes structurally necessary even when optional at single-society level. See `inter-society-protocol.md` §4.6 for inter-society resource-measurement attestation (where the Witness role operates at the resource-attestation layer).
 
 **Example filling entities**: Human, AI, Society (a witness-services society), Oracle (specialized for witnessing)
 
@@ -368,7 +368,7 @@ T3 trust scores for the society as a whole (in inter-society contexts) are deriv
 | `SOCIETY_SPECIFICATION.md` | Specifies structural requirements (Law Oracle, Ledger, Treasury, Society LCT); this spec specifies the roles that operate on those structures |
 | `entity-types.md` | Lists entity types with example roles each can fill; this spec lists roles with example entities each can be filled by (the symmetric dual) |
 | `inter-society-protocol.md` | Inter-society interactions reference the Diplomat role (§2.2 federation genesis). This spec's §6.2 defines semantic viability criteria that constrain role composition. ATP measurement witnessing (§4.6) involves the Witness role at the resource attestation layer. Bidirectional dependency. |
-| `mcp-protocol.md` | MCP actions consume the role taxonomy directly: Policy-Entity signs action decisions (§7.4), Witness co-signs high-consequence actions (§7.5), Archivist persists audit bundles (§7.5), Treasurer negotiates exchange rates (§7.7). |
+| `mcp-protocol.md` | MCP actions consume the role taxonomy directly: Policy-Entity signs action decisions (§7.3), Witness co-signs high-consequence actions (§7.5), Archivist persists audit bundles (§7.3), Treasurer negotiates exchange rates (§7.7). |
 | `web4-society-authority-law.md` | The SAL spec defines Citizen, Authority, Law Oracle, Witness, and Auditor from the Society–Authority–Law perspective with detailed normative requirements (birth certificates, delegation chains, ledger interfaces, audit transcripts). This spec provides the role taxonomy; SAL provides the operational protocol for a subset of those roles. |
 | `r6-framework.md` | R6 actions are dispatched through Administrator, evaluated by Policy-Entity, witnessed by Witness, recorded by Archivist |
 | `r7-framework.md` | R7 actions add Reputation back-propagation through the same role chain |


### PR DESCRIPTION
## Summary

Resolves the two MEDIUM cross-reference defects tracked in **#220** — C7 residuals that survived PR #217 and were routed through a governed channel by the 2026-05-22 06:00 session.

Single file, two line edits, documentation-only. Closes #220.

## R1 — wrong mcp §-numbers in the §7 cross-reference table (line 371)

The `mcp-protocol.md` row cited the wrong sections for two roles. Both the **Policy-Entity-signs** and **Archivist-persists** requirements live in `mcp-protocol.md` **§7.3** ("MCP Actions as R7 Transactions"; verified at L394 and L402), not §7.4 ("Cross-Society LCT Envelope") and §7.5 ("Cross-Society Witnessing and R7 Reputation Propagation").

- `Policy-Entity signs action decisions (§7.4)` → `(§7.3)`
- `Archivist persists audit bundles (§7.5)` → `(§7.3)`
- Witness co-signs (§7.5) and Treasurer negotiates exchange rates (§7.7) were already correct — **unchanged**.

## R2 — §4.6 self-contradiction within society-roles.md (line 212)

`inter-society-protocol.md` §4.6 is titled **"Resource Measurement and Attestation"**. The §7 table (line 370) already characterizes it correctly ("ATP measurement witnessing ... resource attestation layer"); line 212 described the same section as general "inter-society witnessing" → in-file contradiction. Line 212 reworded to match.

## Verification

- mcp §7.3 @ L353; §7.4 @ L404; §7.5 @ L471; §7.7 @ L510. Policy-Entity-signs requirement @ mcp L394, Archivist-persists @ mcp L402 — both inside §7.3.
- inter-society §4.6 @ L237 = "Resource Measurement and Attestation".
- Post-edit: only remaining §7.4/§7.5 citation is Witness→§7.5 (correct). society-roles.md lines 212 and 370 now mutually consistent about §4.6.
- Repo-wide grep for "inter-society witnessing": only remaining hits are in the frozen C6 audit doc (historical, pre-C7 state) — out of scope, untouched.
- GitNexus `detect_changes`: 0 changed symbols, 0 affected processes, risk low (prose markdown only).

## Governance

- v2 protocol: propose → policy review **APPROVED** (first pass) → execute → document.
- Policy review (06:00 session) had explicitly ruled AGAINST bundling these into PR #219 (C8 entity-types.md) to keep that PR single-file scoped. This PR is the designated follow-up.
- Session log: `private-context/autonomous-sessions/legion-web4-20260522-120000-session.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)