### PR TITLE
remediate(C38): apply autonomous-actionable findings to presence-protocol.md

### DIFF
--- a/web4-standard/core-spec/presence-protocol-CHANGELOG.md
+++ b/web4-standard/core-spec/presence-protocol-CHANGELOG.md
@@ -124,14 +124,20 @@ structured content. See spec §6.
 - `TrustState` is missing `entityId`, `successCount`, `successRate`
   fields in all three SDKs (daemon emits them; SDKs ignore).
 - Daemon's `hestia://society/state` returns `trust_states_known`
-  in snake_case — should be `trustStatesKnown` for consistency
-  (deferred to v1).
+  in snake_case — at v0 this was filed as a casing inconsistency to
+  rename to `trustStatesKnown` (deferred to v1). _Later resolved the
+  other way: `society/state` is an ad-hoc snake_case stats object
+  bound by vector P0-009, so **no rename** — see the Upcoming note
+  and spec §8._
 
 **Not yet implemented at v0 (reserved fields):**
 - `hestia_query_policy` returns default-allow for every action.
   Real policy engine arrives in v1.
 - `approvalToken` in vault_get response is always `null`.
-  Interactive vault approval arrives in v1.
+  Interactive vault approval was forecast for v1 but **deferred** —
+  it did not land in v1 and is now targeted for v2+ (see the v1
+  "Not yet implemented" and "Upcoming" sections). `vault_denied`
+  remains reserved-but-unemittable until it ships.
 - Error codes `policy_denied`, `vault_denied`, `invalid_role` are
   reserved in the registry but the v0 daemon emits
   `internal_error` for these conditions instead.
@@ -152,9 +158,12 @@ implemented at v1" in the v1 section above, and "Known drift" in v0):
 - **Hardbound parity.** Hardbound exposes the v1 trait surface from
   `hardbound-pak`; an actual Hardbound implementation is its own
   private workstream.
-- **`trust_states_known` → `trustStatesKnown`** case fix in
-  `hestia://society/state`. Noted as drift in v0 (deferred to v1)
-  but not resolved in the v1 release.
+_(The v0 "known drift" item `trust_states_known` → `trustStatesKnown`
+is intentionally **not** listed here: the v1 spec resolved it as **no
+rename**. `hestia://society/state` is an ad-hoc stats object that
+stays `snake_case`, bound by conformance vector P0-009; the earlier
+camelCase aspiration contradicted that vector. See spec §8 and the
+per-resource casing split in §3. No casing rename is pending.)_
 
 ---
 

--- a/web4-standard/core-spec/presence-protocol.md
+++ b/web4-standard/core-spec/presence-protocol.md
@@ -111,8 +111,19 @@ is split by surface and is fixed by the JSON Schemas in
   `host_agent`, `action_id`, …), as the input schemas require.
 - **Tool output and all §5 type-catalog shapes are `camelCase`**
   (`sessionId`, `softLct`, `protocolVersion`, …).
-- **§4 resource bodies are `snake_case`** (`sovereign_lct`,
-  `chain_length`, …), matching the bound conformance vectors.
+- **§4 resource bodies follow the casing of what they return** —
+  there is no single blanket rule, because the six resources return
+  different kinds of payload:
+  - `hestia://society/state` returns an **ad-hoc `snake_case`** stats
+    object (`sovereign_lct`, `chain_length`, …) — it is *not* a §5
+    type-catalog struct; its casing is bound by vector P0-009.
+  - `hestia://context/shared` is an **opaque** user-owned JSON
+    namespace with no casing mandate.
+  - The other four resources return §5 type-catalog structs and so
+    carry the same **`camelCase`** keys: `witness/recent` →
+    `WitnessEntry` (`chainPosition`, …; bound by vector P0-010),
+    `session/own` → `Session`, `society/trust/{plugin_id}` →
+    `TrustState`, `vault/{name}` → `VaultEntry`.
 
 Timestamps are ISO-8601 UTC strings. UUIDs are RFC 4122 v4 hex
 with dashes. Session IDs are UUIDs.
@@ -294,8 +305,9 @@ entity or external attestation service; orchestrator implementations
 MUST support both branches today so the protocol stays back-compatible
 when those engines arrive.
 
-**Errors:** `hestia.action_not_found`, `hestia.policy_denied` (when
-deny is enforced), `hestia.internal_error`.
+**Errors:** `hestia.action_not_found`, `hestia.policy_denied` (v1+;
+when deny is enforced — v0 daemons MAY emit `hestia.internal_error`
+instead, see §6.1), `hestia.internal_error`.
 
 ### 3.5 `hestia_vault_get`
 
@@ -447,8 +459,13 @@ The type-catalog shapes below — and all tool **output** shapes —
 use **camelCase keys** regardless of the source language's native
 convention. Languages map to their native casing via serializer
 hints. This camelCase rule does **not** extend to tool *input*
-arguments or §4 resource bodies, both of which are `snake_case`
-per §3 and the bound schemas/vectors.
+arguments, which are `snake_case` per §3 and the bound input
+schemas. For §4 resource bodies the casing is per-resource (see the
+split in §3): a resource that returns one of these §5 structs carries
+its `camelCase` keys (e.g. `witness/recent` → `WitnessEntry`,
+`session/own` → `Session`), while the ad-hoc `society/state` stats
+object is `snake_case` (bound by vector P0-009) and `context/shared`
+is opaque.
 
 ### 5.1 Session
 
@@ -659,9 +676,10 @@ honesty about where it isn't yet held.
 |---|---|---|
 | `PROTOCOL_VERSION` constant exists only in Rust SDK | TS, Python SDKs | Add to both — covered by `1a-4`. |
 | `TrustState` is missing `entityId`, `successCount`, `successRate` in all SDKs | All 3 SDKs | Add fields — covered by `1a-4`. |
-| ~~Error codes `policy_denied`, `vault_denied`, `invalid_role` referenced by SDKs but never emitted by daemon~~ | ~~Daemon~~ | **Resolved in v1.** The policy engine is wired (v1, 2026-05-16); these codes are now emittable. §6.1 marks them `(v1+)`. |
+| ~~Error codes `policy_denied`, `invalid_role` referenced by SDKs but never emitted by daemon~~ | ~~Daemon~~ | **Resolved in v1.** The policy engine is wired (v1, 2026-05-16); these two codes are now emittable. §6.1 marks them `(v1+)`. |
+| `vault_denied` referenced by SDKs but not yet emittable | Daemon | **Still pending.** Its only trigger — interactive vault approval refused (§6.1) — is deferred to v2+ (see §3.5/§3.6 and the CHANGELOG). Reserved in §6.1 as `(v1+)` so SDKs MAY map it, but no daemon can emit it until that approval flow ships. |
 | `WitnessEntry.timestamp` is a string in SDK types but parsed as `chrono::DateTime` in Rust | Rust SDK | Internal — wire format is the string. No spec change. |
-| Daemon's `hestia://society/state` resource returns `trust_states_known` (snake_case) | None — not drift | §3/§4.1 fix `snake_case` as the normative casing for resource bodies, consistent with the §7-bound conformance vectors (`sovereign_lct`, `chain_length`, …). No rename: the earlier camelCase aspiration contradicted the bound vectors. |
+| Daemon's `hestia://society/state` resource returns `trust_states_known` (snake_case) | None — not drift | `society/state` is an **ad-hoc stats object** (not a §5 struct); its `snake_case` keys are bound by vector P0-009 (`sovereign_lct`, `chain_length`, …). **No rename:** the earlier camelCase aspiration contradicted that vector. This is resource-specific — the four §5-typed resource bodies (`witness/recent`, `session/own`, `society/trust/{plugin_id}`, `vault/{name}`) stay `camelCase`, as vector P0-010 (`entries[0].chainPosition`) and the `witness_entry`/`trust_state` schemas require. See the per-resource casing split in §3. |
 | `synthetic` field in §3.1 `hestia_connect` input has no JSON Schema, no conformance vector, no CHANGELOG entry | Spec ↔ artifacts | Discipline gap (C5 audit P2). No v1 `hestia_connect` schema exists (only `v0/tools/hestia_connect.schema.json`); creating one is a structural prerequisite. Until then, `synthetic` is spec-documented but not artifact-conformed. |
 
 ---


### PR DESCRIPTION
## C38 Remediation — presence-protocol.md

Alternation turn following the **C38 audit** (PR #284, merged `1608c2be`). Applies the **5 confirmed AUTONOMOUS-actionable findings** to `presence-protocol.md` + `presence-protocol-CHANGELOG.md`. All edits are spec/CHANGELOG-internal — **no SDK/daemon, no schema/conformance-vector, no DESIGN-Q changes**. The §7 Precedence clause already fixes the canonical direction (schemas/vectors normative), so the per-resource resolution is unambiguous.

### G1 — resource-casing scoping (C38-1 HIGH + C38-3 MED, coupled) — load-bearing
The C5 P6 fix over-generalized *"all resource bodies camelCase"* into a **blanket** *"all §4 resource bodies snake_case"*. But **4 of the 6** §4 resources return camelCase §5-typed structs, and the §7-bound vector **P0-010** reads `witness/recent` as `entries[0].chainPosition` (camel), with `witness_entry.schema.json` forbidding snake via `additionalProperties:false`. The §8 drift table even labeled the blanket "consistent with the §7-bound conformance vectors" — a claim **P0-010 falsifies**.
- Rewrote §3 + §5 + §8 into a **per-resource split**: ad-hoc snake (`society/state`, P0-009) + opaque (`context/shared`) vs §5-typed camel (`witness/recent`→WitnessEntry, `session/own`→Session, `society/trust/{plugin_id}`→TrustState, `vault/{name}`→VaultEntry, P0-010).
- Dropped the false "consistent with the §7-bound vectors" justification.
- Propagated the snake-case `society/state` resolution into the CHANGELOG — removed the **opposite-direction** `trust_states_known → trustStatesKnown` rename forecast; back-annotated the v0 origin.

### G2 — vault_denied / approval-deferral honesty (C38-2 MED + C38-5 LOW, coupled)
§8 swept `vault_denied` into *"Resolved in v1 / now emittable"*, but its only trigger (interactive vault approval) is **deferred to v2+** per §3.5/§3.6 + CHANGELOG.
- Scoped the §8 "Resolved in v1" row to `policy_denied`+`invalid_role`; added a separate **Still-pending** row for `vault_denied` (reserved-but-unemittable).
- Fixed the stale CHANGELOG v0 *"Interactive vault approval arrives in v1"* → deferred (now v2+).

### G3 — reservation-tag cohort symmetry (C38-4 LOW)
Annotated §3.4 `policy_denied` with the `(v1+; v0 daemons MAY emit hestia.internal_error, see §6.1)` marker, mirroring the C5 P9 fix that had reached only the `invalid_role` cohort sibling.

### Notes
- **§8 "as of 2026-05-18" date intentionally NOT bumped** — it denotes the implementation-drift *survey* date; this session corrected documentation-internal errors without re-surveying SDK/daemon source (out of bounds). Deliberate, to avoid reading as staleness.
- Optional `F-r6action-orphan` INFO catalog-label note **skipped** (audit: safe to skip).
- This is the **cleanest remediation-introduced-regression fix since the pattern was born at C36** — 3 of the 5 fresh defects were residuals of the C5 remediation's broadened-wording / un-propagated / asymmetric edits.

### Verification
- Re-verified P0-009 (snake) + P0-010 (camel) against live `presence-protocol-conformance.json` before editing.
- `git grep` confirms no remaining blanket-snake / false-vector-justification / opposite-direction-rename / "approval arrives in v1" assertions.
- CHANGELOG "Upcoming" retains the genuinely-pending approval-flow item; only the resolved rename forecast removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)