### PR TITLE
fix(spec): resolve 5 autonomous-actionable C16 SAL findings (M7/L2/M2/H2/H1-partial); defer 7 design-Q items

### DIFF
--- a/web4-standard/core-spec/web4-society-authority-law.md
+++ b/web4-standard/core-spec/web4-society-authority-law.md
@@ -54,8 +54,8 @@ When an entity’s LCT is created, implementations **MUST**:
   "birthTimestamp": "2025-09-14T12:00:00Z",
   "witnesses": ["lct:web4:witness1", "lct:web4:witness2"],
   "genesisBlock": "block:12345",
-  "initialRights": ["exist", "interact", "accumulate_reputation"],
-  "initialResponsibilities": ["abide_law", "respect_quorum"]
+  "rights": ["exist", "interact", "accumulate_reputation"],
+  "obligations": ["abide_law", "respect_quorum"]
 }
 ```
 
@@ -148,11 +148,11 @@ A minimal JSON-LD structure:
 {
   "@context": ["https://web4.io/contexts/law.jsonld"],
   "type": "Web4LawDataset",
-  "id": "web4://law/society/1.2.0",
+  "law_id": "web4://law/society/1.2.0",
   "hash": "sha256-...",
-  "norms": [{"id":"LAW-ATP-LIMIT","selector":"r6.resource.atp","op":"<=","value":100}],
-  "procedures": [{"id":"PROC-WIT-3","requiresWitnesses":3}],
-  "interpretations": [{"id":"INT-42","replaces":"INT-41","reason":"edge case fix"}],
+  "norms": [{"norm_id":"LAW-ATP-LIMIT","selector":"r6.resource.atp","op":"<=","value":100}],
+  "procedures": [{"procedure_id":"PROC-WIT-3","requires_witnesses":3}],
+  "interpretations": [{"interpretation_id":"INT-42","replaces":"INT-41","reason":"edge case fix"}],
   "r6Bindings": ["web4://schemas/r6-rules-v1"]
 }
 ```
@@ -182,7 +182,7 @@ A minimal JSON-LD structure:
 
 ### 5.4 Witness
 - Maintains the **immutable record** via co-signed ledger entries for SAL-critical events.
-- Quorum policy defined by **Law Oracle** (e.g., `requiresWitnesses: 3`).
+- Quorum policy defined by **Law Oracle** (e.g., `requires_witnesses: 3`).
 - **MUST** support **timestamping**, **co-signing**, and **availability proofs**.
 
 ### 5.5 Auditor
@@ -197,8 +197,9 @@ A minimal JSON-LD structure:
   "society": "lct:web4:society:...",
   "targets": ["lct:web4:citizen:..."],
   "scope": ["context:data_analysis"],
-  "basis": ["hash:...","hash:..."],
-  "proposed": {"t3":{"temperament":-0.02}, "v3":{"veracity":-0.03}}
+  "evidence": ["hash:...","hash:..."],
+  "proposed_t3_deltas": {"temperament":-0.02},
+  "proposed_v3_deltas": {"veracity":-0.03}
 }
 ```
 
@@ -295,7 +296,6 @@ ASK {
 | Insufficient scope | W4_ERR_AUTHZ_SCOPE | Deny; suggest correct authority path |
 | Expired delegation | W4_ERR_BINDING_REVOKED | Re‑bind under valid authority |
 
-| Missing witness quorum | W4_ERR_WITNESS_DEFICIT | Refuse; require quorum or fall back to delayed finalize |
 | Ledger write failed | W4_ERR_LEDGER_WRITE | Retry with backoff; degrade to escrow buffer |
 | Audit evidence insufficient | W4_ERR_AUDIT_EVIDENCE | Reject adjustment; request stronger proofs |
 | Law inheritance conflict | W4_ERR_LAW_CONFLICT | Invoke conflictPolicy; request parent/child oracle mediation |


### PR DESCRIPTION
## Summary

Applies the **spec→SDK wire-rename subset** of the 12 C16 audit findings (`docs/audits/sal-internal-consistency-2026-05-27.md`, merged `afd60a48`) to `web4-society-authority-law.md`. SDK = authority for runtime/wire per the C12–C15 precedent.

This is a **partial remediation** — 5 of 12 findings resolved; 7 remain as deliberate deferrals listed below. C16 is the first audit cycle to leave a remainder because half the findings are SDK-side or genuine design questions that require operator/cross-model decisions outside autonomous-session scope.

## Resolved findings (5 of 12)

| Finding | Location | Change | SDK authority |
|---|---|---|---|
| **M7** | §2.2 L57–58 | `initialRights` → `rights`; `initialResponsibilities` → `obligations` | `federation.py:128-129` (default values match exactly) |
| **L2** | §4.1 L151 | Top-level `id` → `law_id` | `federation.py:340` `LawDataset.law_id` (serialized at L773) |
| **M2** | §4.1 L153–155 + §5.4 L185 | List-element `id` → `*_id`; `requiresWitnesses` → `requires_witnesses` (JSON + prose) | `federation.py:707-753` `*_to_dict` serializers |
| **H2** | §5.5 L200–201 | `basis` → `evidence`; flatten nested `proposed:{t3,v3}` → `proposed_t3_deltas`/`proposed_v3_deltas` | `federation.py:226` (`evidence`), L227–228 (`proposed_*_deltas`) in `AuditRequest` |
| **H1 partial** | §9 L298 | Remove duplicate `W4_ERR_WITNESS_DEFICIT` row | — (SAL-internal coherence; see below) |

### Why H1 is partial (per BC#2)

The audit's own remediation guidance for H1 splits the finding cleanly:

> *"WITNESS_DEFICIT → fold into existing `W4_ERR_WITNESS_QUORUM` (same condition, the SAL §9 second row is a duplicate)"*

This is a SAL-internal coherence fix — L294 already covers "Quorum not met" with `W4_ERR_WITNESS_QUORUM`, so the L298 row is a strict duplicate describing the same condition with a non-existent code. Removing it eliminates the intra-§9 contradiction.

This is **distinct** from the add-vs-consolidate design question for the other 3 missing codes (`W4_ERR_LEDGER_WRITE`, `W4_ERR_AUDIT_EVIDENCE`, `W4_ERR_LAW_CONFLICT`) — those need an operator decision on whether to add them to the canonical taxonomy or rewrite §9 to use existing codes (and if so, which existing code maps to each condition).

### Corpus-sweep find: L185 prose `requiresWitnesses`

The corpus-wide grep (BC#6) caught a second occurrence of `requiresWitnesses` at §5.4 L185 (prose example), which the audit's M2 finding cited only at L154 (JSON example). Both occurrences are renamed under the same M2 finding to keep SAL internally consistent post-edit.

## Deferred findings (7 of 12 — all require external decisions)

Per BC#4:

| Finding | Reason deferred |
|---|---|
| **H1 remainder** (3 missing codes: `LEDGER_WRITE`, `AUDIT_EVIDENCE`, `LAW_CONFLICT`) | Add-to-taxonomy vs. reword §9 to use existing codes is a normative-taxonomy design choice. Needs operator decision. |
| **M1** (role taxonomy: SAL §5's 5-role set vs. `society-roles.md`'s 7-base + 2-context set) | `DESIGN-Q` tagged in the audit. SDK carries dual parallel enums (`federation.RoleType` + `role.SocietyRole`). Needs operator/cross-model decision parallel to C15 H1's averaging-vs-accumulating reputation question. |
| **M3** (`r6Bindings` field in SAL §4.1 L156, absent from SDK `LawDataset`) | Either add to SDK (extension) or remove from spec. Design Q + SDK-side. |
| **M4** (Ledger Interface: SAL §3.4 MUSTs `prove`/`events` + `get(hash)`; SDK has `get_entry(id)` + no inclusion proof / topic stream) | Either extend SDK or scope the SAL MUST back. Design Q + SDK-side. |
| **M5** (Event-topic naming: SAL `sal.*` topics vs. SDK `LedgerEventType` enums; SDK missing AUDIT topic) | Reconciliation requires picking a canonical naming scheme + an SDK extension. Design Q. |
| **M6** (`cool_down_period` MUST in SAL §5.5 L208, missing from SDK `AuditAdjustment`) | SDK-side change. Kept out of this spec-only PR. |
| **M8** (§3.3 RDF turtle edges not formalized in canonical ontology; `web4-core-ontology.ttl:195` refers to a missing `sal-ontology.ttl`) | Needs operator coordination with ontology maintainers + `pairedWith` domain reconciliation. |
| **L1** (SDK lacks distinct `BirthCertificate` type; fields conflated into `CitizenshipRecord`) | SDK-side change. |

## Why partial-remediation is the right cut here

C12–C15 each closed all findings in a single PR because every finding was a spec→SDK rename in a clean direction. C16 is structurally different: 7 of 12 findings are either SDK-side, cross-doc, or require normative decisions on terminology/taxonomy. Forcing them into this PR would either:

1. **Self-authorize design decisions** that should be operator/cross-model calls (H1 add-or-consolidate, M1 role taxonomy, M8 ontology promotion), or
2. **Sprawl a single-file spec PR into multi-module multi-spec churn** (M3/M4/M5/M6/L1 all touch the SDK), violating the single-bounded-PR-per-cycle rule.

This PR cleanly captures the unambiguous spec→SDK wire alignments. The deferred set is now a documented operator/next-session backlog.

## Verification

- **`gitnexus_detect_changes`** (BC#7): 0 affected processes; risk LOW; 20 changed symbols are all section headers + the file node itself; markdown-only.
- **No collateral edits** (BC#5): diff is constrained to the 5 in-scope edits + L185 corpus-sweep follow-on. Untouched: §3.3 RDF (M8), §3.4 ledger ops/topics (M4/M5), §5 role taxonomy (M1), §5.5 cool-down language (M6), §2.2 BirthCertificate field set beyond L57-58 (L1), §9 rows L294/L299–301 (H1 remainder).
- **Authority hierarchy explicit** (BC#1): every rename verified against `federation.py` at the line cited in the audit; re-read immediately before the edit.

## Whitepaper publisher no-change check (BC#10)

SAL is `web4-standard/core-spec/`, not whitepaper. These spec edits should observe as a **no-change** for the whitepaper publish track. No whitepaper.sh re-run needed.

## Test plan

- [x] `git diff --stat`: 1 file, 10 insertions, 10 deletions — matches the 5 enumerated edits.
- [x] `gitnexus_detect_changes`: 0 affected processes, risk LOW.
- [x] Corpus-wide grep for renamed terms confirms full SAL-internal coverage (L185 caught and included).
- [x] All renames verified against `federation.py` at the cited lines.
- [ ] (reviewer) confirm partial-cut at H1 is sound (audit-text quote is in §"Why H1 is partial" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)