### PR TITLE
fix(sdk): ATP transfer() fee-free by default per §6.3 (C11 audit finding M3)

### DIFF
--- a/web4-standard/implementation/sdk/tests/test_atp.py
+++ b/web4-standard/implementation/sdk/tests/test_atp.py
@@ -291,6 +291,18 @@ class TestTransfer:
         assert sender.available == pytest.approx(50.0)
         assert receiver.available == pytest.approx(50.0)
 
+    def test_transfer_default_is_fee_free(self):
+        # Per atp-adp-cycle.md §6.3, ATP transfers are "fee-free at the protocol
+        # level" and implementations "MUST NOT hard-code fee rates". The default
+        # must therefore charge zero fee. (Distinct from test_transfer_zero_fee,
+        # which passes fee_rate=0.0 explicitly; this guards the *default*.)
+        sender = ATPAccount(available=100.0)
+        receiver = ATPAccount(available=0.0)
+        result = transfer(sender, receiver, 50.0)  # no fee_rate → protocol default
+        assert result.fee == pytest.approx(0.0)
+        assert sender.available == pytest.approx(50.0)
+        assert receiver.available == pytest.approx(50.0)
+
     def test_transfer_result_fields(self):
         sender = ATPAccount(available=1000.0)
         receiver = ATPAccount(available=0.0)

--- a/web4-standard/implementation/sdk/web4/atp.py
+++ b/web4-standard/implementation/sdk/web4/atp.py
@@ -234,11 +234,17 @@ def transfer(
     sender: ATPAccount,
     receiver: ATPAccount,
     amount: float,
-    fee_rate: float = 0.05,
+    fee_rate: float = 0.0,
     max_balance: Optional[float] = None,
 ) -> TransferResult:
     """
     Transfer ATP between accounts (test vectors atp-001 through atp-003).
+
+    Fees are NOT a protocol constant. Per atp-adp-cycle.md §6.3, ATP transfers
+    are "fee-free at the protocol level" and implementations "MUST NOT hard-code
+    fee rates" — so the default is 0.0. A society that levies a transfer fee as
+    economic law passes its declared rate explicitly (the "5%" used in the atp
+    test vectors and sims is a *simulation parameter*, not a protocol default).
 
     Fee is charged to sender ON TOP of the transfer amount.
     If max_balance is set, overflow is returned to sender.
@@ -345,6 +351,12 @@ def sybil_cost(
     Sybil attack cost analysis (test vector atp-011).
 
     Returns setup cost and per-cycle circular flow loss.
+
+    Note: unlike transfer(), the fee_rate here is a *simulation parameter*
+    modelling a hypothetical society's economic law (per atp-adp-cycle.md §6.3 —
+    "5% transfer fee" is an explicit simulation value, not a protocol constant).
+    The 0.05 default reproduces test vector atp-011; pass the modelled society's
+    declared rate for other analyses.
     """
     per_identity = hardware_cost + atp_stake
     total_setup = num_identities * per_identity


### PR DESCRIPTION
## Summary

Resolves **M3**, the SDK-conformance finding deferred from PR #227 (the C11 internal-consistency audit of \`atp-adp-cycle.md\`). M3 was explicitly routed as an SDK follow-up because it was out of scope for a spec-only PR.

The SDK \`web4/atp.py\` \`transfer()\` function hard-coded a **5% default fee** (\`fee_rate: float = 0.05\`). This contradicts **atp-adp-cycle.md §6.3**:

> The core protocol does **not** prescribe transfer fees. Peer-to-peer ATP transfers within a society and cross-society exchanges are **fee-free at the protocol level**. […] Any specific fee rates appearing in simulations, explainers, or demos (e.g., "5% transfer fee") are **simulation parameters**, not protocol constants. **Implementations MUST NOT hard-code fee rates**; they MUST read them from the governing society's published laws.

A bare \`transfer(sender, receiver, amount)\` call therefore must charge **zero** fee; a society levying a fee passes its declared rate explicitly.

## Changes (2 files, 0 new)

- **\`web4/atp.py\`**
  - \`transfer()\`: default \`fee_rate\` **0.05 → 0.0**; docstring now cites §6.3 and explains that 5% is a simulation parameter, not a protocol default.
  - \`sybil_cost()\`: docstring note clarifying its \`fee_rate\` **is** a legitimate simulation parameter per §6.3 — **no behavior change** (this function models a hypothetical society's economic law; §6.3 explicitly blesses "5%" as a simulation value).
- **\`tests/test_atp.py\`**
  - New \`test_transfer_default_is_fee_free\` guarding the fee-free **default** (distinct from the existing \`test_transfer_zero_fee\`, which passes \`fee_rate=0.0\` explicitly).

## Why this is safe (verified)

- **Test vectors unaffected**: \`transfer-operations.json\` (atp-001..004) pass \`fee_rate: 0.05\` **explicitly** — exactly what §6.3 permits — so the conformance vectors are untouched.
- **No test relies on the old default for a nonzero fee**: all \`TestTransfer\` tests pass \`fee_rate\` explicitly; the default-relying call sites (test_integration:178, test_jsonld_roundtrip:379/387/869, test_jsonld_lifecycle:660, test_package_api:402) assert only \`actual_credit\` / roundtrip-equality / \`>0\`, none asserts a nonzero fee.
- **Blast radius**: gitnexus_impact = LOW; no production execution flows depend on the fee default.
- **Full SDK suite**: **2750 passed, 5 xfailed**.

## Governance

- v2 protocol, **peer voice** (concurrent with lead 000005, which is in the spec-audit domain — this PR touches only \`sdk/*.py\`, zero \`.md\` edits → orthogonal, no collision).
- Policy review: **APPROVED** (development-phase conformance fix to an existing reusable module; proportional; no drift).
- Session log: \`private-context/autonomous-sessions/legion-web4-20260524-000044-session.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)