### PR TITLE
fix(spec): resolve 6 autonomous-actionable C19 findings; defer 4 design-Q + 3 LOW

### DIFF
--- a/web4-standard/core-spec/multi-device-lct-binding.md
+++ b/web4-standard/core-spec/multi-device-lct-binding.md
@@ -173,7 +173,7 @@ The Root LCT extends the base LCT with device constellation management:
   "device_constellation": {
     "devices": [
       {
-        "device_lct": "lct:web4:device:phone:...",
+        "device_lct_id": "lct:web4:device:phone:...",
         "anchor_type": "phone_secure_element",
         "platform": "ios",
         "enrolled_at": "2026-01-13T00:00:00Z",
@@ -182,7 +182,7 @@ The Root LCT extends the base LCT with device constellation management:
         "status": "active"
       },
       {
-        "device_lct": "lct:web4:device:fido2:...",
+        "device_lct_id": "lct:web4:device:fido2:...",
         "anchor_type": "fido2",
         "transport": "usb",
         "enrolled_at": "2026-01-14T00:00:00Z",
@@ -191,7 +191,7 @@ The Root LCT extends the base LCT with device constellation management:
         "status": "active"
       },
       {
-        "device_lct": "lct:web4:device:laptop:...",
+        "device_lct_id": "lct:web4:device:laptop:...",
         "anchor_type": "tpm2",
         "platform": "linux",
         "enrolled_at": "2026-01-15T00:00:00Z",
@@ -276,7 +276,7 @@ Each device has its own LCT that binds to the root:
 
   "cross_device_witnesses": [
     {
-      "device_lct": "lct:web4:device:laptop:...",
+      "device_lct_id": "lct:web4:device:laptop:...",
       "last_witness": "2026-01-13T11:00:00Z",
       "witness_count": 42,
       "mutual": true
@@ -286,11 +286,18 @@ Each device has its own LCT that binds to the root:
   "device_trust": {
     "anchor_strength": 0.95,
     "attestation_freshness": 0.98,
-    "cross_witness_score": 0.88,
-    "composite": 0.93
-  }
+    "cross_witness_score": 0.88
+  },
+
+  "status": "active"
 }
 ```
+
+**Device lifecycle states**: A device record's `status` field is one of three values:
+
+- `"active"` — Device participates in trust computation, cross-witnessing, and may authorize removal/recovery.
+- `"suspended"` — Device is temporarily excluded from trust computation and cross-witnessing without being permanently revoked. Re-activation by quorum is a future extension; this spec does not define entry/exit transitions for `suspended`. Implementations that do not require suspension semantics MAY treat `suspended` as equivalent to `revoked` for trust-computation purposes.
+- `"revoked"` — Device is permanently removed from the constellation (see §3.5 Device Removal). A revoked device's keys MUST NOT authorize any further operations.
 
 ## 3. Protocols
 
@@ -507,29 +514,28 @@ def cross_witness(device_a, device_b):
     # 2. Sign challenges
     sig_a_for_b = device_a.sign_witness_challenge(
         challenge_b,
-        device_lct=device_a.device_lct
+        device_lct_id=device_a.device_lct_id
     )
     sig_b_for_a = device_b.sign_witness_challenge(
         challenge_a,
-        device_lct=device_b.device_lct
+        device_lct_id=device_b.device_lct_id
     )
 
     # 3. Exchange and verify
-    assert device_a.verify_witness(sig_b_for_a, device_b.device_lct)
-    assert device_b.verify_witness(sig_a_for_b, device_a.device_lct)
+    assert device_a.verify_witness(sig_b_for_a, device_b.device_lct_id)
+    assert device_b.verify_witness(sig_a_for_b, device_a.device_lct_id)
 
     # 4. Record mutual witnessing
     witness_record = {
         "ts": utc_now(),
-        "device_a": device_a.device_lct.lct_id,
-        "device_b": device_b.device_lct.lct_id,
+        "device_a": device_a.device_lct_id,
+        "device_b": device_b.device_lct_id,
         "sig_a": sig_a_for_b,
         "sig_b": sig_b_for_a
     }
 
     # 5. Update cross_device_witnesses in both device LCTs
-    device_a.device_lct.record_cross_witness(device_b.device_lct.lct_id)
-    device_b.device_lct.record_cross_witness(device_a.device_lct.lct_id)
+    record_cross_witness(constellation, device_a.device_lct_id, device_b.device_lct_id, utc_now())
 
     return witness_record
 ```
@@ -549,7 +555,10 @@ def compute_constellation_trust(root_lct):
     """
     Compute aggregate trust from device constellation.
 
-    Key insight: More devices = higher trust ceiling.
+    Per-device trust = anchor_weight × witness_freshness × attestation_freshness.
+    Constellation trust is the weighted average modulated by coherence bonus
+    and cross-witness density, then clamped to the §4.2 anchor-composition-derived
+    ceiling.
     """
     devices = root_lct.device_constellation.devices
     active = [d for d in devices if d.status == "active"]
@@ -557,12 +566,15 @@ def compute_constellation_trust(root_lct):
     if len(active) == 0:
         return 0.0
 
-    # Individual device trust (weighted by anchor strength)
+    # Individual device trust: anchor × witness freshness × attestation freshness.
+    # Anchor strength is incorporated via anchor_weight ONLY (it is not also
+    # contained in a separate `composite` aggregate — see §2.4 device_trust).
     device_trusts = []
     for device in active:
         anchor_weight = ANCHOR_WEIGHTS[device.anchor_type]
-        freshness = compute_witness_freshness(device)
-        device_trust = anchor_weight * freshness * device.device_trust.composite
+        w_fresh = witness_freshness(days_since_last_witness(device))
+        a_fresh = device.device_trust.attestation_freshness
+        device_trust = anchor_weight * w_fresh * a_fresh
         device_trusts.append((device, device_trust, device.trust_weight))
 
     # Weighted average
@@ -576,10 +588,12 @@ def compute_constellation_trust(root_lct):
     # Cross-witness density
     witness_density = compute_cross_witness_density(active)
 
-    # Final constellation trust
-    constellation_trust = min(1.0,
-        base_trust * (1 + coherence_bonus) * (1 + witness_density * 0.1)
-    )
+    # Final constellation trust — clamped to anchor-composition ceiling (§4.2),
+    # NOT to a universal 1.0 cap. The ceiling reflects the security properties
+    # of the actual anchor composition (e.g. a single phone SE caps at 0.75).
+    raw_trust = base_trust * (1 + coherence_bonus) * (1 + witness_density * 0.1)
+    ceiling = constellation_trust_ceiling(root_lct.device_constellation)
+    constellation_trust = min(ceiling, raw_trust)
 
     return constellation_trust
 
@@ -638,7 +652,7 @@ def remove_device(root_lct, device_to_remove, reason, authorizing_devices):
     """
     # 1. Verify quorum
     remaining = [d for d in root_lct.device_constellation.devices
-                 if d.device_lct.lct_id != device_to_remove.lct_id]
+                 if d.device_lct_id != device_to_remove.lct_id]
 
     if len(authorizing_devices) < root_lct.device_constellation.recovery_quorum:
         raise InsufficientQuorumError(
@@ -725,7 +739,7 @@ def recover_identity(root_lct_id, recovery_devices, new_device, society):
     for device in recovery_devices:
         sig = device.sign_recovery_request(recovery_request)
         recovery_signatures.append({
-            "device_lct": device.device_lct.lct_id,
+            "device_lct_id": device.device_lct_id,
             "signature": sig
         })
 
@@ -741,7 +755,7 @@ def recover_identity(root_lct_id, recovery_devices, new_device, society):
 
     # 6. Mark lost devices as revoked
     for device in root_lct.device_constellation.devices:
-        if device.device_lct.lct_id not in [d.device_lct.lct_id for d in recovery_devices]:
+        if device.device_lct_id not in [d.device_lct_id for d in recovery_devices]:
             device.status = "revoked"
             device.revocation.reason = "recovery_revoked"
 
@@ -785,24 +799,30 @@ The multi-device binding adds two dimensions to the T3 tensor:
 |---------------|-----------|
 | Single software key | 0.40 |
 | Single phone SE | 0.75 |
+| Single TPM2 | 0.75 |
 | Single FIDO2 | 0.80 |
 | Phone + FIDO2 | 0.90 |
 | Phone + FIDO2 + TPM | 0.95 |
 | 3+ diverse hardware anchors | 0.98 |
+
+The ceiling is applied by §3.4 `compute_constellation_trust` via
+`constellation_trust_ceiling(constellation)`, which derives the applicable row
+from the anchor composition of the active device set. Implementations MUST use
+the anchor-composition-derived ceiling (not a universal `1.0` cap) when
+clamping the final constellation trust.
 
 ### 4.3 Trust Decay
 
 Devices that haven't been witnessed recently decrease constellation trust:
 
 ```python
-def apply_witness_decay(device):
+def witness_freshness(days_since_witness):
     """
-    Trust decays if device hasn't been witnessed.
+    Trust decay factor based on days since last witness event.
 
-    Half-life: 30 days without witnessing
+    See decay table below. Returns a multiplicative factor in [0.3, 1.0]
+    applied to per-device trust in §3.4.
     """
-    days_since_witness = (utc_now() - device.last_witnessed).days
-
     if days_since_witness <= 7:
         return 1.0
     elif days_since_witness <= 30:
@@ -813,6 +833,11 @@ def apply_witness_decay(device):
         return 0.5
     else:
         return 0.3  # Should probably re-enroll
+
+
+def days_since_last_witness(device):
+    """Convenience: days since this device was last cross-witnessed."""
+    return (utc_now() - device.last_witnessed).days
 ```
 
 ### 4.4 Canonical Terminology and Simulation Parameters
@@ -867,14 +892,18 @@ def default_recovery_quorum(device_count):
     """
     Minimum devices needed for recovery.
 
-    Balances security vs. recoverability.
+    Balances security vs. recoverability. For device_count > 4, the quorum
+    is a true majority: ceil(device_count / 2). Test vectors in
+    `web4-standard/test-vectors/binding/binding-vectors.json` (group
+    `recovery_quorum_calculation`) are normative for the expected values
+    (n=5 → 3, n=6 → 3, n=10 → 5).
     """
     if device_count <= 2:
         return device_count  # All devices required
     elif device_count <= 4:
         return 2
     else:
-        return max(2, device_count // 2)  # Majority
+        return max(2, (device_count + 1) // 2)  # ceil(n/2) = majority
 ```
 
 ### 5.3 Compromise Response


### PR DESCRIPTION
## Summary

Resolves the 6 wire-actionable findings from the C19 audit
(`docs/audits/multi-device-lct-binding-internal-consistency-2026-05-28.md`,
merged in #245): **H1, H2, H3, M1, M2, M6**. Defers 4 cross-corpus/cross-spec
design-Q items (M3, M4, M5, M7) and 3 LOW spec-cleanup items (L1, L2, L3) per
the C-series graceful-partial-remediation pattern (C16, C17, C18).

Single-file change: `web4-standard/core-spec/multi-device-lct-binding.md`.
Diff: +62/−33 (95 changes, 29 net), well under BC#10's 600-line PR ceiling.
File: 1007 → 1036 lines (+29 net, lightly over the ±20 verification target due
to substantive M6 lifecycle prose, §4.2 ceiling MUST-clamp paragraph, and M1
test-vector citation — each justified by audit content).

## Findings Applied (6)

| ID | Severity | Resolution |
|----|----------|------------|
| H1 | HIGH | `device_lct` → `device_lct_id` (string field per SDK); schema rename across §2.3 (3 sites), §2.4 (1 site), §3.6 (1 site); pseudocode field-access rename `device.device_lct.lct_id` → `device.device_lct_id` (11 accesses); §3.3 method-call reframe (`device_lct.record_cross_witness(...)` → module-level `record_cross_witness(constellation, ...)`). Local LCT-object variables left as `device_lct` — they are objects, not the ID field. |
| H2 | HIGH | §3.4 caller and §4.3 definition both unified to `witness_freshness(days_since_witness)` matching SDK `binding.py:214`; new `days_since_last_witness(device)` helper; false "Half-life: 30 days" docstring (actual ≈180d) replaced (BC#9). |
| H3 | HIGH | §3.4 L562-566 trust formula rewritten to 3-factor `anchor × witness_freshness × attestation_freshness` matching SDK `binding.py:465-472`. `device_trust.composite` field DROPPED from §2.4 schema (SDK does not model it). Bundled per BC#2 — schema-drop and formula-rewrite are one structural edit. |
| M1 | MEDIUM | §5.2 L877 `device_count // 2` → `(device_count + 1) // 2  # ceil(n/2) = majority` matching SDK `binding.py:244` and shipped test vector `binding-vectors.json:23-34` (n=5 → 3, n=6 → 3, n=10 → 5). Docstring cites the canonical vector group. |
| M2 | MEDIUM | (a) `Single TPM2 \| 0.75` row added to §4.2 table matching SDK `binding.py:111`. (b) §3.4 final clamp rewritten from `min(1.0, ...)` to `min(constellation_trust_ceiling(constellation), raw_trust)` matching SDK `binding.py:524-528` and test vector `binding-vectors.json:88-99`. (c) Unsupported §3.4 L552 docstring ("Key insight: More devices = higher trust ceiling") replaced with accurate formula description. Bundled per BC#2. |
| M6 | MEDIUM | `SUSPENDED` device state documented in §2.4 schema + prose lifecycle paragraph (3-state enum matching SDK `binding.py:81-86`). Suspension entry/exit transitions explicitly deferred (BC#11 minimal-surface). |

## Findings Deferred (4 design-Q + 3 LOW = 7)

Per BC#6 (cross-corpus normalization is its own scope), these are documented-not-solved in this PR:

| ID | Severity | Reason for Deferral |
|----|----------|----------------------|
| M3 | MEDIUM | `InsufficientQuorumError`, `InsufficientRecoveryQuorum`, `NoHardwareAnchorError` absent from `errors.md` W4_ERR taxonomy. Cross-corpus design-Q (W4_ERR_MULTI_DEVICE_* family or W4_ERR_BINDING_* extensions). |
| M4 | MEDIUM | `LCT-linked-context-token.md` does not acknowledge the §7.1 multi-device extension. Cross-spec reciprocity design-Q (edits the LCT spec, not this one). |
| M5 | MEDIUM | 8 T3 sub-dimensions absent from `t3v3-ontology.ttl`. Cross-corpus ontology design-Q. |
| M7 | MEDIUM | §7.3 ATP costs (10/1/5/20) not aligned with `atp-adp-cycle.md`. Cross-spec design-Q (edits the ATP spec or relabels §7.3 as informational). |
| L1 | LOW | `mutual: true` redundancy. Spec-cleanup; defer to follow-up. |
| L2 | LOW | §2.4 schema omits `revocation` object. Spec-cleanup; defer to follow-up. |
| L3 | LOW | §5.3 "24h review window" unsubstantiated. Spec-cleanup; defer to follow-up. |

## Cross-Audit Cluster Surfacing (BC#7) — Operator-Engagement Candidates

Both clusters are now at **4-audit convergence** — the strongest signals in the entire C-series. Operator engagement on a single normalization PR would resolve all 8 instances at once.

### Canonical-errors-taxonomy cluster (4-audit convergence)
- C16-H1 — `WitnessDeficit` (SAL)
- C17-M4 — bare exceptions without W4_ERR_DICT (dictionary-entities)
- C18-M2 — undefined ACP error classes (acp-framework)
- **C19-M3** — `InsufficientQuorumError`, `InsufficientRecoveryQuorum`, `NoHardwareAnchorError` (multi-device-lct-binding)

### Subordinate-ontology cluster (4-audit convergence)
- C16-M8 — SAL predicates absent
- C17-M1 — 6 dictionary predicates absent
- C18-M6 — 12 ACP predicates absent
- **C19-M5** — 8 T3 sub-dimensions absent (`t3v3-ontology.ttl` extension)

## Test-Vectors-As-Authority Pattern (BC#8)

M1 and M2 both derive from shipped test vectors disagreeing with spec text:
- M1: `binding-vectors.json:23-34` expects `n=5 → 3` (true majority); spec returned 2.
- M2: `binding-vectors.json:88-99` expects 0.75 ceiling for single phone SE; spec capped at 1.0.

C19 is the 2nd C-series spec exhibiting this pattern (after C18-H3 against `acp-jsonld-validation.json`). Establishes test vectors as co-equal canonical authority alongside SDK + JSON-LD schema. Going forward, audits should always check test vectors when present.

## SDK-Side Followup (Flagged, Not Edited)

BC#9 surfaced one SDK-side cleanup: `binding.py:218` carries the same misleading "Half-life: 30 days" docstring reference that was corrected in spec §4.3. SDK was not edited in this PR (spec aligns to SDK is the established direction; SDK behavior matches the corrected table). Flagged as a one-line SDK followup for the next exit on the SDK code-track.

## BC Compliance Summary

| BC | Topic | Compliance |
|----|-------|-----------|
| BC#1 | Placeholder-disclaim | Example LCT URI values preserved byte-identical except field name. ✓ |
| BC#2 | Combinability/structural-bundling | H3 schema-drop+formula-rewrite as one logical edit; M2 (a/b/c) as one cluster. ✓ |
| BC#3 | Pre-edit corpus grep | 26 spec matches confirmed; 0 outside-spec consumers. ✓ |
| BC#4 | SDK-as-canonical | Every wire edit anchored to exact SDK line (179, 214, 244, 465-472, 524-528, 81-86, 111). ✓ |
| BC#5 | H1 sweep verification | Post-edit grep: 0 remaining `device_lct.lct_id`, 0 unrenamed schema fields, 8 remaining bare `device_lct` are legitimate local LCT-object variables. ✓ |
| BC#6 | Documents-not-solves | M3, M4, M5, M7 explicitly deferred with one-line rationale each. ✓ |
| BC#7 | Cross-audit cluster surfacing | Both 4-audit clusters surfaced as operator-engagement candidates. ✓ |
| BC#8 | Test-vectors-as-authority surfacing | M1, M2 derivation called out; pattern strengthened. ✓ |
| BC#9 | Half-life docstring forensics | False "30 days" claim replaced; SDK-side counterpart flagged as followup. ✓ |
| BC#10 | 600-line PR ceiling | +62/-33 = 95 changes, well under. ✓ |
| BC#11 | SUSPENDED minimal-surface | 3-state enum + prose; transition semantics explicitly deferred. ✓ |

## Test Plan

This is a spec-only edit. No runtime behavior changes. Verification is by:
- [x] Diff visual review confirms each edit matches the audit's recommended resolution direction.
- [x] BC#5 sweep: `grep -n "device_lct" web4-standard/core-spec/multi-device-lct-binding.md` returns expected post-edit shape (0 `.lct_id` field accesses, 0 unrenamed schema fields, only legitimate local-variable uses remain).
- [x] BC#10 line budget: `git diff --stat` returns +62/-33, well under 600-line ceiling.
- [ ] Reviewer cross-checks against SDK lines cited in audit (`binding.py:179, 214, 244, 465-472, 524-528, 81-86, 111`) and test vectors (`binding-vectors.json:23-34, 88-99`).
- [ ] Reviewer confirms deferral set (M3, M4, M5, M7, L1, L2, L3) follows the C-series graceful-partial-remediation precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)