### PR TITLE
fix(spec): resolve 6 autonomous-actionable C18 findings; defer 6 design-Q items

### DIFF
--- a/web4-standard/core-spec/acp-framework.md
+++ b/web4-standard/core-spec/acp-framework.md
@@ -81,7 +81,8 @@ A declarative specification of what an agent intends to accomplish:
     },
     "witnessLevel": 2,
     "humanApproval": {
-      "mode": "auto-if<=10 else prompt",
+      "mode": "conditional",
+      "autoThreshold": 10,
       "timeout": 3600,
       "fallback": "deny"
     }
@@ -159,7 +160,7 @@ Immutable record of action execution:
   },
   "t3v3Delta": {
     "agent": {"t3": {"temperament": +0.01}},
-    "client": {"v3": {"value": +0.02}}
+    "client": {"v3": {"valuation": +0.02}}
   },
   "witnesses": ["lct:web4:witness:A"],
   "ledgerInclusion": {
@@ -245,9 +246,9 @@ def validate_acp_agency(plan, intent):
     if exceeds_caps(intent, grant.resourceCaps):
         raise ResourceCapExceeded()
     
-    # 4. Check witness requirements
-    if len(intent.witnesses) < grant.witnessLevel:
-        raise InsufficientWitnesses()
+    # 4. Witness check deferred to approval-gate phase (§3.2 Approval Gate
+    # state). Witnesses live on Decision (§2.3), not Intent (§2.2); agency
+    # validation only confirms grant scope + caps.
     
     return True
 ```
@@ -296,15 +297,15 @@ def check_law_compliance(plan, law_oracle):
     # 2. Check plan triggers against law
     for trigger in plan.triggers:
         if not law.allows_trigger(trigger):
-            raise IllegalTrigger(trigger)
+            raise ScopeViolation(f"trigger {trigger} not allowed by law")
     
     # 3. Verify resource caps within law limits
     if plan.guards.resourceCaps.max_atp > law.max_atp_per_plan:
-        raise ExcessiveResourceCap()
+        raise ResourceCapExceeded()
     
     # 4. Ensure witness requirements met
     if plan.guards.witnessLevel < law.min_witness_level:
-        raise InsufficientWitnessLevel()
+        raise WitnessDeficit()
     
     return True
 ```
@@ -512,6 +513,14 @@ class PlanExpired(ACPError):
 class LedgerWriteFailure(ACPError):
     """Failed to write to immutable ledger"""
     error_code = "W4_ERR_ACP_LEDGER_WRITE"
+
+class InvalidTransition(ACPError):
+    """Invalid state machine transition"""
+    error_code = "W4_ERR_ACP_INVALID_TRANSITION"
+
+class ResourceCapExceeded(ACPError):
+    """Action exceeds resource caps"""
+    error_code = "W4_ERR_ACP_RESOURCE_CAP_EXCEEDED"
 ```
 
 ### 10.2 Error Recovery


### PR DESCRIPTION
## Summary

Bundles the wire-actionable cluster identified in the C18 audit's implementation-plan summary (`docs/audits/acp-framework-internal-consistency-2026-05-28.md` §"Implementation Plan Summary" L516-528). Mirrors C16 PR #240 + C17 PR #242 graceful-partial-remediation pattern. **Single-file, single-commit, +17/−8 (25 net lines)** — matches the audit's `~25-line diff` estimate exactly.

## Resolved findings (6)

| ID | Site | Fix | Authority |
|----|------|-----|-----------|
| **H1** | §4.1 L250 | `raise InsufficientWitnesses()` → removed as side-effect of M5-partial (entire raise removed when algorithmic correction applied) | §10.1 + §10.2 + SDK `acp.py:101` (`WitnessDeficit`) |
| **H2a** | §5.1 L299 | `IllegalTrigger(trigger)` → `ScopeViolation(f"trigger {trigger} not allowed by law")` | SDK `acp.py:89` |
| **H2b** | §5.1 L303 | `ExcessiveResourceCap()` → `ResourceCapExceeded()` | SDK `acp.py:125` (added to §10.1 via M1) |
| **H2c** | §5.1 L307 | `InsufficientWitnessLevel()` → `WitnessDeficit()` | SDK `acp.py:101` |
| **H3** | §2.1 L84 | `"mode": "auto-if<=10 else prompt"` → `"mode": "conditional", "autoThreshold": 10` | `ApprovalMode` enum at `acp.py:163-168`; JSON-LD schema `acp-jsonld.schema.json:80`; **test vector `acp-jsonld-validation.json:480-491`** (explicitly validates out-of-enum mode values are rejected) |
| **M1** | §10.1 | Added `InvalidTransition` + `ResourceCapExceeded` class definitions | SDK `acp.py:119` + L125 — verbatim per BC#3 |
| **M4** | §2.4 L162 | `"v3": {"value": +0.02}` → `"v3": {"valuation": +0.02}` | Canonical V3 dim per `t3-v3-tensors.md:227-229,532` |
| **M5-partial** | §4.1 L249 | Removed `intent.witnesses` check (field absent from §2.2 Intent shape AND SDK `Intent` dataclass `acp.py:614-633`); replaced with `§3.2 Approval Gate` deferral comment | Reading (a) of audit M5; witnesses live on Decision (§2.3 L135) + ExecutionRecord (§2.4 L164), not Intent |

**Note on H1/M5-partial interaction**: applying M5-partial removes the `raise InsufficientWitnesses()` line entirely, so H1's one-token rename becomes moot. The canonical-`WitnessDeficit`-only invariant of §10.1 + §10.2 + SDK is preserved by removal rather than renaming. Net result is identical to the audit's H1 intent.

**Note on H3 test-vector authority precedent**: this is the first C-series finding where the spec's flagship example fails the spec's OWN shipped conformance test vector. Establishes "shipped test vectors as first-class audit authority" alongside SDK + schema + ontology, surfaced as a KEY pattern in memory exit #127.

## Deferred design-Q findings (6)

Each is enumerated per BC#7 with one-line rationale + cluster membership:

- **M2** — `W4_ERR_ACP_*` + `W4_ERR_AGY_*` error families absent from canonical `errors.md` §2 taxonomy. **Joins the canonical-errors-taxonomy 3-audit cluster**: C16-H1 (`W4_ERR_WITNESS` overlap) + C17-M4 (`W4_ERR_DICT_*`) + C18-M2. Three independent audits flagging the SAME structural gap — strongest operator-decision signal in the C-series.
- **M3** — `resourceCaps` snake_case (`max_atp`) vs. JSON-LD schema + SDK camelCase (`maxAtp`). Cross-corpus per BC#6 — affects r6/r7/entity-types/mcp siblings.
- **M5-shape-extension** — Adding a `witnesses` array to Intent (reading (b) of audit M5). Requires SDK Intent extension + §3.1 lifecycle diagram + §10.2 retry semantics rework.
- **M6** — 12 `acp:` RDF/SPARQL predicates absent from canonical ontology TTLs. **Joins subordinate-ontology cluster**: C16-M8 (SAL) + C17-M1 (dictionary) + C18-M6.
- **M7** — §2.1 Guards integer `witnessLevel: 2` vs. §5.2 structured `witness_requirement` object (types/quorum/byzantine/timeout/fallback). Three options each non-trivial.
- **L1** — §4.2 `proofOfAgency` (camelCase) vs. `mcp-protocol.md` `proof_of_agency` (snake_case) inside the SAME `web4_context` envelope. Same cross-spec cluster as M3.

## Sweep + scope-precision compliance

- **BC#2** corpus sweep: all four undefined exception names (`InsufficientWitnesses`, `IllegalTrigger`, `ExcessiveResourceCap`, `InsufficientWitnessLevel`) existed ONLY at the four cited sites in `acp-framework.md`. Zero sibling-spec extras → BC#9 single-PR scope held.
- **BC#5** V3-dimension `value` sweep: exactly one `"value"` site in this file (L162); it occupies the V3-dimension-name slot. No non-dimension `value` fields existed to preserve. Distinct from C15/exit #121 precedent (where 5 dimension sites coexisted with non-dimension uses).
- **BC#3** SDK signature alignment: added classes match `acp.py:119` (`InvalidTransition`) + L125 (`ResourceCapExceeded`) exactly — same parent class, same error_code constant. Spec's compact style (no blank line before `error_code`) preserved.
- **BC#7** All 6 deferred findings enumerated above with cluster tags.
- **BC#9** Single PR, single file (`web4-standard/core-spec/acp-framework.md` only), single commit (`2416cbe4`).

## C-series status after this PR

- C12 (r6) — audit + remediation **MERGED**
- C13 (t3-v3) — audit + remediation **MERGED**
- C14 (r7) — audit + remediation **MERGED** + r6-sync MERGED
- C15 (reputation-computation) — audit + remediation **MERGED**
- C16 (SAL) — audit + partial remediation (5/12) **MERGED**; 7 design-Q deferred
- C17 (dictionary-entities) — audit + partial remediation (5/10) **MERGED**; 5 design-Q deferred
- C18 (acp-framework) — audit **MERGED** (#243); **partial remediation (6/11) = THIS PR**; 6 design-Q deferred (M2/M3/M5-ext/M6/M7/L1)

## Test plan

- [x] `git diff --stat` confirms +17/−8 = 25 lines (matches audit estimate)
- [x] BC#2 corpus sweep across `web4-standard/` — zero sibling-spec extras for any of the 4 renamed exception names
- [x] BC#5 V3-dim sweep — no scope-precision miss
- [x] BC#3 SDK signature match for `InvalidTransition` + `ResourceCapExceeded` verified against `web4-standard/implementation/sdk/web4/acp.py:119,125`
- [x] BC#4 test vector cited as authority in H3 row
- [x] Post-edit grep for old names (`InsufficientWitnesses` / `IllegalTrigger` / `ExcessiveResourceCap` / `InsufficientWitnessLevel` / `"v3": {"value"` / `"auto-if`) returns ZERO matches in `acp-framework.md`
- [ ] Reviewer: verify §10.1 still parses as Python code block (added 6 lines should be syntactically valid Python class definitions matching pre-existing §10.1 style)
- [ ] Reviewer: confirm `valuation` (vs. `validity`) is the operator's preferred V3 dim choice for M4 — one-token follow-up if not

🤖 Generated with [Claude Code](https://claude.com/claude-code)