### PR TITLE
fix(spec): resolve all 11 C12 audit findings in r6-framework.md

### DIFF
--- a/web4-standard/core-spec/r6-framework.md
+++ b/web4-standard/core-spec/r6-framework.md
@@ -228,29 +228,29 @@ def validate_r6_action(r6_action):
     # 1. Verify actor has required role
     if not verify_role_pairing(r6_action.role):
         raise InvalidRole("Actor not paired with specified role")
-    
+
     # 2. Check for agency delegation if acting as agent
     if r6_action.request.get('proofOfAgency'):
         if not verify_agency_grant(r6_action.request.proofOfAgency):
             raise InvalidAgency("Invalid or expired agency grant")
         if not check_agency_scope(r6_action.request, r6_action.request.proofOfAgency):
             raise AgencyScopeViolation("Action outside delegated scope")
-    
+
     # 3. Check rules compliance
     if not check_law_compliance(r6_action.rules, r6_action.request):
         raise RuleViolation("Request violates active rules")
-    
+
     # 4. Verify resource availability (including agency caps)
     if not check_resources(r6_action.resource.required):
         raise InsufficientResources("Cannot fulfill resource requirements")
-    
+
     # 5. Validate references
     if not verify_references(r6_action.reference):
         raise InvalidReference("Referenced precedents/witnesses invalid")
-    
+
     # 6. Lock resources (escrow)
     escrow_lock = lock_resources(r6_action.resource.escrow)
-    
+
     return ValidationResult(valid=True, escrow=escrow_lock)
 ```
 
@@ -260,7 +260,7 @@ def execute_r6_action(r6_action, validation_result):
     # 1. Begin metered execution
     meter = ResourceMeter()
     meter.start()
-    
+
     # 2. Execute with role context
     with role_context(r6_action.role):
         try:
@@ -270,21 +270,21 @@ def execute_r6_action(r6_action, validation_result):
                 r6_action.reference,
                 r6_action.rules
             )
-            
+
             # 4. Validate output against rules
             if not validate_output(raw_result, r6_action.rules):
                 raise OutputViolation("Result violates output constraints")
-            
+
             # 5. Stop metering
             resources_used = meter.stop()
-            
+
             # 6. Create result object
             result = create_r6_result(
                 status="success",
                 output=raw_result,
                 resources=resources_used
             )
-            
+
         except Exception as e:
             meter.stop()
             result = create_r6_result(
@@ -292,7 +292,7 @@ def execute_r6_action(r6_action, validation_result):
                 error=str(e),
                 resources=meter.get_partial()
             )
-    
+
     return result
 ```
 
@@ -304,7 +304,7 @@ def settle_r6_action(r6_action, result):
         result.resourceConsumed,
         r6_action.resource.pricing
     )
-    
+
     # 2. Settle ATP transfers
     if result.status == "success":
         transfer_atp(
@@ -317,18 +317,18 @@ def settle_r6_action(r6_action, result):
         # Partial refund on failure
         refund = calculate_refund(r6_action.resource.escrow, result)
         release_escrow(refund, "failed")
-    
+
     # 3. Update tensors
     update_t3_v3_tensors(
         entity=r6_action.role.actor,
         role_lct=r6_action.role.roleLCT,
         updates=result.tensorUpdates
     )
-    
+
     # 4. Record to ledger
     ledger_entry = create_ledger_entry(r6_action, result)
     proof = write_to_ledger(ledger_entry, witnesses=get_witnesses())
-    
+
     # 5. Update MRH
     update_mrh_with_action(
         r6_action.role.actor,
@@ -336,7 +336,7 @@ def settle_r6_action(r6_action, result):
         result,
         proof
     )
-    
+
     return SettlementResult(proof=proof, final_cost=final_cost)
 ```
 
@@ -586,10 +586,19 @@ The R6 framework can evolve through:
 
 The R6 framework provides:
 - **Complete** action specification (nothing ambiguous)
-- **Deterministic** execution (same input → same output)
+- **Deterministic** settlement (same inputs + execution outcome → same settlement)
 - **Auditable** transactions (all on ledger)
 - **Role-contextual** operations (no global permissions)
 - **Resource-bounded** execution (no unbounded consumption)
 - **Law-integrated** validation (SAL compliance built-in)
 
 Every Web4 transaction is an R6 action, making the entire system consistent, predictable, and verifiable.
+
+## 10. References
+
+- [r7-framework.md](r7-framework.md) — R7 superset with explicit reputation tracking and back-propagation
+- [atp-adp-cycle.md](atp-adp-cycle.md) — ATP/ADP token lifecycle, value mechanics, and conservation invariants
+- [t3-v3-tensors.md](t3-v3-tensors.md) — T3 (Trust) and V3 (Value) tensor definitions and update mechanics
+- [mrh-tensors.md](mrh-tensors.md) — Markov Relevancy Horizon graph structure and trust propagation
+- [society-roles.md](society-roles.md) — Role definitions, tier structure, and role pairing lifecycle
+- [SOCIETY_SPECIFICATION.md](SOCIETY_SPECIFICATION.md) — Society-Authority-Law (SAL) governance framework

--- a/web4-standard/core-spec/r6-framework.md
+++ b/web4-standard/core-spec/r6-framework.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-R6 is the **base action grammar** for Web4. ATP→ADP transactions follow this pattern for **routine, low-consequence tasks** that don't merit reputation tracking — the cheap default mode.
+R6 is the **base action grammar** for Web4. ATP→ADP transactions follow this pattern for **routine, low-consequence tasks** that don't merit explicit, first-class reputation tracking — the cheap default mode. (R6 Results do include implicit tensor updates via `tensorUpdates` in §1.6; R7 adds the full reputation machinery: role-contextualized, witnessed, attributed, ledger-recorded.)
 
 For consequential actions where the outcome should shape future trust, use [R7](r7-framework.md) — a superset of R6 that adds reputation back-propagation.
 
@@ -57,18 +57,23 @@ Each component is essential and together they form a complete, deterministic act
 {
   "role": {
     "actor": "lct:web4:entity:alice",
-    "roleType": "web4:DataAnalyst",
-    "roleLCT": "lct:web4:role:analyst:...",
+    "roleLCT": "lct:web4:role:analyst_financial_q4:abc123",
     "pairedAt": "2025-09-15T12:00:00Z",
-    "scopeContext": "financial_analysis",
     "t3InRole": {
       "talent": 0.85,
       "training": 0.90,
       "temperament": 0.88
+    },
+    "v3InRole": {
+      "veracity": 0.92,
+      "validity": 0.88,
+      "value": 0.85
     }
   }
 }
 ```
+
+**Note**: Both T3 (trust) and V3 (value) tensors are stored on the MRH role pairing link. There is no global reputation — all reputation is role-contextualized. The `roleLCT` encodes the domain-specific context (e.g., `analyst_financial_q4`) within the LCT identifier itself.
 
 ### 1.3 Request
 **Definition**: The specific action intent and parameters.
@@ -303,7 +308,7 @@ def settle_r6_action(r6_action, result):
     # 2. Settle ATP transfers
     if result.status == "success":
         transfer_atp(
-            from=r6_action.role.actor,
+            sender=r6_action.role.actor,
             to=resource_providers,
             amount=final_cost
         )
@@ -316,7 +321,7 @@ def settle_r6_action(r6_action, result):
     # 3. Update tensors
     update_t3_v3_tensors(
         entity=r6_action.role.actor,
-        role=r6_action.role.roleType,
+        role_lct=r6_action.role.roleLCT,
         updates=result.tensorUpdates
     )
     
@@ -351,7 +356,7 @@ The R6 framework integrates tightly with the Society-Authority-Law layer:
 ## 4. R6 Security Properties
 
 ### 4.1 Determinism
-Given the same R6 inputs, the result must be identical across all valid implementations.
+Given the same R6 inputs **and execution outcome**, the settlement (resource accounting, tensor updates, ledger entry) must be identical across all valid implementations. The determinism guarantee applies to the R6 framework's processing, not to the underlying action execution which may depend on external factors (hardware, network state, nondeterministic algorithms).
 
 ### 4.2 Non-repudiation
 All R6 actions are signed and recorded on the immutable ledger with witness attestations.
@@ -372,7 +377,7 @@ Resource transfers and tensor updates either fully complete or fully roll back.
 {
   "type": "query",
   "rules": {"lawHash": "..."},
-  "role": {"roleType": "web4:Reader"},
+  "role": {"roleLCT": "lct:web4:role:reader:..."},
   "request": {"action": "read", "target": "data:..."},
   "reference": {"precedents": []},
   "resource": {"required": {"atp": 1}},
@@ -385,7 +390,7 @@ Resource transfers and tensor updates either fully complete or fully roll back.
 {
   "type": "trust_query",
   "rules": {"constraints": [{"type": "atp_minimum", "value": 100}]},
-  "role": {"roleType": "web4:Investigator"},
+  "role": {"roleLCT": "lct:web4:role:investigator:..."},
   "request": {
     "action": "query_trust",
     "target": "lct:web4:entity:...",
@@ -395,8 +400,7 @@ Resource transfers and tensor updates either fully complete or fully roll back.
   "reference": {"mrhContext": {"depth": 2}},
   "resource": {"escrow": {"amount": 100}},
   "result": {
-    "output": {"t3InRole": {...}},
-    "commitment": "must_engage_or_forfeit"
+    "output": {"t3InRole": {...}, "commitment": "must_engage_or_forfeit"}
   }
 }
 ```
@@ -406,7 +410,7 @@ Resource transfers and tensor updates either fully complete or fully roll back.
 {
   "type": "compute",
   "rules": {"permissions": ["execute"]},
-  "role": {"roleType": "web4:DataScientist"},
+  "role": {"roleLCT": "lct:web4:role:data_scientist:..."},
   "request": {
     "action": "train_model",
     "parameters": {"dataset": "...", "algorithm": "..."}
@@ -427,7 +431,7 @@ Resource transfers and tensor updates either fully complete or fully roll back.
 {
   "type": "delegation",
   "rules": {"lawHash": "...", "society": "..."},
-  "role": {"roleType": "web4:Authority"},
+  "role": {"roleLCT": "lct:web4:role:authority:..."},
   "request": {
     "action": "delegate",
     "target": "lct:web4:subauthority:...",
@@ -447,7 +451,7 @@ Resource transfers and tensor updates either fully complete or fully roll back.
 {
   "type": "agency_action",
   "rules": {"lawHash": "...", "agencyGrant": "agy:..."},
-  "role": {"roleType": "web4:Agent", "actingFor": "lct:web4:client:..."},
+  "role": {"roleLCT": "lct:web4:role:agent:...", "actingFor": "lct:web4:client:..."},
   "request": {
     "action": "approve_invoice",
     "target": "invoice:123",
@@ -474,20 +478,22 @@ Resource transfers and tensor updates either fully complete or fully roll back.
       "client": "lct:web4:client:...",
       "grantUsed": "agy:..."
     },
-    "tensorUpdates": {
-      "agent_t3": {"temperament": +0.01},
-      "client_v3": {"validity": +0.005}
-    }
+    "tensorUpdates": [
+      {"entity": "lct:web4:agent:...", "t3": {"temperament": +0.01}},
+      {"entity": "lct:web4:client:...", "v3": {"validity": +0.005}}
+    ]
   }
 }
 ```
+
+**Note on multi-party tensor attribution**: Agency-delegated actions affect multiple parties. The `tensorUpdates` array uses explicit per-entity attribution with standard `t3`/`v3` keys (matching §1.6 Result format). For consequential agency actions, prefer R7's `ReputationDelta` per-party model which provides full attribution, witnessing, and ledger recording.
 
 ## 6. R6 Implementation Requirements
 
 ### MUST Requirements
 1. All actions MUST follow the complete R6 structure
 2. All components MUST be present (even if empty)
-3. Results MUST be deterministic given inputs
+3. Settlement MUST be deterministic given inputs and execution outcome
 4. Failed actions MUST still produce valid R6 results
 5. All R6 transactions MUST be written to ledger
 
@@ -506,6 +512,10 @@ Resource transfers and tensor updates either fully complete or fully roll back.
 
 ## 7. R6 Error Handling
 
+R6 distinguishes two non-success statuses:
+- **`error`**: Pre-execution validation failures — the action was never attempted (e.g., insufficient resources, invalid role, malformed request).
+- **`failure`**: Execution-time errors — the action was attempted but did not succeed (e.g., runtime error, output constraint violation).
+
 ### Error Categories
 ```python
 class R6Error(Exception):
@@ -513,22 +523,24 @@ class R6Error(Exception):
 
 class RuleViolation(R6Error):
     """Action violates governing rules"""
-    
+
 class RoleUnauthorized(R6Error):
     """Actor lacks required role or permissions"""
-    
+
 class RequestMalformed(R6Error):
     """Request structure or parameters invalid"""
-    
+
 class ReferenceInvalid(R6Error):
     """Referenced entities not found or invalid"""
-    
+
 class ResourceInsufficient(R6Error):
     """Required resources unavailable"""
-    
+
 class ResultInvalid(R6Error):
     """Result violates output constraints"""
 ```
+
+**SDK note**: In implementations that support both R6 and R7, the error hierarchy may use a shared base class. The SDK uses `R7Error` as the common base, since R7 is a superset of R6. A pure R6 implementation would define `R6Error` as shown above.
 
 ### Error R6 Result
 ```json


### PR DESCRIPTION
## Summary

Resolves every finding from the C12 internal consistency audit (PR #229), including the H1 scope-undercall identified by peer verification (PR #229 comment).

- **H1+L4**: Remove legacy `roleType`/`scopeContext` from §1.2 Role, §2.3 settlement pseudocode, and all §5 examples — consolidate to `roleLCT` (matching R7 §1.2 and SDK)
- **M1**: Add `v3InRole` to §1.2 Role (matching R7 §1.2 and SDK)
- **M2**: Restructure §5.5 `tensorUpdates` to per-entity array format with standard `t3`/`v3` keys
- **M3**: Qualify Overview: "don't merit explicit, first-class reputation tracking" (was "don't merit reputation tracking")
- **M4**: Add §10 References section cross-linking 6 sibling specs
- **M5**: Qualify determinism claims in §4.1, §6 MUST-3, and §9 Summary
- **M6**: Add SDK note about R6Error/R7Error hierarchy
- **L1**: Move `commitment` into `output` object in §5.2
- **L2**: Fix Python keyword `from=` → `sender=` in §2.3
- **L3**: Add error/failure status distinction note to §7

### Audit reference
- C12 audit: `docs/audits/r6-framework-internal-consistency-2026-05-24.md` (PR #229)
- Peer verification: PR #229 comment (H1 scope-undercall + citation drift list)

### Files changed
- `web4-standard/core-spec/r6-framework.md` (1 file, 64 insertions, 43 deletions)

## Test plan
- [ ] Verify no `roleType` or `scopeContext` references remain in r6-framework.md
- [ ] Verify §1.2 Role structure matches R7 §1.2 (roleLCT, t3InRole, v3InRole)
- [ ] Verify §2.3 settlement uses `roleLCT` (not `roleType`) and `sender` (not `from`)
- [ ] Verify §5.5 tensorUpdates uses array format with per-entity attribution
- [ ] Verify §10 References section links are valid relative paths
- [ ] Cross-check: R7 §5 examples still use `roleType` (deferred to future R7 audit, not this PR's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)