### PR TITLE
fix(spec): resolve 7 autonomous-actionable C17 dictionary-entities findings; defer 5 (design-Q / ontology / SDK)

### DIFF
--- a/web4-standard/core-spec/dictionary-entities.md
+++ b/web4-standard/core-spec/dictionary-entities.md
@@ -45,7 +45,7 @@ Every Dictionary has:
 
 ```json
 {
-  "lct_id": "lct:web4:dictionary:medical-legal:v2",
+  "lct_id": "lct:web4:dictionary:medical-legal",
   "entity_type": "dictionary",
   "dictionary_spec": {
     "source_domain": "medical",
@@ -64,7 +64,7 @@ Every Dictionary has:
     "context_required": "moderate",
     "ambiguity_handling": "probabilistic"
   },
-  "trust_requirements": {
+  "dictionary_trust_config": {
     "minimum_t3": {
       "talent": 0.8,      // Domain expertise
       "training": 0.9,     // Translation accuracy
@@ -217,7 +217,7 @@ def translate_with_dictionary(request, dictionary):
     )
     
     # 5. Handle ambiguity
-    if target_concepts.ambiguity > threshold:
+    if target_concepts.ambiguity > AMBIGUITY_GATE:
         target_concepts = dictionary.disambiguate(
             target_concepts,
             method="context_aware"
@@ -271,7 +271,7 @@ def translate_with_dictionary(request, dictionary):
   ],
   "cumulative_degradation": 0.126,  // 1 - (0.95 * 0.92)
   "trust_acceptable": true,
-  "witness_attestation": ["lct:web4:witness:domain-expert"]
+  "witnesses": ["lct:web4:witness:domain-expert"]
 }
 ```
 
@@ -314,7 +314,7 @@ def update_dictionary_from_feedback(dictionary, feedback):
     )
     
     # 5. Version update if significant
-    if dictionary.changes > threshold:
+    if dictionary.changes > VERSION_BUMP_DELTA:
         dictionary.create_new_version(
             parent=dictionary.current_version,
             changelog=accumulated_changes
@@ -363,7 +363,7 @@ Find appropriate dictionaries through SPARQL:
 ```sparql
 SELECT ?dictionary ?trust ?coverage WHERE {
   ?dictionary a web4:Dictionary ;
-              web4:sourceDomai "medical" ;
+              web4:sourceDomain "medical" ;
               web4:targetDomain "legal" ;
               web4:coverage ?coverage ;
               web4:trustScore ?trust .
@@ -415,7 +415,9 @@ Every translation follows R6:
   },
   "role": {
     "entity": "lct:web4:dictionary:med-legal",
-    "roleType": "web4:Translator"
+    "roleLCT": "lct:web4:role:dictionary-translator:..."
+    // role value is illustrative; canonical SocietyRole resolution
+    // deferred (see C17 audit H2 role-value DESIGN-Q)
   },
   "request": {
     "action": "translate",
@@ -495,14 +497,27 @@ Dictionaries build trust through:
 Hospital records → Insurance claims → Legal proceedings
 
 ```yaml
-chain:
-  - source: "Patient diagnosed with moderate TBI following MVA"
-  - step1: medical → insurance
+source: "Patient diagnosed with moderate TBI following MVA"
+translation_chain:
+  - step: 1
+    from: medical
+    to: insurance
+    dictionary: lct:web4:dictionary:medical-insurance
     output: "Traumatic brain injury from vehicle accident requiring coverage"
-  - step2: insurance → legal  
+    confidence: 0.94
+    degradation: 0.06
+  - step: 2
+    from: insurance
+    to: legal
+    dictionary: lct:web4:dictionary:insurance-legal
     output: "Plaintiff sustained head trauma with cognitive impairment in collision"
-  cumulative_confidence: 0.88
-  witnesses: [medical_expert, insurance_adjuster, legal_clerk]
+    confidence: 0.94
+    degradation: 0.06
+cumulative_degradation: 0.12  # 1 - (0.94 * 0.94)
+witnesses:
+  - lct:web4:witness:medical-expert
+  - lct:web4:witness:insurance-adjuster
+  - lct:web4:witness:legal-clerk
 ```
 
 ### 10.2 AI Model Bridging


### PR DESCRIPTION
## Summary

Applies the next-session remediation block from the **C17 internal-consistency audit** of `web4-standard/core-spec/dictionary-entities.md` (audit at [`docs/audits/dictionary-entities-internal-consistency-2026-05-27.md`](../blob/main/docs/audits/dictionary-entities-internal-consistency-2026-05-27.md), shipped as PR #241).

Mirrors the **C16 partial-remediation pattern (PR #240)**: ship wire-level fixes that have unambiguous direction; defer items that need ontology / SDK / operator input as a documented backlog. **7 of 10 findings closed in this PR.**

Single-file scope: `web4-standard/core-spec/dictionary-entities.md` only. Diff: **+28 / -13** (well under 50-line scope cap).

## Findings closed (7 of 10)

| ID | Loc | Edit | Rationale |
|----|-----|------|-----------|
| **H1** | §6.1 L366 | `web4:sourceDomai` → `web4:sourceDomain` | One-char typo in SPARQL discovery predicate; next line at L367 already uses correctly-spelled `web4:targetDomain` |
| **H2** field | §7.1 L418 | `roleType` → `roleLCT` | Canonical R6/R7 action shape per C14 H1 anchor (PR #234). LCT-value uses hyphenated `dictionary-translator` placeholder + inline comment explicitly disclaiming normativity — SocietyRole-enum resolution stays a deferred DESIGN-Q (see deferral table) |
| **M2** | §4.3 L274 | `witness_attestation` → `witnesses` | Plural array-of-LCT-refs is corpus-canonical (acp / atp-adp / entity-types / r6 / r7 / reputation-computation / SAL / SOCIETY_SPECIFICATION). Singular `witness_attestation` is reserved by mcp-protocol + schema_registry for object-shaped attestation records |
| **M3** | §2.2 L67 | `trust_requirements` → `dictionary_trust_config` | Disambiguates LCT-default-config shape (§2.2: `{minimum_t3, stake_required}`) from per-request override shape (§4.1: `{minimum_fidelity, require_witness, atp_stake}`). Two-scope distinction is real — parallels C17 audit's DEMOTED #1 on `stake_required` vs `atp_stake` |
| **M5** | §2.2 L48 | `:medical-legal:v2` → `:medical-legal` | The `:v2` segment duplicated the dedicated `version: \"2.3.1\"` field at L54; was the only LCT id in the entire core-spec corpus with such a suffix |
| **L1** | §4.2 L220 + §5.1 L317 | bare `threshold` → `AMBIGUITY_GATE` / `VERSION_BUMP_DELTA` | Named constants in UPPER_SNAKE_CASE matching pseudocode convention; parallels existing `lossy_threshold` (L65) and `proposal_threshold` (L344) pattern |
| **L2** | §10.1 L497-506 | YAML reshape to mirror §4.3 | Array-of-step-objects: `translation_chain[]` with `{step, from, to, dictionary, output, confidence, degradation}`; top-level `cumulative_degradation` (was `cumulative_confidence` — semantic mismatch with §4.3); `witnesses` with full LCT form |

## Deferred (5 items — operator / cross-model / external)

| ID | Reason | Unblocks when |
|----|--------|---------------|
| **M1** | Ontology gap — six `web4:*` predicates in §6.1 SPARQL absent from canonical ontology files | Ontology-maintainer + operator coordinate on `dictionary-ontology.ttl` or `web4-core-ontology.ttl` extension. Parallels C16 M8 |
| **M4** | W4_ERR_DICT_* taxonomy — §4.2 raises bare `IncompetentDictionary` / `InsufficientDictionaryTrust` without W4_ERR_* mapping | DESIGN-Q parallel to C16 H1: add new codes vs map to existing taxonomy. Needs operator decision |
| **M6** | Threshold-semantics design — relationship between T3-minimum (0.9), fidelity floor (0.95), and witness gate (0.95) is undeclared | Needs design clarification, not a mechanical edit. Three values look deliberate but the relationship is never stated |
| **H2 role-value** | Whether `dictionary-translator` (or `dictionary` / `translator`) becomes canonical in `SocietyRole` enum | DESIGN-Q parallel to C16 M1 role-taxonomy reconciliation. Cross-model coordination |
| **INFO1** | SDK Dictionary dataclass absent from `web4-standard/implementation/sdk/web4/` | SDK-track work, separate authorization. Parallels C16 M3/M6/L1 SDK-cluster deferrals |

## Cross-doc observation (out of scope for C17)

**INFO3**: `mcp-protocol.md:306` has an identical stale `roleType` site — `\"roleType\": \"web4:Developer\"`. Not touched here (this is a `dictionary-entities.md` audit; cross-spec edit would expand scope). Flagged for a future MCP-spec audit or a hyper-narrow one-line cleanup PR if operator approves. Same audit-class discipline as PR #122's OutputViolation cross-doc sweep and PR #240's BC#6 corpus check.

## Pre-push BC sweeps (all clear)

- `roleType` post-edit: 0 in dictionary-entities.md (mcp:306 remains as INFO3)
- `sourceDomai\b` post-edit: 0 in spec
- `witnesses` plural: confirmed in 7+ core-spec files (corpus-canonical, ≥3 BC threshold met)
- `lct:web4:dictionary:*:v2`: L48 was the only site (post-edit 0)
- bare `> threshold:`: only L220 + L317 (post-edit 0)
- §4.1 per-request scope verified (`TranslationRequest` top-level shape)

## Test plan

- [ ] Reviewer reads the audit table → confirms 7 closed findings map 1:1 to the spec diff
- [ ] Reviewer confirms each deferred item is genuinely external-blocked, not work-avoidance
- [ ] Reviewer scans diff for unintended edits beyond the 8 sites
- [ ] (Optional) Reviewer evaluates whether the H2 LCT-value placeholder + inline disclaim is the right discipline cut vs. a fully abstract `lct:web4:role:<role_id>` placeholder

## C-series status

- **C12** r6-framework: audit #229 + remediation #231 MERGED
- **C13** t3-v3-tensors: audit #230 + remediation #232 MERGED
- **C14** r7-framework: audit #233 + remediation #234 + r6-sync #235 MERGED
- **C15** reputation-computation: audit #236 + remediation #237 MERGED
- `OutputViolation` cross-doc rename #238 MERGED
- **C16** SAL: audit #239 + partial remediation #240 MERGED (5/12, 7 deferred)
- **C17** dictionary-entities: audit #241 MERGED → **this PR = partial remediation (7/10, 5 deferred)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)