### PR TITLE
fix(spec): resolve 4 autonomous-actionable C28 §B findings in web4-handshake.md

### DIFF
--- a/web4-standard/protocols/web4-handshake.md
+++ b/web4-standard/protocols/web4-handshake.md
@@ -1,5 +1,5 @@
 # Web4 Core Handshake (HPKE-based)
-Status: Draft • Last-Updated: 2025-09-11T22:47:56.408268Z
+Status: Draft • Last-Updated: 2026-06-03T06:00:00Z
 Authors: Web4 Editors
 
 ## 1. Scope
@@ -65,7 +65,7 @@ GREASE (Generate Random Extensions And Sustain Extensibility) prevents ossificat
 
 **Extension ID Format:**
 - GREASE extension IDs use format: `w4_ext_[8-hex-digits]@0`
-- Reserved hex patterns: `*a*a*a*a` where `*` is any hex digit
+- The 8 hex digits are chosen uniformly at random for each handshake; there is no fixed reserved value or mask (RFC 8701-style anti-ossification: random values that receivers MUST ignore if unknown)
 - Example: `w4_ext_1a2a3a4a@0`, `w4_ext_fafbfcfd@0`
 
 **Requirements:**
@@ -74,7 +74,7 @@ GREASE (Generate Random Extensions And Sustain Extensibility) prevents ossificat
 - GREASE values MUST be randomly generated for each handshake
 - Suite IDs follow similar pattern: `W4-GREASE-[8-hex-digits]`
 
-### 5.1 ClientHello (plaintext JSON, over TLS/QUIC or out-of-band)
+### 5.1 ClientHello (shown as JSON for readability; serialized per the negotiated media type — CBOR is MTI; over TLS/QUIC or out-of-band)
 ```json
 {
   "type": "ClientHello",
@@ -82,7 +82,7 @@ GREASE (Generate Random Extensions And Sustain Extensibility) prevents ossificat
   "w4idp_hint": "w4idp-<base32>",
   "suites": ["W4-BASE-1", "W4-FIPS-1", "W4-GREASE-93f07f2a"],
   "media": ["application/web4+cbor", "application/web4+json"],
-  "ext": ["w4_ext_sdjwt_vp@1", "w4_ext_noise_xx@1", "w4_ext_93f07f2a@0"],
+  "ext": ["w4_sig_cose@1", "w4_sig_jose@1", "w4_ext_sdjwt_vp@1", "w4_ext_noise_xx@1", "w4_ext_93f07f2a@0"],
   "nonce": "<random 96-bit>",
   "ts": "<iso8601>",
   "kex_epk": "<KEM public key (HPKE)>"
@@ -97,7 +97,7 @@ GREASE (Generate Random Extensions And Sustain Extensibility) prevents ossificat
   "w4idp": "w4idp-<base32>",
   "suite": "W4-BASE-1",
   "media": "application/web4+cbor",
-  "ext_ack": ["w4_ext_sdjwt_vp@1"],
+  "ext_ack": ["w4_sig_cose@1", "w4_ext_sdjwt_vp@1"],
   "nonce": "<random 96-bit>",
   "ts": "<iso8601>",
   "kex_epk": "<KEM public key (HPKE)>"
@@ -204,7 +204,7 @@ stateDiagram-v2
     Established --> Rekey : SessionKeyUpdate
     Rekey --> Established
 ```
-Responder mirrors the flow starting at `WaitClientHello`.
+The Responder runs the mirror-image flow (receive ClientHello → send ServerHello → receive and verify `HandshakeAuth` → `Established`).
 
 ## 9. Anti-Replay & Clocks
 - `nonce` values MUST be unique per key; maintain a replay window.


### PR DESCRIPTION
## C28 REMEDIATION turn (#146)

REMEDIATION turn following #145's C28 **audit** (`docs/audits/C28-web4-handshake-audit-2026-06-03.md`, merged `d781e8ee`). Applies exactly the 4 §B findings that audit classified as **autonomous-actionable-at-next-remediation** — all internal to `web4-standard/protocols/web4-handshake.md`, no cross-spec dependency, clean single-file PR.

### Findings resolved
| ID | Sev | Fix |
|----|-----|-----|
| **B-M1** | MED | GREASE `*a*a*a*a` "reserved hex pattern" contradicted its own examples (`fafbfcfd`/`93f07f2a` don't match the mask) and its "MUST be randomly generated" rule. Adopted RFC 8701-style random-GREASE model (random 8-hex, no fixed mask, ignored-if-unknown) — reconciles all three statements. |
| **B-M2** | MED | Worked Hello examples never carried a `w4_sig_*@1` ext, so never demonstrated the §6.0.1 MUST (selected signature extension ID in TH). Added `w4_sig_cose@1`+`w4_sig_jose@1` to ClientHello `ext` and `w4_sig_cose@1` to ServerHello `ext_ack`. |
| **B-L1** | LOW | §8 prose referenced a `WaitClientHello` node absent from the state diagram → explicit mirror-flow description. |
| **B-L2** | LOW | §5.1 header "plaintext JSON" → "shown as JSON for readability; CBOR is MTI" (stops contradicting the CBOR-MTI stance). |
| **B-INFO1** | INFO | Stale `Last-Updated` 2025-09-11 → 2026-06-03 (BC#15: file received substantive edits). |

### Deferred (NOT self-resolved)
All 4 §C cross-spec items remain **design-Q / cross-track**, bundled with open C27/C24 carries pending operator adjudication:
- **C-H1** (HIGH, design-Q) canonical handshake: 3-msg signature (handshake.md) vs 4-msg MAC (core-protocol+SDK+vectors) — bundles **C27-H2**. handshake.md self-declares MTI but is the lone dissenter vs the implemented+tested 3-anchor cluster on every dimension; resolution needs an operator decision + cascading edits, so it is correctly left untouched here.
- **C-M1** (MED, design-Q) nonce 96-bit vs 256-bit + AEAD-IV/challenge-token conflation (= **C27-M3**).
- **C-M2** (MED, cross-track) `W4-IOT-1` suite registry orphan + P-256 spelling (= **C27-L2**).
- **C-M3** (MED, design-Q/cross-track) `w4idp-<base32>` identifier surface (bundles **C27-H1 + C24-H1**).

### Verification
Spec-only Markdown edit (no code/tests). Verified via `git diff` review + BC#5 corpus sweep: zero remaining `*a*a*a*a` / `plaintext JSON` / `WaitClientHello`; repo-wide sweep confirms the GREASE reserved mask had no sister-doc references (fully contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)