### PR TITLE
fix(spec): resolve 4 autonomous-actionable C27 findings in core-protocol.md; defer 4 design-Q + 1 cross-track

### DIFF
--- a/web4-standard/core-spec/core-protocol.md
+++ b/web4-standard/core-spec/core-protocol.md
@@ -1,6 +1,10 @@
 # Web4 Core Protocol Specification
 
-This document provides the detailed specification for the Web4 core protocol, including the handshake and pairing process, messaging protocol, data formats, and URI scheme.
+Status: Draft • Last-Updated: 2026-06-02
+
+This document provides the detailed specification for the Web4 core protocol, including the handshake, pairing methods, messaging protocol, data formats, and URI scheme.
+
+> **Pairing mechanics** beyond method selection (binding, presence, and witnessing flows) are normatively specified in [`entity-types.md`](entity-types.md) and [`presence-protocol.md`](presence-protocol.md); this document covers only the available pairing *methods* (§2.1).
 
 
 
@@ -50,7 +54,7 @@ ClientFinished
 [Application Data]         <------->         [Application Data]
 ```
 
-### 1.3. Pairing Methods
+### 2.1. Pairing Methods
 
 Web4 supports multiple pairing methods to accommodate different use cases:
 
@@ -61,18 +65,18 @@ Web4 supports multiple pairing methods to accommodate different use cases:
 
 
 
-## 2. Messaging Protocol
+## 3. Messaging Protocol
 
 Once a secure channel has been established, Web4 entities can exchange messages. The Web4 messaging protocol is designed to be simple, efficient, and extensible, supporting a variety of message types and content formats.
 
-### 2.1. Message Structure
+### 3.1. Message Structure
 
 A Web4 message consists of a header and a payload:
 
 -   **Header:** The header contains metadata about the message, such as the message type, content type, and a unique message identifier.
 -   **Payload:** The payload contains the actual content of the message, which can be in any format, including plain text, JSON, or binary data.
 
-### 2.2. Message Types
+### 3.2. Message Types
 
 Web4 defines a set of standard message types to support common interactions:
 
@@ -81,20 +85,22 @@ Web4 defines a set of standard message types to support common interactions:
 -   **`event`:** A message that notifies the recipient of an event or a change in state.
 -   **`credential`:** A message that contains a verifiable credential.
 
-### 2.3. Message Encryption
+### 3.3. Message Encryption
 
 All Web4 messages MUST be encrypted using the keys established during the handshake and pairing process. This ensures the confidentiality and integrity of the communication.
 
 
 
 
-## 3. Data and Credential Formats
+## 4. Data and Credential Formats
 
 Web4 defines a set of standard data and credential formats to ensure interoperability between different implementations. These formats are based on existing open standards, such as JSON and JSON-LD, and are designed to be extensible and flexible.
 
-### 3.1. Web4 Identifier (W4ID)
+> **Normative home:** Web4 data and credential formats (W4ID, Verifiable Credentials, JSON-LD) — together with pairwise-identifier derivation and canonicalization, which are not summarized here — are normatively specified in [`data-formats.md`](data-formats.md). The summaries in this section are for orientation; `data-formats.md` is the single source of truth. Where this section's surface forms differ from `data-formats.md` (notably the W4ID prefix form), the canonical form is subject to an open repo-wide identifier-scheme decision and is intentionally not resolved here.
 
-A Web4 Identifier (W4ID) is a globally unique identifier for a Web4 entity. It is based on the Decentralized Identifier (DID) specification from the W3C and has the following format:
+### 4.1. Web4 Identifier (W4ID)
+
+A Web4 Identifier (W4ID) is a globally unique identifier for a Web4 entity. It is based on the Decentralized Identifier (DID) specification from the W3C. See [`data-formats.md`](data-formats.md) §1 for the normative definition; the illustrative form is:
 
 `w4id:<method-name>:<method-specific-id>`
 
@@ -102,20 +108,20 @@ A Web4 Identifier (W4ID) is a globally unique identifier for a Web4 entity. It i
 -   **`<method-name>`:** The name of the method used to create and manage the identifier (e.g., `key`, `web`).
 -   **`<method-specific-id>`:** A method-specific identifier.
 
-### 3.2. Verifiable Credentials
+### 4.2. Verifiable Credentials
 
 Web4 uses Verifiable Credentials (VCs) as defined by the W3C to represent claims and attestations. VCs are digitally signed credentials that can be verified by any party.
 
-### 3.3. JSON-LD
+### 4.3. JSON-LD
 
 Web4 uses JSON-LD (JSON for Linked Data) to represent data in a structured and interoperable way. JSON-LD allows for the use of semantic vocabularies, such as Schema.org, to describe the meaning of the data.
 
 
 
 
-## 4. Transport and Discovery
+## 5. Transport and Discovery
 
-### 4.1 Transport Matrix
+### 5.1 Transport Matrix
 
 Web4 operates over multiple transport protocols with the following requirements:
 
@@ -135,7 +141,7 @@ Web4 operates over multiple transport protocols with the following requirements:
 - All transports MUST provide confidentiality and integrity
 - Constrained transports MAY use compressed message formats
 
-### 4.2 Discovery Mechanisms
+### 5.2 Discovery Mechanisms
 
 Web4 entities discover each other through multiple mechanisms:
 
@@ -159,18 +165,18 @@ Web4 entities discover each other through multiple mechanisms:
    - Connection endpoints
 3. Entity validates witness signatures before connecting
 
-### 4.3 Transport Selection
+### 5.3 Transport Selection
 
 Endpoints negotiate transport during discovery:
 - Advertise supported transports in priority order
 - Select highest mutual priority
 - Fall back to TLS 1.3 as universal baseline
 
-## 5. URI Scheme
+## 6. URI Scheme
 
 The Web4 URI scheme provides a way to identify and locate Web4 resources. The scheme is based on the standard URI syntax defined in RFC 3986 and is designed to be flexible and extensible.
 
-### 5.1. Syntax
+### 6.1. Syntax
 
 The Web4 URI scheme has the following syntax:
 
@@ -182,7 +188,7 @@ The Web4 URI scheme has the following syntax:
 -   **`[?query]`:** An optional query string.
 -   **`[#fragment]`:** An optional fragment identifier.
 
-### 5.2. Resolution
+### 6.2. Resolution
 
 To resolve a Web4 URI, the client first resolves the W4ID to obtain the entity's service endpoint. The client then sends a request to the service endpoint, including the path, query, and fragment from the URI.
 


### PR DESCRIPTION
## C27 core-protocol.md remediation turn

Applies the **4 AUTONOMOUS-routed findings** from the C27 first-pass audit (`docs/audits/C27-core-protocol-audit-2026-06-02.md`, shipped #261). Single-file change to `web4-standard/core-spec/core-protocol.md` (+24/-18).

| ID | Sev | Finding | Fix |
|----|-----|---------|-----|
| M2 | MED | Broken numbering (duplicate `## 2`, orphan `### 1.3`, no 1.1/1.2) | Renumbered to clean monotonic §1–§6 tree; orphan Pairing promoted to §2.1 under Handshake; Messaging→§3, Data Formats→§4, Transport→§5, URI→§6, sub-numbers cascaded. Pure structural hygiene. |
| M1 | MED | §3 restates/diverges from dedicated `data-formats.md` | Added "Normative home" deference pointer + per-section `data-formats.md §1` pointer; did **not** normalize `w4id:`→`did:web4:` (left to H1). |
| L1 | LOW | Intro promises "pairing process" body never delivers | Softened intro to "pairing methods"; added pointer to `entity-types.md`/`presence-protocol.md` for binding/presence/witnessing. |
| L3 | LOW | No status/version banner | Added `Status: Draft • Last-Updated: 2026-06-02` matching `web4-handshake.md` sibling format. |

## Deferred (routed forward, NOT self-resolved — per audit §E)

- **H1** (DESIGN-Q): W4ID scheme multi-way divergence (`w4id:` vs `did:web4:`, method-name segment). core-protocol/vectors/SDK are the *corroborated* form; dedicated docs dissent → repo-wide canonical-identifier decision; couples **C24-H1** (LCT-ID 4-way).
- **H2 + M3** (DESIGN-Q, bundled): §2 handshake field/shape reconciliation (SDK ↔ normative `web4-handshake.md`) + nonce size (256-bit here vs normative 96-bit). Treated as design-Q overall to avoid a half-fix implying reconciliation.
- **M4** (DESIGN-Q, coupled to H1): `web4://` authority form vs grammar ABNF.
- **L2** (CROSS-TRACK): suite-registry superset + KEM naming.
- **INFO1/INFO2**: observational cross-references.

## Discipline notes
- **BC#15**: no sister-doc date bumps; only core-protocol.md (substantively edited) carries the new date.
- No inbound section-anchor deep-links to core-protocol.md exist (verified by grep) → renumbering breaks nothing.
- **Renumber map for future remediators**: deferred findings cite old numbers — §3 Data Formats is now §4; §5.1 URI is now §6.1; §2 Handshake unchanged. Carries are primitive-keyed (W4ID/handshake/URI) so no loss.

Governance: v2 protocol, policy review APPROVED first-pass. Session log in private-context `legion-web4-20260602-180050-session.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)