### PR TITLE
fix(spec): resolve 3 autonomous-actionable C33 findings (web4:// SSOT + lct: distinctness + RECOMMENDED scope)

### DIFF
--- a/web4-standard/architecture/grammar_and_notation.md
+++ b/web4-standard/architecture/grammar_and_notation.md
@@ -41,6 +41,8 @@ Web4 supports two URI schemes for identifying and locating resources:
 
 This scheme is used for clean, human-readable URIs.
 
+> **Normative home:** The `web4://` scheme is normatively specified in [`../core-spec/data-formats.md`](../core-spec/data-formats.md) §6, which is its single source of truth. The grammar below is provided for orientation. The `w4-authority` production shown here is one illustration of an authority form; its canonical surface form is subject to an open repo-wide identifier-scheme decision and is not settled by this document (see `data-formats.md` §6.2).
+
 ```abnf
 web4-URI = "web4://" w4-authority path-abempty [ "?" query ] [ "#" fragment ]
 w4-authority = w4id-label / hostname
@@ -56,6 +58,8 @@ web4-did-url = did-url
 did-url = "did:web4:" method-specific-id [ path ] [ "?" query ] [ "#" fragment ]
 method-specific-id = base32nopad
 ```
+
+> **Note (scope of "RECOMMENDED"):** This "RECOMMENDED" designation is an architecture-document preference, not an independent settlement of the canonical entity-identifier prefix. The W4ID prefix form (`did:web4:` vs alternatives) is governed by an open repo-wide identifier-scheme decision whose normative home is [`../core-spec/data-formats.md`](../core-spec/data-formats.md) §1. This label is consistent with that document's current ABNF and stands as evidence of the prose lean toward `did:web4:`, but it does not by itself resolve the open decision.
 
 ## References
 

--- a/web4-standard/core-spec/core-protocol.md
+++ b/web4-standard/core-spec/core-protocol.md
@@ -176,9 +176,11 @@ Endpoints negotiate transport during discovery:
 
 The Web4 URI scheme provides a way to identify and locate Web4 resources. The scheme is based on the standard URI syntax defined in RFC 3986 and is designed to be flexible and extensible.
 
+> **Normative home:** The `web4://` URI scheme is normatively specified in [`data-formats.md`](data-formats.md) §6, which is the single source of truth for its structure. The summary in this section is for orientation. In particular, the surface form of the authority component (shown below as `<w4id>`) is one illustration of an authority form that is subject to an open repo-wide identifier-scheme decision and is intentionally not resolved here; see `data-formats.md` §6.2.
+
 ### 6.1. Syntax
 
-The Web4 URI scheme has the following syntax:
+The Web4 URI scheme has the following illustrative syntax:
 
 `web4://<w4id>/<path-abempty>[?query][#fragment]`
 

--- a/web4-standard/core-spec/data-formats.md
+++ b/web4-standard/core-spec/data-formats.md
@@ -30,6 +30,10 @@ Web4 defines the following methods for creating and managing W4IDs. This list is
 - **`web` method:** The `method-specific-id` is a domain name, allowing for the use of existing web infrastructure to host the W4ID document.
 - **`device` method:** The `method-specific-id` identifies a hardware-bound device key (see `multi-device-lct-binding.md`), used when an identifier is anchored to a specific physical device.
 
+### 1.3. Relationship to the LCT identifier (`lct:web4:`)
+
+A W4ID identifies a Web4 **entity** (the subject). It is distinct from an **LCT identifier**, which uses the `lct:web4:` prefix and identifies a specific Linked Context Token *instance* — the reified presence record — rather than the entity that is its subject. The two are different namespaces serving different referents: an entity has a `did:web4:` W4ID, and each LCT bound to that entity has its own `lct:web4:` identifier. (The canonical surface form of the `lct:web4:` identifier is specified by the LCT documents; reconciling it with the open identifier-scheme decision is out of scope for this section.)
+
 ## 2. Verifiable Credentials (VCs)
 
 Web4 uses Verifiable Credentials (VCs) as defined by the W3C [2] to represent claims and attestations. VCs are a standard way to create and verify digital credentials that are tamper-evident and cryptographically verifiable.
@@ -137,3 +141,26 @@ function canonicalizeCBOR(obj) {
   return cbor.encode(obj, {canonical: true});
 }
 ```
+
+## 6. Web4 URI Scheme (`web4://`)
+
+The `web4://` URI scheme provides a way to identify and locate a resource owned by a Web4 entity. This section is the **single source of truth** for the scheme's structure; other documents (e.g., [`core-protocol.md`](core-protocol.md) §6 and [`architecture/grammar_and_notation.md`](../architecture/grammar_and_notation.md) §4.1) describe the same scheme for orientation and defer to this definition.
+
+### 6.1. Structure
+
+A `web4://` URI is built on the generic URI syntax of RFC 3986 and has the structure:
+
+`web4://<authority>/<path-abempty>[?query][#fragment]`
+
+- **`web4://`**: The scheme identifier.
+- **`<authority>`**: Identifies the Web4 entity that owns the resource. **The surface form of this authority is not resolved here** — see §6.2.
+- **`<path-abempty>`**: An optional path to the resource within the entity's namespace, per RFC 3986.
+- **`[?query]`** and **`[#fragment]`**: Optional query and fragment components, per RFC 3986.
+
+### 6.2. Authority form (open identifier-scheme decision)
+
+The exact surface form of the `<authority>` component — for example a full Web4 Identifier versus a base32-encoded label — is **subject to the same open repo-wide identifier-scheme decision** that governs the W4ID prefix form (§1.1) and pairwise-identifier derivation (§4). It is **intentionally not resolved here**. Existing documents currently illustrate more than one form (a full W4ID in [`core-protocol.md`](core-protocol.md) §6.1; a `w4id-label` in [`architecture/grammar_and_notation.md`](../architecture/grammar_and_notation.md) §4.1); reconciling them to a single canonical form is deferred to that decision. Implementations MUST NOT assume the authority form is settled until this decision is recorded here.
+
+### 6.3. Resolution
+
+To resolve a `web4://` URI, a client first resolves the authority to the owning entity's service endpoint, then issues a request to that endpoint carrying the path, query, and fragment from the URI.


### PR DESCRIPTION
## Summary

REMEDIATION turn (alternation) following the merged **C33 identifier-scheme consolidation audit** (PR #274). Applies exactly the three findings the C33 audit §3 (L118) labels **autonomous-actionable** — the ones fixable *without* the operator's canonical-form decision. The four coupled DESIGN-Q items are deliberately **not** touched.

| Finding | Sev | What was done |
|---------|-----|---------------|
| **D-H1** | HIGH | Designate **`data-formats.md` §6** as the single source of truth for the `web4://` URI scheme (structure only). Added `> **Normative home:**` deference blockquotes to `core-protocol.md` §6 and `grammar_and_notation.md` §4.1. |
| **B-M1** | MED | Added `data-formats.md` §1.3 stating `lct:web4:` identifies an LCT *instance*, distinct from the entity W4ID `did:web4:`. |
| **L-1** | LOW | Scoped grammar §4.2's "RECOMMENDED `did:web4`" as prose-lean evidence pending the open A-H1 decision, not an independent settlement. |

## What was deliberately NOT done (held for operator / cross-track)

- **A-H1 / B-H1 / C-H1 / D-M1** — the four coupled DESIGN-Q items. These require the operator to pick the canonical identifier form; a remediation session must not self-resolve them. The new **§6.2 "Authority form (open identifier-scheme decision)"** explicitly defers the `web4://` embedded form (`<w4id>` vs `w4id-label`) — giving that eventual decision a concrete normative home to land in.
- **C-M1** (couples to C-H1's output form) and **E-M1** (`lct://`, cross-track spanning SDK + vectors + spec) — deferred.
- **No SDK or test-vector files touched.** Existing embedded ABNF forms in core-protocol §6.1 and grammar §4.1 left verbatim (no harmonization — harmonization *is* D-M1).

## Governance

- v2 protocol: scope APPROVED by policy review with two binding execution constraints (no concrete embedded form asserted normative; no harmonization of the two existing forms) — both verified satisfied.
- Anchor fix caught at write-time: cited RFC 3986 inline rather than mis-numbering (data-formats ref `[4]` is Schema.org, and RFC 3986 was absent from the ref list).

## Diff

3 existing files, +34/-1. 0 new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)