### PR TITLE
fix(spec): resolve 6 autonomous-actionable C24 findings in LCT spec; defer 4 design-Q + 2 SDK cross-track

### DIFF
--- a/web4-standard/core-spec/LCT-linked-context-token.md
+++ b/web4-standard/core-spec/LCT-linked-context-token.md
@@ -1,7 +1,7 @@
 # Linked Context Token (LCT) - Core Specification
 
 **Status**: Core Specification v1.0.0
-**Date**: October 1, 2025
+**Date**: May 31, 2026
 **Category**: Identity & Context
 
 ## Abstract
@@ -59,6 +59,8 @@ LCTs MAY contain:
 
 ```json
 {
+  "@context": ["https://web4.io/contexts/lct.jsonld"],
+  "@type": "web4:LinkedContextToken",
   "lct_id": "lct:web4:mb32:...",
   "subject": "did:web4:key:z6Mk...",
 
@@ -136,7 +138,7 @@ LCTs MAY contain:
         "creative_problem_solving": 0.80
       }
     },
-    "composite_score": 0.84,
+    "composite_score": 0.85,
     "last_computed": "2025-10-01T00:00:00Z",
     "computation_witnesses": ["lct:web4:oracle:trust:..."]
   },
@@ -151,7 +153,7 @@ LCTs MAY contain:
         "reproducibility": 0.88
       }
     },
-    "composite_score": 0.81,
+    "composite_score": 0.85,
     "last_computed": "2025-10-01T00:00:00Z",
     "computation_witnesses": ["lct:web4:oracle:value:..."]
   },
@@ -236,9 +238,10 @@ def create_lct_binding(entity_type, private_key, hardware_anchor=None):
     """
     Create cryptographic binding for LCT.
 
-    Returns: (lct_id, binding_object, binding_proof)
+    Returns: (lct_id, binding_object) — binding_proof is embedded inside binding_object
+    per §2.3 canonical structure.
     """
-    # 1. Create canonical binding structure
+    # 1. Create canonical binding structure (binding_proof added in step 3)
     binding = {
         "entity_type": entity_type,
         "public_key": multibase_encode(cose_key(private_key.public_key)),
@@ -246,16 +249,17 @@ def create_lct_binding(entity_type, private_key, hardware_anchor=None):
         "created_at": utc_now()
     }
 
-    # 2. Serialize with deterministic CBOR
+    # 2. Serialize with deterministic CBOR (proof input excludes binding_proof itself)
     binding_cbor = cbor_deterministic_encode(binding)
 
-    # 3. Sign with entity's private key
-    binding_proof = cose_sign1(private_key, binding_cbor)
+    # 3. Sign with entity's private key and EMBED proof in the binding object
+    #    (matches §2.3 canonical structure where binding_proof is a FIELD of binding)
+    binding["binding_proof"] = cose_sign1(private_key, binding_cbor)
 
     # 4. Generate LCT ID from binding proof hash
-    lct_id = "lct:web4:" + multibase32_encode(sha256(binding_proof))
+    lct_id = "lct:web4:" + multibase32_encode(sha256(binding["binding_proof"]))
 
-    return lct_id, binding, binding_proof
+    return lct_id, binding
 ```
 
 ## 4. Birth Certificate as Foundational Identity
@@ -378,6 +382,14 @@ Every LCT MUST contain a `t3_tensor` with the three canonical root dimensions. E
 - **Training**: Has it learned how? (knowledge/experience)
 - **Temperament**: Will it behave appropriately? (disposition/reliability)
 
+**Canonical weights** (normative): Implementations MUST compute `composite_score` as a weighted sum of the three root dimensions:
+
+```
+composite_score = 0.4 · talent + 0.3 · training + 0.3 · temperament
+```
+
+Each root dimension is itself an aggregate over its (optional) RDF sub-graph of sub-dimensions; sub-dimension aggregation into roots is implementation-defined (typically arithmetic mean of leaves linked via `web4:subDimensionOf`). Computed composites are therefore in `[0.0, 1.0]` whenever roots are.
+
 **Computation**: Societies or trust oracles compute T3 tensors based on:
 - Historical behavior
 - Witness attestations
@@ -406,6 +418,14 @@ Every LCT MUST contain a `v3_tensor` with the three canonical root dimensions, f
 - **Valuation**: How is value assessed? (subjective worth)
 - **Veracity**: How truthful are claims? (accuracy/reproducibility)
 - **Validity**: How sound is the reasoning? (confirmed value delivery)
+
+**Canonical weights** (normative): Implementations MUST compute `composite_score` as a weighted sum of the three root dimensions:
+
+```
+composite_score = 0.3 · valuation + 0.35 · veracity + 0.35 · validity
+```
+
+Sub-dimension aggregation into roots mirrors the T3 pattern (implementation-defined; typically arithmetic mean of leaves linked via `web4:subDimensionOf`). Because `valuation` is permitted to exceed `1.0` (see comment above), the composite arithmetic CAN exceed `1.0` in pathological cases; behavior under that condition (clamp at `1.0`, rescale, or extend the composite range) is currently underspecified and tracked as a known design question.
 
 **Computation**: Societies or value oracles compute V3 tensors based on:
 - Energy economics (ATP/ADP)
@@ -587,15 +607,21 @@ def validate_lct(lct):
             for p in lct["mrh"]["paired"]
         )
 
-    # Tensor validation
-    validate_t3_tensor(lct["t3_tensor"])
-    validate_v3_tensor(lct["v3_tensor"])
+    # Tensor validation (implementation-defined helpers — see expected semantics below)
+    validate_t3_tensor(lct["t3_tensor"])   # implementation-defined
+    validate_v3_tensor(lct["v3_tensor"])   # implementation-defined
 
-    # Binding proof verification
-    verify_binding_proof(lct["binding"], lct["binding"]["binding_proof"])
+    # Binding proof verification (implementation-defined — see expected semantics below)
+    verify_binding_proof(lct["binding"], lct["binding"]["binding_proof"])   # implementation-defined
 
     return True
 ```
+
+**Implementation-defined helpers** (expected semantics for the three calls above):
+
+- `validate_t3_tensor(t3)`: MUST check that `talent`, `training`, `temperament` are present and each in `[0.0, 1.0]`; that `composite_score` is in `[0.0, 1.0]` and matches the §6.1 canonical weight formula within a documented tolerance (e.g. ±0.01 for rounding); and that any `sub_dimensions` entries are valid `web4:subDimensionOf` RDF sub-graphs of the corresponding root.
+- `validate_v3_tensor(v3)`: MUST check that `valuation` ≥ `0.0` (per §6.2 it MAY exceed `1.0`); that `veracity` and `validity` are each in `[0.0, 1.0]`; that `composite_score` matches the §6.2 canonical weight formula within tolerance; and (as above) that any sub-dimensions are valid RDF sub-graphs.
+- `verify_binding_proof(binding, binding_proof)`: MUST verify that `binding_proof` is a valid COSE_Sign1 signature over the deterministic CBOR encoding of `binding` (with `binding_proof` itself excluded from the signed input) using the public key in `binding.public_key`, per the §3.3 binding algorithm.
 
 ### 11.2 Birth Certificate Validator
 
@@ -654,12 +680,14 @@ def validate_birth_certificate(lct):
 - **R6 Framework**: `core-spec/r6-framework.md`
 - **SAL Specification**: `core-spec/web4-society-authority-law.md`
 - **ATP/ADP Cycle**: `core-spec/atp-adp-cycle.md`
+- **Entity Types**: `core-spec/entity-types.md`
+- **LCT Capability Levels**: `core-spec/lct-capability-levels.md`
 - **LCT Protocol Details**: `protocols/web4-lct.md`
 
 ---
 
 **Version**: 1.0.0
 **Status**: Core Specification
-**Last Updated**: October 1, 2025
+**Last Updated**: May 31, 2026
 
 *"An LCT is not an identity. It is a presence - witnessed, contextualized, and witness-hardened."*


### PR DESCRIPTION
## Summary

Applies the autonomous-actionable subset (**6 of 12**) from the C24 audit (`docs/audits/C24-lct-linked-context-token-audit-2026-05-31.md`, PR #255, merged `dda36bad`). DESIGN-Q items (H1, M4, M6, L3) require operator engagement; SDK cross-track items (M2, M3) defer to SDK sprint planning.

Per **BC-C23-5** (anti-padding): 6 honest items, no DESIGN-Q or cross-track padding. Count of 6 sits inside the C16-C23 autonomous-actionable envelope (5/5/6/6/7/8/8/3+1).
Per **BC#15** (date discipline): only LCT spec dates bumped; no sister-doc date bumps.

## Findings applied — single file `web4-standard/core-spec/LCT-linked-context-token.md`

| ID | Sev | Loc | Action |
|----|-----|-----|--------|
| M1 | MED | §3.3 | Move ``binding_proof`` inside ``binding`` dict; return ``(lct_id, binding)``; matches §2.3 + SDK ``Binding`` dataclass |
| M5a | MED | §6.1 | Add normative **Canonical weights**: ``composite_score = 0.4·talent + 0.3·training + 0.3·temperament`` (matches SDK ``T3_WEIGHTS``) |
| M5b | MED | §6.2 | Add normative **Canonical weights**: ``composite_score = 0.3·valuation + 0.35·veracity + 0.35·validity`` (matches SDK ``V3_WEIGHTS``); cross-reference L3 DESIGN-Q for ``valuation > 1.0`` behavior |
| M5c | MED | §2.3 L139 | T3 ``composite_score`` 0.84 → 0.85 (verified arithmetic: 0.4·0.85 + 0.3·0.92 + 0.3·0.78 = 0.850) |
| M5d | MED | §2.3 L154 | V3 ``composite_score`` 0.81 → 0.85 (verified arithmetic: 0.3·0.89 + 0.35·0.91 + 0.35·0.76 ≈ 0.852) |
| L1 | LOW | §11.1 | Mark three helper calls ``# implementation-defined``; add stub-paragraph defining expected semantics of ``validate_t3_tensor``, ``validate_v3_tensor``, ``verify_binding_proof`` |
| L2 | LOW | §13 | Add ``entity-types.md`` + ``lct-capability-levels.md`` (both cited normatively in body) |
| L4 | LOW | §2.3 | Add ``@context`` + ``@type`` to canonical example (matches SDK ``to_jsonld()`` + 10/10 published vectors) |
| INFO1 | INFO | L4, L663 | Date bump ``October 1, 2025`` → ``May 31, 2026`` per BC#15 |

(M1, M5a-d, L1, L2, L4, INFO1 = 6 PR-table entries; M5 = single audit finding split into 4 coupled edits per BC#1.)

## Deferred — out of scope this PR

- **H1** (HIGH, DESIGN-Q): LCT-ID format **4-way divergence** — §2.3 example ``lct:web4:mb32:<x>`` vs §3.3 algorithm ``lct:web4:<x>`` vs SDK ``lct:web4:<entity>:<sha256hex16>`` vs vectors (mostly SDK shape; 1 outlier). Requires normative decision on canonical wire shape.
- **M2, M3** (cross-track SDK): ``LCT.create()`` does NOT populate ``mrh.witnessing`` (per §3.1 step 5) or auto-create attestations from ``birth_witnesses`` (per §4.2 item 3). Bundle for SDK sprint planning.
- **M4, M6** (DESIGN-Q): ``SUSPENDED`` status undocumented in spec but exercised by published vector 008; ``superseded`` is a STATUS in §7.3 vs REASON in §7.4 vs absent from SDK. **Form a coherent revocation-taxonomy sub-cluster** — resolve together.
- **L3** (DESIGN-Q): V3 ``valuation`` range ``0.0+`` vs ``composite_score`` capped ``0.0-1.0`` — composite-of-mixed-range behavior unspecified (clamp / rescale / extend?). M5b adds a cross-reference; full resolution requires design decision.

## Cross-track cite-only (BC-C23-1 firewall)

- **C23-H1** BirthCertificate 3-way shape drift (SAL §2.2 vs LCT-spec inline vs SDK) — LCT spec is leg (b) of C23-H1's divergence; not re-issued here. Any future LCT-spec birth_certificate inline-example change MUST coordinate with whichever resolution C23-H1 receives.

## Demoted (BC-C23-3 cluster cap)

- **D1** ontology L219 dangling ``web4:Web4BirthCertificate`` reference — already in C16-M8 / C23-D2 subordinate-ontology cluster (7 audits; capped per BC-C23-3).

## Disciplines applied

- **BC#2/BC#3**: each cited block re-read at HEAD before edit
- **BC#5** (pre + post): corpus-swept ``0.84`` / ``0.81`` / three helper names / ``October 1, 2025`` / ``@context`` — all sites unique; post-edit sweep confirms 0 stale instances
- **BC#14** (SDK verification at remediation-write): ``T3_WEIGHTS`` & ``V3_WEIGHTS`` (``trust.py:77-78``), ``LCT_JSONLD_CONTEXT`` (``lct.py:45``), ``@type`` (``lct.py:545``) all confirmed
- **BC#15** (date discipline): ONLY LCT spec dates bumped; no sister-doc date bumps

## Diff

- Files changed: **1** (``web4-standard/core-spec/LCT-linked-context-token.md``)
- Lines: **+44 / -16** (net +28; 665 → 693)
- New files: **0** (well under the 5-file session cap)

## Test plan

- [x] Each edit verified line-by-line against audit text
- [x] Arithmetic for M5c/M5d verified to ±0.001 (T3: 0.850 exact; V3: 0.8515)
- [x] BC#5 corpus re-sweep post-edit (0 stale ``0.84`` / ``0.81`` / ``October 1, 2025``)
- [x] SDK constants verified at remediation-write (BC#14)
- [x] No SDK code changed (M2/M3 SDK-track deferred cleanly)
- [x] No test vectors changed (M4 vector 008 design-Q deferred cleanly)
- [x] No sister specs touched (BC#15 date discipline; BC-C23-1 cross-doc firewall)

## Refs

- **C24 audit**: `docs/audits/C24-lct-linked-context-token-audit-2026-05-31.md` (PR #255, merged `dda36bad`)
- **Session log**: `private-context/autonomous-sessions/legion-web4-20260531-120057-session.md`
- **Cadence**: continues C-series internal-consistency cycle (C12-C24 audits merged; C12-C23 remediations merged; this is C24 remediation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)