### PR TITLE
fix(spec): resolve C11 audit findings in atp-adp-cycle.md

### DIFF
--- a/web4-standard/core-spec/atp-adp-cycle.md
+++ b/web4-standard/core-spec/atp-adp-cycle.md
@@ -151,16 +151,28 @@ ATP discharges through R6 transactions:
 }
 ```
 
+> **R6 / R7 note.** ATP→ADP discharge is an **R6** action. `r6-framework.md`
+> names ATP→ADP transactions as the canonical R6 pattern for routine work, and
+> §1.6 (Result) lists T3/V3 tensor updates as a standard R6 Result component.
+> The `t3v3_updates` above are therefore R6 Result deltas on the direct
+> participants — not evidence that discharge is R7. Discharges whose outcome
+> should feed fractal trust evolution use **R7**, which adds **Reputation** as an
+> explicit seventh output (see `r7-framework.md`, "R6 → R7 Relationship");
+> ATP→ADP spending happens in both modes.
+
 ### 2.4 Slashing (ATP Destruction)
 
 ATP can be slashed for violations:
 
 ```python
-def slash_atp(violator, amount, evidence):
+def slash_atp(caller, violator, amount, evidence):
     """
     Slash ATP for law violations or failed commitments
+
+    caller:   entity initiating the slash (must hold slashing authority)
+    violator: entity whose ATP is slashed
     """
-    # 1. Validate slashing authority
+    # 1. Validate slashing authority of the initiator (not the violator)
     if not has_slashing_authority(caller):
         raise UnauthorizedSlashing()
     
@@ -211,7 +223,7 @@ Each society maintains token pools:
     },
     "metrics": {
       "velocity": 4.2,  // Cycles per period
-      "charge_rate": 0.73,  // ATP/ADP ratio
+      "charge_rate": 0.15,  // ATP/(ATP+ADP): fraction of supply charged
       "decay_rate": 0.001,  // Per period
       "efficiency": 0.91  // Value preserved
     }
@@ -363,6 +375,10 @@ Level 3: Witnesses (1% attribution)
 Level 4: Society (0.1% attribution)
 Level 5: Parent society (0.01% attribution)
 ```
+
+The percentages shown are **illustrative defaults**, not protocol constants.
+Societies SHOULD define attribution rates in their economic laws (cf. §6.3 on
+transfer fees). Implementations MUST NOT hard-code these values.
 
 ## 5. Inter-Society Currency Exchange
 
@@ -545,6 +561,14 @@ them from the governing society's published laws.
 5. Discharging MUST occur through R6 transactions
 6. Value MUST be tracked through T3/V3 tensors
 
+> **Note on intermediate (escrow) state.** The two-state requirement above is
+> not violated by an *escrow/lock* lifecycle: ATP reserved for an in-flight
+> operation ("locked") remains ATP, not a third token state — analogous to the
+> `reserved` sub-partition of a pool (§3.1). Implementations MAY use a
+> two-phase commit (lock → commit / rollback) to prevent double-spend on
+> concurrent operations; that lifecycle is specified in `r6-framework.md`
+> (escrow in §1.5, `lock_resources` in §2.1, `release_escrow` in §2.3).
+
 ### 7.2 SHOULD Requirements
 
 1. Societies SHOULD implement demurrage
@@ -685,5 +709,21 @@ The ATP/ADP cycle creates a value system where:
 This creates an economy aligned with Web4's principles: trust through action, value through contribution, and prosperity through cooperation rather than competition.
 
 ---
+
+## References
+
+This specification cross-references the following Web4 core specs:
+
+- **R6 / R7 action grammar** — `r6-framework.md` (ATP→ADP discharge is the
+  canonical R6 action; §1.6 Result includes T3/V3 updates; escrow/lock lifecycle
+  in §1.5 / §2.1 / §2.3) and `r7-framework.md` ("R6 → R7 Relationship": R7 adds
+  Reputation as the seventh output).
+- **T3 / V3 trust and value tensors** — `t3-v3-tensors.md` and
+  `../ontology/t3v3-ontology.ttl` for the dimensions updated during charging,
+  discharging, and slashing.
+- **LCT identity** — `LCT-linked-context-token.md` for the `lct:web4:...`
+  identifiers used throughout (societies, entities, witnesses).
+- **Societies and roles** — `society-roles.md` and `SOCIETY_SPECIFICATION.md`
+  for pool governance, monetary authority, and role-scoped economic law.
 
 *"In Web4, value flows like energy through living systems—constantly cycling, never hoarded, always creating."*


### PR DESCRIPTION
## Summary

Remediates the **C11** internal-consistency audit (`docs/audits/atp-adp-cycle-internal-consistency-2026-05-23.md`, merged as PR #224) for `web4-standard/core-spec/atp-adp-cycle.md`.

Applies the audit's findings **as corrected by this track's #112 peer verification**, re-verified against the live `r6-framework.md` / `r7-framework.md` this session. **1 file changed, +43/−3.**

Follows the same pattern as C8 (#219) and C9 (#225): single-file spec remediation incorporating the peer-verification correction.

### Applied (6)

| ID | Sev | Fix |
|----|-----|-----|
| H1 | HIGH | §2.4 `slash_atp()` — add `caller` param (slashing authority applies to the *initiator*, not the violator) |
| M1 | MED | §3.1 `charge_rate` `0.73` → `0.15` with corrected comment `// ATP/(ATP+ADP)` — matches the 15M/85M example (was internally inconsistent) |
| M2 | MED | **CORRECTED** — §2.3 adds an R6/R7 cross-ref note **instead of** relabeling R6→R7 (see below) |
| M4 | MED | New `## References` section cross-linking `r6-framework.md`, `r7-framework.md`, `t3-v3-tensors.md`, `LCT-linked-context-token.md`, `society-roles.md`/`SOCIETY_SPECIFICATION.md` |
| M5 | MED | §4.3 — qualify attribution percentages (100/10/1/0.1/0.01) as illustrative defaults / society-configurable (consistent with §6.3) |
| M6 | MED | **CORRECTED** — §7.1 note: an escrow/lock (`locked`) state is still ATP, **not** a third token state / two-state violation; lifecycle is specified in `r6-framework.md` §1.5/§2.1/§2.3 |

### Why M2 and M6 are corrected (not applied verbatim)

The audit's **M2** proposed relabeling "R6"→"R7" at lines 17/119/123/545. **This would contradict two normative specs:**
- `r6-framework.md` L5: *"ATP→ADP transactions follow this pattern [R6] for routine, low-consequence tasks"* — ATP discharge **is** canonical R6.
- `r6-framework.md` §1.6 (Result) L184 lists *"Tensor updates (T3/V3)"* as a standard R6 Result component — so the `t3v3_updates` in §2.3 are R6 behavior **by definition**, not evidence of R7.
- `r7-framework.md` "R6 → R7 Relationship" L14–16: the R6→R7 boundary is the added **Reputation** 7th output; *"ATP→ADP spending happens in both modes."*

So the R6 labels are **kept**, and a clarifying cross-ref note resolves the reader-confusion the audit legitimately sensed. The audit's **M6** "two-state violation / race conditions" framing is likewise an overcall — `locked` is an ATP sub-state and the escrow lifecycle is already specified in `r6`.

### Deferred (3, documented)

- **M3** — SDK `atp.py` `fee_rate=0.05` default. Spec §6.3 is **already correct** ("Implementations MUST NOT hard-code fee rates"); the divergence is in SDK *code*, which is out of scope for a spec-consistency PR. **Routed as an SDK follow-up** (a one-line default change `fee_rate=0.0`, needs SDK impact + test run).
- **L1** — audit itself says "no action needed."
- **L2** — `type` vs `@type`: illustrative pseudocode examples; only 2 of 4 cited lines are real `type` fields; partial JSON-LD-ification would mislead. Deferred.

### Context

- **Audit**: PR #224 (C11)
- **Peer verification**: session #112 memo (`legion-web4-20260523-120044-c11-verification.md`)
- **C-series status after this PR**: C1–C9 remediated; C10 remediation in flight (#226); **C11 remediated (this PR)**.

## Test plan

- [ ] Confirm R6 labels at lines 17/119/123 + §7.1 item 5 are **unchanged** (M2 is a cross-ref, not a relabel)
- [ ] Confirm §3.1 `charge_rate` now equals ATP/(ATP+ADP) for the example pool
- [ ] Confirm `slash_atp` signature includes `caller` and the authority check uses it
- [ ] Confirm the `## References` cross-ref section names resolve (r6 §1.5/§1.6/§2.1/§2.3 exist; all linked files exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)