### PR TITLE
fix(spec): rename undefined OutputViolation to canonical ResultInvalid in r6/r7 pseudocode

### DIFF
--- a/web4-standard/core-spec/r6-framework.md
+++ b/web4-standard/core-spec/r6-framework.md
@@ -273,7 +273,7 @@ def execute_r6_action(r6_action, validation_result):
 
             # 4. Validate output against rules
             if not validate_output(raw_result, r6_action.rules):
-                raise OutputViolation("Result violates output constraints")
+                raise ResultInvalid("Result violates output constraints")
 
             # 5. Stop metering
             resources_used = meter.stop()

--- a/web4-standard/core-spec/r7-framework.md
+++ b/web4-standard/core-spec/r7-framework.md
@@ -362,7 +362,7 @@ def execute_r7_action(r7_action, validation_result):
 
             # 4. Validate output against rules
             if not validate_output(raw_result, r7_action.rules):
-                raise OutputViolation("Result violates output constraints")
+                raise ResultInvalid("Result violates output constraints")
 
             # 5. Stop metering
             resources_used = meter.stop()
@@ -374,7 +374,7 @@ def execute_r7_action(r7_action, validation_result):
                 resources=resources_used
             )
 
-        except OutputViolation as e:
+        except ResultInvalid as e:
             # Action ran but produced an unsuccessful outcome → "failure"
             meter.stop()
             result = create_r7_result(


### PR DESCRIPTION
## Summary

Three single-line edits across two spec files rename the undefined exception
name `OutputViolation` (referenced in normative pseudocode but defined
nowhere) to the canonical `ResultInvalid` already present in both specs'
§7 error catalogs and in the SDK.

## Defect

Sites raising/catching an undefined identifier:

| File | Line | Statement |
|------|------|-----------|
| `web4-standard/core-spec/r6-framework.md` | 276 | `raise OutputViolation(...)` |
| `web4-standard/core-spec/r7-framework.md` | 365 | `raise OutputViolation(...)` |
| `web4-standard/core-spec/r7-framework.md` | 377 | `except OutputViolation as e:` |

`OutputViolation` is not defined in:
- `r6-framework.md` §7 error catalog (L513–L543) — defines `ResultInvalid` at L539.
- `r7-framework.md` §7 error catalog (L854–L879) — defines `ResultInvalid` at L876.
- The SDK (`web4-standard/implementation/sdk/web4/r6.py`) — defines `class ResultInvalid(R7Error)` at L114 with docstring `"Result violates output constraints"` (the **exact** string the `raise` calls use).

## Resolution

Rename to `ResultInvalid` at all three pseudocode sites. The semantic match
is exact:
- Docstring of `r6.py:114` `ResultInvalid`: `"Result violates output constraints"`
- Argument of the patched `raise ResultInvalid(...)`: `"Result violates output constraints"`

Per the established C-series rule (SDK is authority, spec converges to SDK),
the SDK already has the canonical name; the spec converges.

## Scope discipline

- **No SDK changes** — SDK is the authority and already correct.
- **No catalog changes** — both §7 catalogs already define `ResultInvalid`.
- **No new audit memo** — the defect was characterized in MEMORY.md from
  exit #121 (the C15 remediation session) as a ready-fix carry-item.
- **No test changes** — pseudocode is illustrative; SDK tests already
  exercise `ResultInvalid` through `r6.py:114`.
- **No new files** — modify-only.

## Out of scope (explicitly noted per scope-precision discipline)

A corpus-wide `grep` for `OutputViolation` surfaced one additional reference:

- `whitepaper/PUBLISHER_CONTEXT.md` L222 — a publisher logbook entry
  describing PR #234 (the C14 r7-framework remediation), with the phrase
  "catch `OutputViolation` vs generic `Exception`".

This is a **historical narrative** in the publisher decision log describing
what PR #234 chose at the time. The logbook records past decisions; touching
it would be a collateral edit that distorts the historical record. The
description remains accurate for what PR #234 itself did. The next no-change
publisher check will naturally observe the renamed live spec while the
historical entry preserves its as-of accuracy.

## Verification

- `gitnexus_detect_changes`: 0 affected processes, risk LOW. 40 "changed
  symbols" are markdown section headers (markdown indexer flags every
  section in a modified file); no execution flow is affected because no
  SDK code changed.
- Post-edit `grep`: confirmed the only remaining `OutputViolation` reference
  in `web4-standard/` is the catalog cross-check below; all three normative
  sites now reference `ResultInvalid` (defined at r6:539 / r7:876).

## Closes

Next-session carry-item (b) flagged at exit #121 (after PR #237 / C15
remediation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)