### PR TITLE
remediate(C37): apply autonomous-actionable findings to acp-framework.md

### DIFF
--- a/web4-standard/core-spec/acp-framework.md
+++ b/web4-standard/core-spec/acp-framework.md
@@ -38,7 +38,6 @@ A declarative specification of what an agent intends to accomplish:
 
 ```json
 {
-  "@context": ["https://web4.io/contexts/acp.jsonld"],
   "type": "ACP.AgentPlan",
   "planId": "acp:plan:invoice-processor",
   "principal": "lct:web4:entity:CLIENT",
@@ -47,7 +46,7 @@ A declarative specification of what an agent intends to accomplish:
   
   "triggers": [
     {"kind": "cron", "expr": "0 */6 * * *"},  // Every 6 hours
-    {"kind": "event", "topic": "invoice.ready"},  // On event
+    {"kind": "event", "expr": "invoice.ready"},  // On event
     {"kind": "manual", "authorized": ["lct:web4:human:CFO"]}  // Manual trigger
   ],
   
@@ -85,11 +84,9 @@ A declarative specification of what an agent intends to accomplish:
       "autoThreshold": 10,
       "timeout": 3600,
       "fallback": "deny"
-    }
-  },
-  
-  "expiresAt": "2026-01-01T00:00:00Z",
-  "signatures": [...]
+    },
+    "expiresAt": "2026-01-01T00:00:00Z"
+  }
 }
 ```
 
@@ -102,18 +99,20 @@ An actionable proposal generated from plan evaluation:
   "type": "ACP.Intent",
   "intentId": "acp:intent:...",
   "planId": "acp:plan:invoice-processor",
+  "stepId": "approve",
   "proposedAction": {
     "mcp": "invoice.approve",
     "args": {"id": "INV-123", "amount": 9.5}
   },
   "proofOfAgency": {
     "grantId": "agy:grant:...",
-    "ledgerProof": {"hash": "...", "block": 12345}
+    "planId": "acp:plan:invoice-processor",
+    "intentId": "acp:intent:...",
+    "nonce": "0x9f2c..."
   },
   "explain": {
     "why": "Invoice matches auto-approval criteria",
     "confidence": 0.95,
-    "alternatives": ["route_to_manual", "request_clarification"],
     "riskAssessment": "low"
   },
   "needsApproval": false,
@@ -130,7 +129,6 @@ Human or automated decision on an intent:
   "type": "ACP.Decision",
   "intentId": "acp:intent:...",
   "decision": "approve",  // approve | deny | modify
-  "modifications": null,
   "by": "lct:web4:entity:AUTO-APPROVER",
   "rationale": "Within auto-approval limits",
   "witnesses": ["lct:web4:witness:A", "lct:web4:witness:B"],
@@ -145,6 +143,7 @@ Immutable record of action execution:
 ```json
 {
   "type": "ACP.ExecutionRecord",
+  "recordId": "exec:web4:001",
   "intentId": "acp:intent:...",
   "grantId": "agy:grant:...",
   "lawHash": "sha256:...",
@@ -163,11 +162,8 @@ Immutable record of action execution:
     "client": {"v3": {"valuation": +0.02}}
   },
   "witnesses": ["lct:web4:witness:A"],
-  "ledgerInclusion": {
-    "hash": "0x...",
-    "block": 12346,
-    "proof": "..."
-  }
+  "timestamp": "2025-09-15T15:30:10Z",
+  "canonicalHash": "sha256:exec_hash_002"
 }
 ```
 
@@ -189,16 +185,16 @@ Immutable record of action execution:
                               Pass    │    Fail
                                       │     │
                                       v     v
-                              ┌──────────┐ Reject
-                              │ Approval │
+                              ┌──────────┐ Failed
+                              │ Approval │ (Fail → law/scope reject)
                               │   Gate   │
                               └──────────┘
                                       │
                              Approve  │  Deny
                                       │   │
                                       v   v
-                              ┌──────────┐ Abort
-                              │ Execute  │
+                              ┌──────────┐ Failed
+                              │ Execute  │ (Deny → approval abort)
                               └──────────┘
                                       │
                                       v
@@ -223,7 +219,11 @@ Immutable record of action execution:
 | Approval Gate | Approved | Executing | Call MCP resources |
 | Executing | Success | Recording | Write execution record |
 | Recording | Witnessed | Complete | Update trust tensors |
-| Any | Error/Timeout | Failed | Log error, rollback |
+| Complete | Reset / Retrigger | Idle | Clear intent/decision/record, ready for re-execution |
+| Failed | Retry | Idle | Reset state for retry |
+| Any active state¹ | Error / Timeout / Deny / Law-check fail | Failed | Log reason, rollback |
+
+¹ **"Any active state"** = the five in-flight states (Planning, Intent Created, Approval Gate, Executing, Recording). `Idle` and `Complete` are excluded: a terminal/idle plan does not transition straight to `Failed` (the SDK `VALID_TRANSITIONS` permits `→Failed` only from the five active states). The wildcard row therefore expands to **six** distinct `→Failed` edges (one per active state, plus the Intent-Created law-check-fail / Approval-Gate deny edges collapse into their source-state entry). Counting the six wildcard-expanded `→Failed` edges plus the seven explicit rows above yields the **13 transitions** asserted by conformance vector `acp-002` (`totalValidTransitions=13`). The `Deny` and `Law-check fail` events are normal governance outcomes routed to `Failed`, not transport errors.
 
 ## 4. ACP-AGY Integration
 
@@ -297,6 +297,7 @@ def check_law_compliance(plan, law_oracle):
     # 2. Check plan triggers against law
     for trigger in plan.triggers:
         if not law.allows_trigger(trigger):
+            # law-scope violation: §10.2 must NOT route this to grant expansion
             raise ScopeViolation(f"trigger {trigger} not allowed by law")
     
     # 3. Verify resource caps within law limits
@@ -305,6 +306,7 @@ def check_law_compliance(plan, law_oracle):
     
     # 4. Ensure witness requirements met
     if plan.guards.witnessLevel < law.min_witness_level:
+        # config-level deficit (static): §10.2 must amend/abort, not wait
         raise WitnessDeficit()
     
     return True
@@ -339,7 +341,7 @@ Humans interact with ACP through the console:
 interface ApprovalRequest {
   intent: Intent;
   plan: AgentPlan;
-  riskAssessment: RiskProfile;
+  riskAssessment: "low" | "medium" | "high" | "critical";
   explanation: {
     summary: string;
     details: string;
@@ -527,6 +529,14 @@ class ResourceCapExceeded(ACPError):
 
 Graceful degradation strategies:
 
+Recovery dispatches over the §10.1 error **taxonomy** (the defined error
+classes), not over the raise-site inventory. A single class may be raised
+from more than one site with different underlying semantics (`ScopeViolation`
+from both §4.1 grant checks and §5.1 law checks; `WitnessDeficit` from both
+runtime-count and plan-configuration checks), so those branches MUST
+discriminate on context before selecting a remedy — applying the wrong remedy
+(e.g. expanding a grant to cure a LAW violation) cannot resolve the fault.
+
 ```python
 def handle_acp_error(error, context):
     if isinstance(error, ApprovalRequired):
@@ -534,11 +544,24 @@ def handle_acp_error(error, context):
         return escalate_to_human(context)
     
     elif isinstance(error, WitnessDeficit):
-        # Wait for more witnesses
+        # This class is raised for two distinct deficits:
+        #   - runtime-count deficit (§4.1): too few witnesses gathered at
+        #     execution time -> waiting can still satisfy the requirement.
+        #   - config-level deficit (§5.1): the plan's DECLARED witnessLevel is
+        #     below the law minimum -> waiting cannot raise a static config
+        #     value; the plan must be amended or aborted.
+        if context.get("witness_deficit") == "config":
+            return escalate_or_amend_plan(context)
         return wait_for_witnesses(context, timeout=300)
     
     elif isinstance(error, ScopeViolation):
-        # Request grant expansion
+        # This class is raised for two distinct violations:
+        #   - grant-scope (§4.1): action exceeds the agency grant -> a wider
+        #     grant could legitimately authorize it.
+        #   - law-scope (§5.1): action/trigger is forbidden by society LAW ->
+        #     laws bound the grant, so expanding the grant cannot cure it.
+        if context.get("scope") == "law":
+            return escalate_or_abort(context)
         return request_grant_expansion(context)
     
     elif isinstance(error, LedgerWriteFailure):


### PR DESCRIPTION
## C37 Remediation — `acp-framework.md`

Paired remediation for the merged **C37 delta re-audit** (`docs/audits/C37-acp-framework-audit-2026-06-07.md`, audit PR #282 `e95fc6e7`). Applies every **AUTONOMOUS-routed** §B finding to `web4-standard/core-spec/acp-framework.md`. Single file, 0 new files. The canonical authorities (JSON-LD schema, SDK `to_dict`/`to_jsonld` serializers, conformance vectors) were already correct — only the spec examples/prose lagged, so the spec is brought into line.

### Cluster 1 — §2 example-shape correction
- **§2.4** add required `recordId` (**C37-2, HIGH**); add top-level `timestamp` (B2-3); `ledgerInclusion` object → `canonicalHash` string (C37-3/B2-4/B4-3)
- **§2.1** event-trigger `topic` → `expr` (**B4-1/B2-6, HIGH**); move `expiresAt` into `guards` (B2-7); drop top-level `signatures` (B2-8); delete stray `@context` (B2-9/B5-1)
- **§2.2** add `stepId` (B2-1/C37-1); `proofOfAgency` → `{grantId, planId, intentId, nonce}` dropping schema-forbidden `ledgerProof` (C37-4 autonomous half); drop `explain.alternatives` (B5-3/C37-6)
- **§2.3** drop `modifications: null` (B4-5)

### Cluster 2 — §3 state-machine reconciliation
- **§3.2** add `Complete→Idle` and `Failed→Idle` rows; `Any` → `Any active state` with broadened `Deny / Law-check fail` event label + footnote reconciling the `acp-002` `totalValidTransitions=13` count (C37-7/B3-1/B4-6, B3-2, B3-4)
- **§3.1** relabel diagram `Reject`/`Abort` branches to terminate at `Failed` (B3-3)

### Cluster 3 — §10.2 recovery-branch discrimination (C18-H2 regression fix)
Live instance of the **remediation-introduced-regression** pattern: C18-H2 collapsed two undefined classes onto canonical `ScopeViolation`/`WitnessDeficit`, which the single-branch §10.2 dispatcher then misrouted (safe-abort → wrong active remedy).
- Discriminate `ScopeViolation` law-scope (escalate/abort) vs grant-scope (`request_grant_expansion`); `WitnessDeficit` config-level (`escalate_or_amend_plan`) vs runtime-count (`wait_for_witnesses`) (B1-1/B1-2)
- Taxonomy-dispatch preamble (B1-4); annotated §5.1 raise sites for the cross-reference

### Standalone
- **§6.1** `riskAssessment: RiskProfile` → string enum, removing the dangling undefined `RiskProfile` type (B4-7)

### Deferred as carries (NOT self-applied)
- **DESIGN-Q (operator):** `ledgerProof` admit-vs-drop in ProofOfAgency (B2-2/B5-4, couples §4.2 + schema + SDK + C18-L1); to_dict-vs-JSON-LD §2 example convention (B5-5/C37-8/B4-4)
- **CROSS-TRACK:** C37-5 (three divergent ledger-proof shapes); B1-3 (SDK base `W4_ERR_ACP` → carry-C30); B5-8 (§5.1 casing → C18-M3); B4-8 (`//` JSON comments, corpus-wide)
- **C18 deferred:** M2/M3/M6/M7/L1

**§4.2 `ledgerProof` left untouched** (the DESIGN-Q half).

### Verification
- All 7 `json` blocks parse cleanly after stripping the established `//`-comment and `+0.0x` illustrative conventions
- Scope discipline confirmed by grep: `ledgerInclusion`/`signatures`/`modifications:null`/`RiskProfile`/`explain.alternatives`/`@context` all = 0; `ledgerProof` only at §4.2
- No SDK, schema, or cross-spec files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)