### PR TITLE
fix(spec): resolve all 8 C9 audit findings in LCT-linked-context-token.md

### DIFF
--- a/web4-standard/core-spec/LCT-linked-context-token.md
+++ b/web4-standard/core-spec/LCT-linked-context-token.md
@@ -8,6 +8,10 @@
 
 The Linked Context Token (LCT) is Web4's foundational presence primitive. An LCT is a verifiable digital presence certificate that binds an entity to its context through witnessed relationships. Unlike traditional identity tokens that assert "who you are," LCTs establish "where you exist" - your position in the web of trust and context.
 
+## Notation
+
+Key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are to be interpreted as described in RFC 2119.
+
 ## 1. Introduction
 
 ### 1.1 Purpose
@@ -21,7 +25,7 @@ LCTs solve the fundamental problem of contextual presence in distributed systems
 
 ### 1.2 Terminology
 
-- **Entity**: Any participant in Web4 (human, AI, device, service, role, task, resource, oracle, accumulator, dictionary)
+- **Entity**: Any participant in Web4 (human, AI, society, organization, role, task, resource, device, service, oracle, accumulator, dictionary, hybrid, policy, infrastructure — see `entity-types.md` §2.1 for the canonical 15-type taxonomy)
 - **Binding**: Permanent, verifiable cryptographic link between entity and LCT
 - **Pairing**: Authorized operational relationship between entities
 - **Witnessing**: Trust-building observation by other entities
@@ -59,7 +63,7 @@ LCTs MAY contain:
   "subject": "did:web4:key:z6Mk...",
 
   "binding": {
-    "entity_type": "human|ai|organization|role|task|resource|device|service|oracle|accumulator|dictionary|hybrid",
+    "entity_type": "human|ai|society|organization|role|task|resource|device|service|oracle|accumulator|dictionary|hybrid|policy|infrastructure",
     "public_key": "mb64:coseKey",
     "hardware_anchor": "eat:mb64:hw:...",
     "created_at": "2025-10-01T00:00:00Z",
@@ -219,7 +223,7 @@ In absence of existing society, entities MAY create self-issued LCTs:
 2. Create binding with hardware anchor (if available)
 3. Self-sign binding_proof
 4. Initialize empty MRH
-5. Set birth_certificate.issuing_society = null
+5. Omit `birth_certificate` section (self-issued LCTs are Regular LCTs per §4.3)
 6. Publish with low initial T3 scores
 ```
 
@@ -274,7 +278,8 @@ For an LCT to serve as a birth certificate, it MUST:
    - `citizen_role`: LCT of the role this entity inhabits
    - `birth_witnesses`: Array of ≥3 witness LCTs
    - `birth_timestamp`: ISO 8601 timestamp
-   - `genesis_block_hash`: Blockchain anchor (if applicable)
+   - `birth_context`: Society type classification — one of `nation`, `platform`, `network`, `organization`, `ecosystem` (RECOMMENDED)
+   - `genesis_block_hash`: Blockchain anchor for temporal proof (RECOMMENDED; omit if no blockchain anchor is available)
 
 2. **Have permanent citizen pairing** in `mrh.paired`:
    ```json
@@ -310,20 +315,20 @@ The MRH defines the **context boundary** for an entity - the set of all entities
 
 ### 5.2 Relationship Types
 
-#### Binding Relationships (`mrh.bound`)
+#### 5.2.1 Binding Relationships (`mrh.bound`)
 - **Purpose**: Permanent hierarchical attachments
 - **Type**: `parent`, `child`, `sibling`
 - **Example**: Device LCT bound to hardware anchor LCT
 - **Trust Flow**: Bidirectional, strong
 
-#### Pairing Relationships (`mrh.paired`)
+#### 5.2.2 Pairing Relationships (`mrh.paired`)
 - **Purpose**: Authorized operational connections
 - **Type**: `birth_certificate`, `role`, `operational`
 - **Example**: Entity paired with citizen role
 - **Trust Flow**: Bidirectional, context-specific
 - **Permanence**: Birth certificate pairings are permanent
 
-#### Witnessing Relationships (`mrh.witnessing`)
+#### 5.2.3 Witnessing Relationships (`mrh.witnessing`)
 - **Purpose**: Trust accumulation through observation
 - **Roles**: `time`, `audit`, `oracle`, `existence`, `action`, `state`, `quality`
 - **Example**: Time oracle witnessing entity's actions
@@ -545,7 +550,7 @@ LCTs are governed by SAL:
 ### 10.3 LCT and ATP/ADP
 
 LCTs track energy economics:
-- **V3 tensor**: Contains energy_balance dimension
+- **V3 tensor**: ATP/ADP balance MAY be tracked via a context-specific `energy_balance` sub-dimension (see `lct-capability-levels.md`)
 - **Transactions**: Recorded in society's energy cycle ledger
 - **Metering**: Capabilities consume ATP
 
@@ -577,7 +582,10 @@ def validate_lct(lct):
     # Birth certificate validation
     if "birth_certificate" in lct:
         assert len(lct["birth_certificate"]["birth_witnesses"]) >= 3
-        assert "citizen_role" in lct["mrh"]["paired"]
+        assert any(
+            p["pairing_type"] == "birth_certificate" and p["permanent"]
+            for p in lct["mrh"]["paired"]
+        )
 
     # Tensor validation
     validate_t3_tensor(lct["t3_tensor"])


### PR DESCRIPTION
## Summary

Remediates all 8 findings from the C9 internal consistency audit (PR #222, merged as `09f6f2bc`), incorporating peer verification corrections from session #110 (the M2 precedent overcall correction).

### Changes (1 file, +17/-9)

| ID | Severity | Fix |
|----|----------|-----|
| H1 | HIGH | §10.3: phantom V3 `energy_balance` root claim → context-specific sub-dimension with cross-ref |
| H2 | HIGH | §1.2 + §2.3: entity type lists updated to canonical 15-type set (was 10/12, now 15) |
| M1 | MEDIUM | §11.1: `validate_lct()` birth certificate assertion fixed (broken `in` check → `any()` pattern) |
| M2 | MEDIUM | Added RFC 2119 Notation section (matches `society-roles.md` — peer verification corrected audit's false C6/C8 attribution) |
| M3 | MEDIUM | §4.2: `genesis_block_hash` normative strength aligned to RECOMMENDED (was MUST + "if applicable") |
| M4 | MEDIUM | §3.2 step 5: `issuing_society = null` → omit `birth_certificate` section (self-issued = Regular LCT per §4.3) |
| L1 | LOW | §4.2: `birth_context` field documented in prose (was in §2.3 JSON but undocumented) |
| L2 | LOW | §5.2: sub-headings numbered as §5.2.1–5.2.3 |

### Context

- **Audit**: PR #222 (C9, merged)
- **Peer verification**: Session #110 memo (`legion-web4-20260523-000044-c9-verification.md`)
- **Key correction applied**: M2 cites `society-roles.md` as Notation precedent (not C6/C8 as the audit incorrectly stated)
- **C-series status after this PR**: C1-C8 fully remediated, C9 remediated (this PR), C10-C11 remediation pending

## Test plan

- [ ] Verify all 8 findings are resolved by reading modified sections
- [ ] Confirm §1.2 and §2.3 entity type lists now match entity-types.md §2.1 (15 types)
- [ ] Confirm §11.1 pseudocode matches §11.2's correct pattern
- [ ] Confirm §4.2 genesis_block_hash + birth_context are consistently documented
- [ ] Confirm §3.2 step 5 no longer contradicts §4.2/§4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)