### PR TITLE
fix(spec): resolve 8 autonomous-actionable C21 findings in SOCIETY_METABOLIC_STATES.md + 2 parent-doc cross-refs; defer 8 design-Q

### DIFF
--- a/web4-standard/core-spec/SOCIETY_METABOLIC_STATES.md
+++ b/web4-standard/core-spec/SOCIETY_METABOLIC_STATES.md
@@ -17,11 +17,14 @@ Just as biological organisms require different metabolic states to survive and t
 ### 1.2 Biological Inspiration
 
 Each state maps to biological precedents:
-- Sleep cycles for daily rhythms
-- Hibernation for seasonal resource scarcity
-- Torpor for emergency conservation
-- Molting for structural renewal
-- REM/dreaming for memory consolidation
+- Wakeful alertness for full operations (Active)
+- Light sleep for predictable low-activity periods (Rest)
+- Slow-wave sleep for scheduled downtime (Sleep)
+- Bear-style hibernation for seasonal resource scarcity (Hibernation)
+- Hummingbird torpor for emergency conservation (Torpor)
+- Snail-style estivation for adverse-environment survival (Estivation)
+- REM/dreaming for memory consolidation (Dreaming)
+- Crab molting for structural renewal (Molting)
 
 ---
 
@@ -72,7 +75,7 @@ Each state maps to biological precedents:
 - Wake triggers monitored
 
 **Energy Cost**: 15% of baseline
-**Biological Analog**: Deep sleep with REM cycles
+**Biological Analog**: Deep non-REM (slow-wave) sleep
 **Use Case**: Weekends, holidays, scheduled maintenance
 
 ### 2.4 Hibernation State (Extended Dormancy)
@@ -150,6 +153,7 @@ Each state maps to biological precedents:
 - Citizenship review and renewal
 - Temporary performance degradation
 - Heightened security during transition
+- Temporary trust-tensor penalty of -20% applied during transition (see §5.1)
 
 **Energy Cost**: 60% of baseline
 **Biological Analog**: Crab molting its shell
@@ -166,10 +170,10 @@ From State → To State: Trigger Condition
 ─────────────────────────────────────────
 Active → Rest: 1 hour no transactions
 Active → Sleep: Scheduled time reached
-Active → Torpor: ATP reserves < 10%
+Active → Torpor: ATP reserves < 10% (see §4.1 triggers.torpor)
 Active → Dreaming: Maintenance window
 Active → Molting: Governance change approved
-Active → Estivation: Threat detected
+Active → Estivation: Threat detected (threat_score > 80, see §4.1 triggers.estivation)
 
 Rest → Active: Transaction received
 Rest → Sleep: 6 hours no activity
@@ -177,12 +181,12 @@ Rest → Sleep: 6 hours no activity
 Sleep → Active: Wake trigger fired
 Sleep → Hibernation: 30 days no activity
 
-Hibernation → Active: External witness or timeout
+Hibernation → Active: External witness, new_citizen trigger, or 90-day timeout (see §4.1 triggers.hibernation.wake_on)
 
 Torpor → Active: Energy producer recharges
 Torpor → Hibernation: Grace period expired
 
-Estivation → Active: Threat resolved
+Estivation → Active: Threat resolved (threat_score < 20, see §4.1 triggers.estivation.clear)
 Estivation → Hibernation: Extended duration
 
 Dreaming → Active: Consolidation complete
@@ -204,6 +208,8 @@ Each transition MUST:
 ## 4. Implementation
 
 ### 4.1 Configuration Schema
+
+The following YAML is illustrative of a society's metabolic configuration. The `triggers` block shows quantitative thresholds for three state classes (hibernation, torpor, estivation); states not listed (active, rest, sleep, dreaming, molting) use the schedule-driven or event-driven transitions specified in §3.1. Implementations MAY extend `triggers` to cover additional states; the §3.1 transition matrix is the normative source of trigger semantics.
 
 ```yaml
 society_metabolic_config:
@@ -290,7 +296,7 @@ class SentinelWitness:
 | Rest | 90% update rate | Slightly delayed |
 | Sleep | 10% decay rate | Minimal activity |
 | Hibernation | Frozen | Preserved state |
-| Torpor | Frozen + Alert bonus | Crisis response |
+| Torpor | Frozen | Crisis response |
 | Estivation | Internal only | Defensive mode |
 | Dreaming | Recalibration | Pattern recognition |
 | Molting | -20% temporary | Vulnerable period |
@@ -329,11 +335,13 @@ def calculate_metabolic_reliability(society):
 
 ### 6.1 ATP Cost by State
 
-Societies pay different ATP costs based on metabolic state:
+Societies pay different ATP costs based on metabolic state. With `Baseline` expressed per hour (see §4.1 `energy.baseline_cost`):
 
 ```
-Daily ATP Cost = Baseline * State_Multiplier * Society_Size
+Hourly ATP Cost = Baseline * State_Multiplier * Society_Size
 ```
+
+For longer periods, multiply by the number of hours elapsed in the given state.
 
 ### 6.2 Wake Penalties
 
@@ -414,6 +422,23 @@ Metabolic states transform Web4 Societies from always-on resource consumers into
 - Scale sustainably
 
 The principle that "idle isn't" acknowledges the constant energy cost of maintaining coherent presence in distributed systems, while these metabolic states provide mechanisms to modulate that cost based on actual needs.
+
+---
+
+## 10. Conformance
+
+Implementations of this specification SHOULD validate against the canonical test vector suite at:
+
+- `web4-standard/test-vectors/metabolic/society-metabolic-states.json`
+
+The suite contains 12 vectors across four categories:
+
+- **Energy-cost computation** per §6.1 — 3 vectors (active, rest, torpor)
+- **Wake-penalty calculation** per §6.2 — 3 vectors (sleep, hibernation, dreaming)
+- **Transition validity** per §3.1 — 4 vectors (valid and invalid transitions, including self-transition rejection)
+- **Metabolic-reliability scoring** per §5.2 — 2 vectors (all-factors-met and no-factors-met)
+
+Cross-language reimplementations MUST produce numerically equal results to the vector expectations for the deterministic cases (energy cost, wake penalty, transition matrix membership). The reliability-score vectors use the §5.2 weights as written. Coverage is currently 6 of 8 states (estivation and molting are not exercised by the current vector set); future vector additions SHOULD close this gap.
 
 ---
 

--- a/web4-standard/core-spec/SOCIETY_SPECIFICATION.md
+++ b/web4-standard/core-spec/SOCIETY_SPECIFICATION.md
@@ -69,6 +69,12 @@ For a collective to constitute a Society, it MUST have:
    - Trust relationships form
 ```
 
+### 1.4 Operational Modes (Metabolic States)
+
+A society in the Operational Phase does not run at a single fixed activity level. Web4 defines eight **metabolic states** (Active, Rest, Sleep, Hibernation, Torpor, Estivation, Dreaming, Molting) that modulate consensus participation, witness duty cycles, ATP/ADP flow, trust-tensor updates, and citizenship acceptance based on activity demand, resource availability, and operational conditions. The metabolic-state subsystem is normative for societies running long-lived operations; it determines which transactions a society accepts at a given time, what its instantaneous energy cost is, and what trust effects (update rate, decay rate, temporary penalty) apply during the current state.
+
+The full normative definition — including state characteristics, transition rules, configuration schema, trust adjustments, and economic implications — is given in `web4-standard/core-spec/SOCIETY_METABOLIC_STATES.md`. Implementations of this Society Specification MUST also conform to the metabolic-states specification for any society that intends to operate beyond a single bootstrap window.
+
 ---
 
 ## 2. Citizenship

--- a/web4-standard/core-spec/web4-society-authority-law.md
+++ b/web4-standard/core-spec/web4-society-authority-law.md
@@ -131,6 +131,15 @@ effectiveLaw(child) = merge(parentLaw, childOverrides) with conflictPolicy
 ```
 where `conflictPolicy` is machine-readable in law dataset.
 
+### 3.6 Metabolic State Considerations — **SHOULD**
+SAL governance actions interact with a society's operational mode as defined in `web4-standard/core-spec/SOCIETY_METABOLIC_STATES.md`. Eight metabolic states (Active, Rest, Sleep, Hibernation, Torpor, Estivation, Dreaming, Molting) govern when consensus runs, which witnesses are on duty, and which actions a society accepts. Several SAL-critical actions are sensitive to the current state:
+
+- **Law dataset amendments** (norm/procedure/interpretation publication per §4) SHOULD occur during the **Molting** state, which is explicitly defined as the vulnerable-transition state for "Society laws under active revision" (see §2.8 of `SOCIETY_METABOLIC_STATES.md`). Amendments attempted during dormant states (Sleep, Hibernation, Torpor, Estivation) MAY be queued for processing at the next Active/Molting cycle rather than rejected outright.
+- **Citizenship issuance** (§2.1 Birth Certificate) is sensitive to `accepts_new_citizens` per state — Active SHOULD accept immediately; Rest MAY queue; dormant states SHOULD defer.
+- **Witness quorum requirements** (§3.1) scale down during reduced-operation states; sub-authorities MUST verify that the current state supports the quorum required for their action before issuing.
+
+Implementations MAY treat the metabolic-state check as a precondition of the R6 evaluation pipeline (§6) so that state-incompatible actions are rejected with a clear error before law evaluation runs.
+
 
 ---
 


### PR DESCRIPTION
## Summary

C21 remediation per audit doc `docs/audits/C21-society-metabolic-states-audit-2026-05-29.md` (PR #249, merged `d5bdd37d`). Applies the 8 autonomous-actionable C21 findings across 3 spec files and defers the 8 design-Q findings to operator engagement. Follows the established C16/C17/C18/C19/C20 graceful-partial-remediation pattern (9th repetition).

- **Files changed**: 3 (target spec + 2 parent specs); 0 new files; 0 SDK/ontology/test-vector edits
- **Net diff**: +53 / -13 lines
- **Pattern**: matches C16-C20 partial-remediation precedent (autonomous fixes shipped; design-Q deferred with explicit manifest)

## Findings applied (8)

| ID | Severity | File | Resolution |
|---|---|---|---|
| H2 | HIGH | SOCIETY_METABOLIC_STATES.md §1.2 | Extended biological-inspiration list from 5/8 to 8/8 entries; the "Each state maps to" universal claim is now backed |
| M1 | MEDIUM | SOCIETY_SPECIFICATION.md §1.4 + web4-society-authority-law.md §3.6 | **1 finding, 2 sister-file cross-refs added**. Substantive paragraphs (≥2 sentences each), naming all 8 metabolic states and citing the spec path |
| M2 | MEDIUM | SOCIETY_METABOLIC_STATES.md §5.1 | Stripped "+ Alert bonus" phantom feature from Torpor row (was undefined in §2.5 body and elsewhere) |
| M4 | MEDIUM | SOCIETY_METABOLIC_STATES.md §6.1 | Relabeled "Daily ATP Cost" → "Hourly ATP Cost" to match §4.1 `baseline_cost: "100 ATP/hour"`; added hours-elapsed multiplier note |
| M6 | MEDIUM | SOCIETY_METABOLIC_STATES.md §10 (new) | Added Conformance section citing `web4-standard/test-vectors/metabolic/society-metabolic-states.json` with 4-category breakdown, vector count (12), and explicit 6/8 state-coverage gap (estivation + molting not exercised) |
| M8 | MEDIUM | SOCIETY_METABOLIC_STATES.md §3.1 + §4.1 | Cohesive matrix+schema edit: §3.1 imports §4.1 thresholds (threat_score>80 for Estivation, threat_score<20 for clear, 90d timeout + new_citizen trigger for Hibernation); §4.1 gets explicit illustrative-vs-normative note |
| L1 | LOW | SOCIETY_METABOLIC_STATES.md §2.3 | Sleep biological analog "Deep sleep with REM cycles" → "Deep non-REM (slow-wave) sleep" to disambiguate from §2.7 Dreaming "REM sleep" |
| L6 | LOW | SOCIETY_METABOLIC_STATES.md §2.8 | Added "-20% trust-tensor penalty during transition (see §5.1)" characteristic to ground the §5.1 table's previously-orphan magic number |

## Deferred (Design-Q, operator engagement) — 8

| ID | Rationale |
|---|---|
| H1 | Sleep state's `update_rate` vs `decay_rate` axis disambiguation — requires operator decision on whether Sleep accepts updates at all; §5.1 column redesign territory |
| H3 | §5.1 single-column trust-effect → multi-column redesign — requires operator decision on what semantic axes are normative |
| M3 | Emergency-state (Torpor/Estivation) entry from non-Active states — may be intentional Active-only design to avoid emergency-state oscillation |
| M5 | "Dormant" semantics undefined; spec ↔ SDK `DORMANT_STATES` partition divergence (Dreaming) — requires operator decision on canonical partition |
| M7 | **→ carry-NEW-A subordinate-ontology TTL bundle**. `web4:MetabolicState` and related predicates absent from `web4-core-ontology.ttl`. 6th C-series audit identifying this cluster (C16-M8 + C17-M1 + C18-M6 + C19-M5 + C20-M5 + C21-M7); past 5-audit operator-engagement threshold; bundled TTL PR is the right vehicle |
| L4 | Estivation 10% < Sleep 15% energy ordering — needs prose justification or transposition; operator design call |
| L5 | Rest "queued for active period" (spec) vs SDK `accepts_new_citizens(REST)=False` — API-contract decision (queued-acceptance vs refusal) |
| L7 | Wake-penalty coverage gap (no penalty defined for Torpor/Estivation/Molting) — operator decision whether to extend or document the omission |

## Cross-track note (BC#2)

SDK `web4-standard/implementation/sdk/web4/metabolic.py:110` retains the description string `Frozen + alert bonus` as faithful-to-spec illustrative text. The M2 spec edit (removing "+ Alert bonus" from §5.1 table) makes the spec authoritative for Torpor's trust-effect semantics without forcing SDK churn. The SDK string is descriptive prose, not a normative interface — leaving it removes a fresh-drift risk; a future SDK-side audit cycle may align the description string. No cross-track follow-up required for this PR.

## BC#6 pre-finalization corpus sweep

Per the mandatory sweep discipline (default since #132), swept the full target spec post-edits for:

- **Other 5/8 truncation sites** (H2 pattern): none — `Each state` claim now backed by 8 entries; no other universal claims with truncated coverage.
- **Other phantom-feature strings** (M2 pattern): none — `Alert bonus` no longer in spec; no other unbacked feature mentions like "X bonus" or comparable.
- **Other "Daily"/"Hourly" unit mismatches** (M4 pattern): none — `Daily ATP Cost` was the only instance.
- **Other Sleep/Dreaming REM ambiguity sites** (L1 pattern): the only two REM-bearing analogs are §2.3 Sleep (now "Deep non-REM (slow-wave) sleep") and §2.7 Dreaming ("REM sleep") — properly disambiguated after L1 fix.

**Sweep result**: no audit-undercalls. The 8 applied findings cover the spec's known consistency-defect surface for autonomous remediation.

## BC#3 line-citation sweep

The 3 target spec files were unmodified between the C21 audit (`b6383e71` at audit time) and this remediation. Spec history confirms the most recent prior edit was `3e152e02` (C16 SAL remediation, distinct files). All audit-time line citations were stable through to remediation; the audit's `L<n>` references applied cleanly to the pre-edit spec, and remediation edits land in the cited ranges. No off-by-one drift detected.

## Audit reference

- Audit doc: `docs/audits/C21-society-metabolic-states-audit-2026-05-29.md`
- Audit PR: #249 (merged as `d5bdd37d`)
- Findings summary table: §3 of the audit doc (16 actionable + 6 INFO + 2 DEMOTED)

## Test plan

- [ ] Verify SOCIETY_METABOLIC_STATES.md §1.2 lists 8 biological precedents (one per state)
- [ ] Verify §5.1 Torpor row reads "Frozen | Crisis response" (no "+ Alert bonus")
- [ ] Verify §6.1 reads "Hourly ATP Cost" + hours-elapsed note
- [ ] Verify §3.1 matrix Hibernation entry includes "90-day timeout" + "new_citizen trigger"
- [ ] Verify §4.1 has the illustrative-vs-normative paragraph before the YAML block
- [ ] Verify §2.3 Sleep analog reads "Deep non-REM (slow-wave) sleep"
- [ ] Verify §2.8 Molting characteristics includes the "-20% trust-tensor penalty" line
- [ ] Verify new §10 Conformance section cites the test vector path with 12 vectors / 4 categories
- [ ] Verify SOCIETY_SPECIFICATION.md has new §1.4 paragraph naming all 8 states + spec-path link
- [ ] Verify web4-society-authority-law.md has new §3.6 paragraph naming all 8 states + spec-path link + Molting-for-amendments guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)