### PR TITLE
fix(spec): resolve 5 autonomous-actionable C31 findings in security-framework.md

### DIFF
--- a/web4-standard/core-spec/security-framework.md
+++ b/web4-standard/core-spec/security-framework.md
@@ -1,6 +1,6 @@
 # Web4 Security Framework
 
-This document defines the security framework for the Web4 standard. It covers the cryptographic primitives, key management, authentication and authorization, and a comprehensive analysis of security considerations.
+This document defines the security framework for the Web4 standard. It covers the cryptographic primitives, key management, and authentication and authorization.
 
 
 
@@ -11,15 +11,15 @@ Web4 defines standardized cryptographic suites to ensure interoperability and se
 
 ### 1.1. Suite Definitions
 
-| Suite ID          | KEM     | Sig       | AEAD                | Hash    | Profile | Status |
-|-------------------|---------|-----------|---------------------|---------|---------|--------|
-| W4-BASE-1         | X25519  | Ed25519   | ChaCha20-Poly1305   | SHA-256 | COSE    | MUST   |
-| W4-FIPS-1         | P-256   | ECDSA-P256| AES-128-GCM         | SHA-256 | JOSE    | SHOULD |
+| Suite ID          | KEM       | Sig        | AEAD                | Hash    | Profile | Status |
+|-------------------|-----------|------------|---------------------|---------|---------|--------|
+| W4-BASE-1         | X25519    | Ed25519    | ChaCha20-Poly1305   | SHA-256 | COSE    | MUST   |
+| W4-FIPS-1         | ECDH-P256 | ECDSA-P256 | AES-128-GCM         | SHA-256 | JOSE    | SHOULD |
 
 **Implementation Requirements:**
 - Implementations MUST support W4-BASE-1
 - FIPS-bound environments SHOULD support W4-FIPS-1
-- Other suites MAY be offered but MUST NOT be negotiated as MTI
+- Other suites MAY be offered but MUST NOT be required in place of the mandatory W4-BASE-1 baseline
 
 ### 1.2. Algorithm Specifications
 
@@ -32,7 +32,7 @@ Web4 defines standardized cryptographic suites to ensure interoperability and se
 - **Encoding**: COSE (RFC 8152)
 
 #### W4-FIPS-1 (FIPS Compliance)
-- **Key Exchange**: ECDH with P-256 (FIPS 186-4)
+- **Key Exchange**: ECDH-P256 (ECDH with P-256, FIPS 186-4)
 - **Signatures**: ECDSA with P-256 (FIPS 186-4)
 - **AEAD**: AES-128-GCM (NIST SP 800-38D)
 - **Hash**: SHA-256 (FIPS 180-4)
@@ -41,7 +41,7 @@ Web4 defines standardized cryptographic suites to ensure interoperability and se
 
 ### 1.3. Canonicalization and Signatures
 
-All Web4 signed payloads **MUST** implement COSE/CBOR (Ed25519/EdDSA) as mandatory-to-implement (MTI). JOSE/JSON (ES256) is OPTIONAL/SHOULD for bridge scenarios.
+All Web4 signed payloads **MUST** implement COSE/CBOR (Ed25519/EdDSA) as mandatory-to-implement (MTI). JOSE/JSON (ES256) is SHOULD for bridge scenarios.
 
 #### COSE/CBOR (MUST)
 - Deterministic CBOR encoding per CTAP2
@@ -75,7 +75,7 @@ Private keys MUST be stored securely to prevent unauthorized access. Recommended
 
 ### 2.3. Key Rotation
 
-To mitigate the risk of key compromise, Web4 entities SHOULD rotate their keys periodically. The key rotation process involves generating a new key pair and updating the entity's Web4 Identifier to use the new public key.
+To mitigate the risk of key compromise, Web4 entities SHOULD rotate their keys periodically. The key rotation process involves generating a new key pair and updating the entity's Web4 Identifier to use the new public key. See `LCT-linked-context-token.md` Section 7.3 for the normative rotation lifecycle (new LCT issuance, `lineage` to the parent, and the dual-validity overlap window before the parent is retired as `superseded`).
 
 
 


### PR DESCRIPTION
## C31 Remediation — `security-framework.md`

Remediation turn of the C-series audit/remediation alternation. Applies the **5 AUTONOMOUS** findings from the C31 audit (`docs/audits/C31-security-framework-audit-2026-06-04.md`, merged in #270). The 3 DESIGN-Q and 3 CROSS-TRACK findings remain **recorded-not-resolved** (out of scope this turn).

### Findings resolved (1 file, +6/-6)

| ID | Sev | Change |
|----|-----|--------|
| **B-H1 + A-L4** | HIGH | W4-FIPS-1 KEM `P-256` (§1.1 table) / `ECDH with P-256` (§1.2 prose) → canonical token **`ECDH-P256`**. The spec previously **failed its own conformance vector `sec-002`** and disagreed with SDK `SUITE_FIPS` (`security.py:117`) — both already assert `ECDH-P256`. No design decision: the spec simply trailed the agreed SDK+vector value. |
| **A-L1** | LOW | §1.3 `OPTIONAL/SHOULD` → `SHOULD` (conflated RFC 2119 keywords; `SHOULD` canonical in 5 other places). |
| **A-L2** | LOW | §1.1 `MUST NOT be negotiated as MTI` → `MUST NOT be required in place of the mandatory W4-BASE-1 baseline` (MTI is a static designation, not runtime-negotiable; no behavioral change). |
| **A-L3** | LOW | Trimmed the abstract's unmet "comprehensive analysis of security considerations" claim (no such section in the body). |
| **B-M3** | MED | §2.3 adds `See LCT-linked-context-token.md §7.3` rotation-lifecycle deference (file already uses this See-pattern at §1.3). |

### Discipline notes
- **BC#5 corpus sweep (intra-file only)**: post-write, `ECDH-P256` is the sole FIPS KEM spelling in-file. Line 36 Signature (`ECDSA with P-256`) left untouched — audit C-I1 confirms it already matches vector token `ECDSA-P256`, and it was out of approved scope. **No leak** into the deferred CROSS-TRACK token-normalization files (`core-protocol.md`, `cloud-service-profile.md`, `registries/initial-registries.md`, `web4-handshake.md §3`); those normalize only after the C-M1 SSOT decision.
- **B-M2 stays DESIGN-Q**: B-M3 only adds a cross-reference; the §2.3 "update the identifier" vs LCT §7.3 stable-subject-DID semantic contradiction is recorded, not resolved.
- A-L3 **trims** (does not author a new Security Considerations section — that would expand scope and overlaps the deferred `r6-security-analysis.md`).

### Deferred (recorded-not-resolved)
- **DESIGN-Q**: C-M1 (canonical crypto-suite registry SSOT, ≥3-way), B-H2 (W4-IOT-1 inclusion), B-M2 (rotation semantics).
- **CROSS-TRACK**: B-L5 (`cose:ES256`→`cose:EdDSA` example labels), B-L6 (split/annotate `security-primitives.json`), B-L7 (`device` W4ID method coverage), downstream FIPS-KEM token normalization once SSOT chosen.

Produced under Autonomous Session Protocol v2 — policy review APPROVED first-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)