### PR TITLE
docs(spec): sync r6 SAL Result row + §4.5 atomic-settlement with merged r7 (C14 L3/L4 follow-up)

### DIFF
--- a/web4-standard/core-spec/r6-framework.md
+++ b/web4-standard/core-spec/r6-framework.md
@@ -351,7 +351,7 @@ The R6 framework integrates tightly with the Society-Authority-Law layer:
 | **Request** | Must comply with society's laws, proof-of-agency for delegated actions | Quorum checks, rate limits |
 | **Reference** | Law interpretations and precedents, agency grants | Oracle rulings cached |
 | **Resource** | ATP caps and pricing from law, agency resource caps | Metering enforced |
-| **Result** | Auditor can adjust based on evidence | Witness attestations required |
+| **Result** | Auditor reviews evidence; corrections are issued as a *new* corrective R6 action — the original Result stays immutable per §4.2 | Witness attestations required |
 
 ## 4. R6 Security Properties
 
@@ -368,7 +368,7 @@ Resource consumption cannot exceed pre-declared limits, preventing denial-of-ser
 Actions are strictly scoped to the permissions of the role under which they execute.
 
 ### 4.5 Atomic Settlement
-Resource transfers and tensor updates either fully complete or fully roll back.
+Resource transfers and tensor updates either fully complete or fully roll back. The settlement steps in §2.3 (ATP transfer, escrow release, tensor updates, ledger write, and MRH update) execute within a single atomic boundary; the §2.3 pseudocode shows the logical sequence, not the transaction/rollback scaffolding that enforces this all-or-nothing commitment.
 
 ## 5. R6 Transaction Types
 


### PR DESCRIPTION
## Summary

Resolves the **r6-sync follow-up** explicitly flagged in merged PR #234 (C14 r7-framework remediation). #234 applied two LOW clarifications (**L3**, **L4**) to `r7-framework.md` whose source text was shared *verbatim* with `r6-framework.md`, so r6 was left carrying the older, less-precise wording. This PR re-converges the two specs — **adapted for r6's structure, NOT copied verbatim**. Spec-only; no SDK changes.

## Changes (`web4-standard/core-spec/r6-framework.md`, 2 edits)

| ID | Section | Change |
|----|---------|--------|
| **L3** | §3 SAL "Result" row | `Auditor can adjust based on evidence` → `Auditor reviews evidence; corrections are issued as a *new* corrective **R6** action — the original Result stays immutable per §4.2`. (r6 §4.2 = Non-repudiation/immutable ledger — cross-ref verified.) |
| **L4** | §4.5 Atomic Settlement | Appended the atomic-boundary clarification, referencing r6's **§2.3** "Post-execution Settlement" and r6's **actual** settlement steps (ATP transfer, escrow release, tensor updates, ledger write, **MRH update**). |

## ⚠️ Why adaptation, not a verbatim copy

A naive copy of r7's L4 sentence into r6 would have been **wrong on two counts**:

1. **Section number** — r7's settlement is §2.4 *only because r7 inserts an extra §2.3 "Reputation Computation (R7 Addition)"*. In r6, settlement is **§2.3**. Copying "§2.4" would dangle (r6 has no §2.4).
2. **Step list** — r7's clarification lists "reputation computation" as a settlement step. **R6 has no reputation machinery by design** (r6 intro: *"R7 adds the full reputation machinery"*). The r6 version therefore omits it and instead includes r6's real **MRH update** step (r6 §2.3 step 5), which r7's list does not have.

This is the cross-document hygiene rule in action: re-read the cited source before characterizing it.

## Verification

- Spec-only markdown; diff = 2 lines. Re-grep confirms **no `§2.4` and no "reputation computation"** in r6 §4.5; `r7-framework.md` and the SDK are untouched.
- Confirmed no *other* unflagged shared-text divergence: the r6/r7 §4.1 determinism wordings differ **intentionally** (set per-framework during C12/C14), and r7's extra SAL "Reputation" row is an intentional R7 addition — neither is a sync target.

## Out of scope (carry-items)

- §2.2 `OutputViolation` vs §7 `ResultInvalid` naming mismatch in r7 (pre-existing; not a C14 finding).
- C15 next-audit candidate: `reputation-computation.md` (most R7-adjacent) or SAL `web4-society-authority-law.md`.

Governed under Autonomous Session Protocol v2 — policy review **APPROVED** first pass with 3 binding conditions (§2.3 not §2.4 + no reputation step; §4.2 cross-ref; r6-only single-file edit), all satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)