### PR TITLE
fix(spec): resolve 12 autonomous-actionable C35 findings in mcp-protocol.md

### DIFF
--- a/web4-standard/core-spec/mcp-protocol.md
+++ b/web4-standard/core-spec/mcp-protocol.md
@@ -104,7 +104,7 @@ MCP clients (including AI models) are also Web4 entities:
     "context_window": 200000,
     "trust_profile": {
       "t3": {"talent": 0.9, "training": 0.95, "temperament": 0.85},
-      "v3": {"veracity": 0.92, "validity": 0.88, "value": 0.90}
+      "v3": {"veracity": 0.92, "validity": 0.88, "valuation": 0.90}
     }
   }
 }
@@ -157,7 +157,7 @@ def handle_resource_request(request, web4_context):
         return Error("Insufficient trust")
     
     # 3. Verify ATP stake if required
-    if not verify_atp_stake(web4_context.atp_stake):
+    if not verify_atp_stake(web4_context.trust_context.atp_stake):
         return Error("Insufficient ATP stake")
     
     # 4. Check agency delegation if present
@@ -271,7 +271,7 @@ Shared context maintained across interactions:
 {
   "resource_type": "mcp_context",
   "context_state": {
-    "session_id": "sess:...",
+    "session_id": "mcp:session:...",
     "accumulated_facts": [...],
     "mrh_graph": {
       "entities": [...],
@@ -394,7 +394,7 @@ R7 MCP actions extend the §7.1 R6 structure with a `reputation` field in the re
 - The `reputation.responding_society_signature` MUST be signed by the responding society's Policy-Entity (the role that made the decision per `society-roles.md` §2.3)
 - The `reputation.outcome_class` MUST be one of the canonical values; implementations MUST NOT invent new values without spec extension
 - The `reputation.trust_dimension_updates` deltas MUST be within bounds set by the responding society's Law Oracle for the role context (per `t3-v3-tensors.md` parameter governance)
-- The `reputation.propagation_scope` MUST be set; absent it, implementations SHOULD default to `both` for cross-society actions and `responding_society` for intra-society R7
+- The `reputation.propagation_scope` MUST be set; absent it, implementations SHOULD default by `cross_society.interaction_type` (§7.4): `responding_society` for intra-society R7; `both` for cross-society `first_contact`/`established` actions; and `encompassing_society` for `federated` actions where caller and responder share an encompassing society (the federation standard per §7.5), falling back to `both` when no encompassing society exists
 - For high-consequence actions (per the responding society's classification), `reputation.witness_signatures` MUST contain at least one signature from a Witness role per `society-roles.md` §4.1; the encompassing society's Witness is preferred when one exists
 
 - When `outcome_class` is `violation`, the `trust_dimension_updates` deltas MUST be non-positive (zero or negative); the responding society's Policy-Entity still signs the envelope (the violation is a completed adjudication, not a protocol error); and the caller's Archivist MUST persist it identically to any other R7 outcome. A `violation` is distinct from a §7.6 transport/protocol failure — it indicates the action completed but breached the responding society's rules.
@@ -410,12 +410,11 @@ When the MCP caller and responder are in different societies, the Web4 Context H
   "web4_context": {
     "sender_lct": "lct:web4:entity:...",
     "sender_society": "lct:web4:society:A:...",
-    "sender_role": "web4:role:...",
+    "sender_role": "web4:...",
     "responding_society": "lct:web4:society:B:...",
-    "responding_role_expected": "web4:role:resource_provider",
+    "responding_role_expected": "web4:ResourceProvider",
     "cross_society": {
       "interaction_type": "first_contact | established | federated",
-      "exchange_agreement_hash": "sha256:...",
       "applicable_law_oracle": "lct:web4:society:A:law-oracle:...  OR  lct:web4:encompassing:law-oracle:...",
       "atp_settlement": {
         "caller_currency": "lct:web4:society:A:atp",
@@ -444,7 +443,7 @@ When the MCP caller and responder are in different societies, the Web4 Context H
 - `applicable_law_oracle` resolves the "whose law applies under cross-society interaction" question by explicit reference. Two patterns are supported:
   - **Caller-law**: sender's Law Oracle governs the call; responder MAY refuse if local law conflicts
   - **Encompassing-law**: when caller and responder share a fractal-encompassing society, that society's Law Oracle governs (per `inter-society-protocol.md` §3.2 Option 3)
-- `atp_settlement` MUST be present for cross-society calls with non-zero ATP cost when the two societies use different currencies. The settlement block carries both societies' independent valuations of a common referent (per §7.7's referent-grounded model). Implementations MUST populate either:
+- `atp_settlement` MUST be present for cross-society calls with non-zero ATP cost when the two societies use different currencies (see the interim conformance note below for the scope of this MUST while §7.7 is WIP). The settlement block carries both societies' independent valuations of a common referent (per §7.7's referent-grounded model). Implementations MUST populate either:
   - An `exchange_agreement_ref` hash referencing a standing agreement (per §7.7.2 standing-agreement flow), OR
   - Inline `referent` + `caller_amount` + `responder_amount` fields representing a per-transaction negotiation outcome (per §7.7.3 acceptance payload)
 
@@ -477,14 +476,14 @@ Cross-society R7 actions interact with the witness role per `society-roles.md` �
 1. **Encompassing society's Witness** — when A and B share a fractal-encompassing society D, D's Witness role provides neutral attestation peer to both A and B
 2. **Third-society Witness** — when A and B do not share an encompassing D, they MAY invoke witnesses from a third society both trust (selection negotiated at first contact or by standing arrangement)
 3. **Bilateral witness** — A and B each provide a Witness; cross-signed attestations record the action in both ledgers
-4. **No witness** — low-consequence R6 calls MAY proceed without witnessing; R7 SHOULD NOT proceed without witnessing for high-consequence actions
+4. **No witness** — low-consequence R6 calls MAY proceed without witnessing; for high-consequence actions, R7 MUST NOT proceed without witnessing (consistent with the §7.3 normative requirement that `reputation.witness_signatures` MUST carry at least one Witness signature for high-consequence actions)
 
 **R7 Reputation propagation** rules:
 
 | `propagation_scope` | Effect |
 |---|---|
 | `responding_society` | Only Society B's view of the calling entity's T3/V3 updates. A does not record the Reputation in its own ledger. Used for intra-society or low-consequence cases. |
-| `caller_society` | Only Society A's view of the responding society / resource updates. B does not record the Reputation. Unusual; typically combined with `both` semantics. |
+| `caller_society` | Only Society A's view of the responding society / resource updates. B does not record the Reputation. Unusual; when both sides need to record, use the single `both` value below rather than combining scopes (`propagation_scope` is a single enum, not a set). |
 | `both` | Both A and B record the signed Reputation envelope to their respective ledgers. A updates its T3/V3 view of B; B updates its T3/V3 view of A's calling entity. Standard for cross-society R7 without an encompassing D. |
 | `encompassing_society` | The Reputation also propagates to the encompassing society's ledger and contributes to its society-society trust tensor between A and B. Standard for cross-society R7 within a federation. |
 
@@ -500,7 +499,7 @@ This resolves the `inter-society-protocol.md` §9 future-work item "society-soci
 |---|---|---|
 | Caller's LCT not recognized by responding society | `403 web4_cross_society_unrecognized_lct` | First-contact protocol per `inter-society-protocol.md` §3 |
 | Exchange rate stale or absent | `409 web4_cross_society_exchange_invalid` | Renegotiate per inter-society protocol |
-| Applicable Law Oracle disagrees with responding society's Law Oracle | `409 web4_cross_society_law_conflict` | Escalate to encompassing society or refuse |
+| Applicable Law Oracle disagrees with responding society's Law Oracle | `409 web4_cross_society_law_conflict` | If caller and responder share an encompassing society, escalate to its Law Oracle; otherwise no shared authority can adjudicate, so the responder refuses (the caller MAY retry under caller-law if the responder's local law permits) |
 | Witness signature required but absent | `412 web4_cross_society_witness_required` | Acquire witness and retry |
 | R7 Reputation signature invalid | `400 web4_r7_reputation_invalid` | Responding society's Policy-Entity must re-sign |
 | Propagation scope unsupported by responding society | `400 web4_propagation_scope_unsupported` | Caller must request a supported scope |
@@ -652,6 +651,8 @@ This is the same form-vs-substance split that runs through Web4: the protocol sp
 
 #### 7.7.5 Per-transaction vs. standing agreement guidance (informative)
 
+This subsection expands, with implementation rationale, the per-transaction-vs-standing distinction established normatively in §7.7.1; it adds no conformance requirements of its own.
+
 Per-transaction scoping is ideal because:
 - No stale rates
 - No ongoing rate-relationship maintenance overhead
@@ -664,11 +665,11 @@ Standing agreements are practical when:
 - Pre-commitment of resources is required before transaction begins
 - Operational simplicity outweighs the cost of occasional staleness
 
-Implementations SHOULD default to per-transaction unless the calling Treasurer explicitly references a standing agreement hash. Standing agreements MAY be unilaterally terminated by either Treasurer with notice per the agreement's own terms (or 24h default).
+As informative guidance (no conformance force), implementations typically default to per-transaction unless the calling Treasurer explicitly references a standing agreement hash. By convention, a standing agreement can be unilaterally terminated by either Treasurer with notice per the agreement's own terms — commonly a 24-hour default where the agreement is silent on its termination notice.
 
 #### 7.7.6 Oracle reference (informative)
 
-When two societies cannot independently value a referent, they MAY reference a third-party Oracle society. The Oracle publishes prices for common referents via its own MCP server (typically `web4_referent_price` tool). The two negotiating Treasurers each query the Oracle independently and use the returned price as their proposed rate, with explicit `reference_standard` in the proposal naming the Oracle's LCT.
+This subsection expands the third-party-oracle fallback introduced in §7.7.1; it adds no conformance requirements of its own. When two societies cannot independently value a referent, they may reference a third-party Oracle society. The Oracle publishes prices for common referents via its own MCP server (typically `web4_referent_price` tool). The two negotiating Treasurers each query the Oracle independently and use the returned price as their proposed rate, with explicit `reference_standard` in the proposal naming the Oracle's LCT.
 
 The Oracle's own T3 trust governs how much weight is placed on the reference. Oracle pricing does NOT remove the requirement that each society's Treasurer separately sign the agreement — the Oracle is an input to the negotiation, not the authority. This preserves the anti-hierarchical-by-design property: no Oracle has unilateral authority over what rates two societies use; both societies retain refusal authority.
 
@@ -736,7 +737,7 @@ class MCPMeter:
         
         total_cost = base_cost * trust_modifier * complexity_factor
         
-        return min(total_cost, context.atp_cap)  # Respect caps
+        return min(total_cost, context.atp_remaining)  # Cap at the session's remaining ATP balance (per §11)
 ```
 
 ### 9.2 Dynamic Pricing (informative)


### PR DESCRIPTION
## C35 Remediation — `mcp-protocol.md`

Remediation turn for the **C35 delta re-audit** (PR #278, merged `e2ae9514`). Single file, **APPROVED first-pass**. Applies the 12 autonomous-actionable findings + 1 optional; **declines F9** as a corpus-wide overcall; defers all §7.7-WIP and operator design-Q items.

### Applied (12 + 1 optional)
| Finding | Where | Change |
|---|---|---|
| **N3** | §3 L107 | V3 dim `value`→`valuation` — **closes carry-C34** (identical to C34 M1, shipped in atp-adp via #277) |
| **N2** | §7.4 | role-id `web4:role:`→`web4:<Name>` (mcp-internal: §4.1/§6.1/§7.1 all use `web4:<Name>`) |
| **N6** | §7.7.5 | stray `SHOULD`/`MAY`/24h restated as informative (subsection is tagged *Informative — no conformance requirements*) |
| **N7** | §6.3 | session-id `sess:`→`mcp:session:` (match §11) |
| **N8** | §7.4 | delete orphan `exchange_agreement_hash` (only nested `exchange_agreement_ref` is normatively defined) |
| **N10** | §4.2 | pseudocode `web4_context.atp_stake`→`…trust_context.atp_stake` |
| **N11** | §9.1 | metering `context.atp_cap`→`context.atp_remaining` (`atp_cap` defined nowhere; `atp_remaining` is in §11) |
| **N1** | §7.5 | No-witness `R7 SHOULD NOT proceed`→`MUST NOT`, aligned to §7.3's MUST for the same condition † |
| **F6** | §7.5 | `caller_society` prose reconciled against single-enum `propagation_scope` |
| **F7** | §7.3 | `propagation_scope` default now `interaction_type`-aware (reconciles vs §7.5 federation standard) |
| **F10** | §7.6 | law-conflict recovery split by whether an encompassing society exists |
| **F13** | §7.7.5/6 | back-reference §7.7.1 (reduce triplication; WIP-safe) |
| **N14** | §7.4 | optional inline cross-ref MUST→interim-conformance-note |

† **N1 softening alternative (operator visibility)**: the conflict could instead be resolved by leaving §7.5 `SHOULD NOT` and softening §7.3's MUST to SHOULD. Aligned **up** to §7.3's MUST because §7.3 owns the "Normative requirements" block and already commits to MUST.

### Declined — documented, NOT self-resolved
- **F9** `Policy-Entity`→`PolicyEntity`: corpus sweep (BC#5) found `society-roles.md` — the doc mcp **cites by section number** — uses `Policy-Entity` (hyphenated, 10×); corpus is 27 hyphenated vs 5, and all 5 `PolicyEntity` are the entity-type/SAGE-`PolicyGate` context. mcp refers to the **role**. Normalizing mcp alone would make it **diverge from its cited authority**. Routed to a corpus-wide operator DESIGN-Q carry (couples C33 identifier-scheme cluster).

### Deferred — untouched (operator / design)
- **§7.7 wire-shape cluster** N5/N9/N13/F11-residual → resolve as ONE unit at §7.7 v0.1.0-final promotion (re-patching piecemeal would reintroduce the inconsistency the 2026-05-17 pass cleared).
- **N4/N12** error-canonicity → carry-C30. **N15** identifier-scheme → carry-C33.

### Scope
- 1 file changed (`web4-standard/core-spec/mcp-protocol.md`, +15/−14). 0 new files. Doc-only; no SDK/test code. §7.4 JSON example remains structurally valid after orphan-field removal. No doc-level date banner exists; §7.7 WIP status date left unchanged (not substantively edited — BC#15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)