### PR TITLE
fix(hub): share one ledger across MCP, REST, and admin surfaces

### DIFF
--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -752,8 +752,21 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
         }
     };
     let shared_law = std::sync::Arc::new(tokio::sync::RwLock::new(initial_law));
-    let mcp_state = McpState::open_with_law(hub_dir.clone(), shared_law.clone()).await?;
-    let rest_state = RestState::open_with_law(hub_dir.clone(), shared_law).await?;
+    // Single in-memory ledger shared across MCP, REST, and admin so an act
+    // recorded through any surface is immediately visible to the others
+    // (previously each surface loaded its own ledger at startup and only
+    // reconverged on restart).
+    let shared_ledger = {
+        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
+        std::sync::Arc::new(tokio::sync::Mutex::new(
+            hub_lib::ledger::HubLedger::open(store).await?,
+        ))
+    };
+    let mcp_state =
+        McpState::open_with_law_and_ledger(hub_dir.clone(), shared_law.clone(), shared_ledger.clone())
+            .await?;
+    let rest_state =
+        RestState::open_with_law_and_ledger(hub_dir.clone(), shared_law, shared_ledger).await?;
     // Admin UI reuses RestState (read-only; shares ledger + law snapshot).
     let admin_state = rest_state.clone();
     let app = mcp_router(mcp_state)

--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -69,21 +69,17 @@ pub struct McpState {
 }
 
 impl McpState {
-    /// Backward-compat: load law from the chapter store into a fresh slot.
-    pub async fn open(hub_dir: PathBuf) -> Result<Self> {
-        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
-        let law: Option<Law> = match store.read_law().await? {
-            Some(yaml) => Some(Law::parse_and_validate(&yaml)?),
-            None => None,
-        };
-        Self::open_with_law(hub_dir, Arc::new(tokio::sync::RwLock::new(law))).await
-    }
-
-    /// Open with a caller-supplied shared law slot. `hub serve` uses
-    /// this so REST + MCP evaluate against the same law + share reload.
-    pub async fn open_with_law(
+    /// Open with a caller-supplied shared law slot AND a shared in-memory
+    /// ledger handle. `hub serve` uses this to give MCP, REST, and the admin
+    /// dashboard a *single* `Arc<Mutex<HubLedger>>`, so an act recorded
+    /// through any one surface is immediately visible to the others. Without
+    /// this, each surface held its own ledger loaded at startup and only
+    /// reconverged on daemon restart — live writes (e.g. a member declaring a
+    /// skill via MCP) were invisible to the admin dashboard until then.
+    pub async fn open_with_law_and_ledger(
         hub_dir: PathBuf,
         law: Arc<tokio::sync::RwLock<Option<Law>>>,
+        ledger: Arc<Mutex<HubLedger>>,
     ) -> Result<Self> {
         let paths = HubPaths::new(hub_dir.clone());
         let config = hub_lib::hub::HubConfig::load(paths.config())?;
@@ -100,15 +96,13 @@ impl McpState {
                 (lct_id, signer)
             }
         };
-        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
-        let ledger = HubLedger::open(store).await?;
         Ok(Self {
             paths,
             hub_id: society.lct_id,
             hub_name: society.name,
             sovereign_lct_id,
             signer,
-            ledger: Arc::new(Mutex::new(ledger)),
+            ledger,
             law,
         })
     }

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -77,16 +77,19 @@ pub struct RestState {
 }
 
 impl RestState {
-    /// Open with the caller-supplied shared law slot. Used by `hub serve`
-    /// so REST + MCP evaluate against the same snapshot + share reload.
-    pub async fn open_with_law(
+    /// As `hub serve` needs it: a caller-supplied shared in-memory ledger
+    /// handle. `hub serve` passes the *same* `Arc<Mutex<HubLedger>>` here and
+    /// to `McpState`, so MCP, REST, and the admin dashboard all read/write one
+    /// ledger — an act recorded through any surface is immediately visible to
+    /// the others (previously each held its own startup snapshot and only
+    /// reconverged on restart).
+    pub async fn open_with_law_and_ledger(
         hub_dir: PathBuf,
         law: Arc<tokio::sync::RwLock<Option<Law>>>,
+        ledger: Arc<Mutex<HubLedger>>,
     ) -> Result<Self> {
         let paths = HubPaths::new(hub_dir.clone());
         let config = hub_lib::hub::HubConfig::load(paths.config())?;
-        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
-        let ledger = HubLedger::open(store).await?;
         let society = load_society(&hub_dir).await?;
 
         // Build the right Sovereign LCT + signer for the chapter's mode.
@@ -111,7 +114,10 @@ impl RestState {
         // public key recorded at admission time.
         let mut resolver = MapResolver::new();
         resolver.insert(sovereign_lct.clone());
-        let projected = HubState::project(&ledger);
+        let projected = {
+            let l = ledger.lock().await;
+            HubState::project(&*l)
+        };
         for (member_lct_id, pubkey_hex) in &projected.member_pubkeys {
             match hub_lib::hub::hestia_sovereign_lct(*member_lct_id, pubkey_hex) {
                 Ok(lct) => resolver.insert(lct),
@@ -144,24 +150,11 @@ impl RestState {
             hub_name: society.name.clone(),
             sovereign_lct_id: sovereign_lct.id,
             signer,
-            ledger: Arc::new(Mutex::new(ledger)),
+            ledger,
             nonces: Arc::new(NonceStore::new()),
             resolver: Arc::new(tokio::sync::RwLock::new(resolver)),
             law,
         })
-    }
-
-    /// Backward-compat: load the chapter's law from storage into a
-    /// fresh slot. Standalone callers that don't need REST/MCP shared
-    /// reload can use this.
-    pub async fn open(hub_dir: PathBuf) -> Result<Self> {
-        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
-        let law: Option<Law> = match store.read_law().await? {
-            Some(yaml) => Some(Law::parse_and_validate(&yaml)
-                .map_err(|e| anyhow::anyhow!("loading chapter law: {}", e))?),
-            None => None,
-        };
-        Self::open_with_law(hub_dir, Arc::new(tokio::sync::RwLock::new(law))).await
     }
 
     /// Re-read the chapter law from storage and swap it into the


### PR DESCRIPTION
## Problem

`hub serve` builds **two independent in-memory ledgers** — one in `McpState`, one in `RestState` (which `admin` clones). They share `shared_law` but **not** the ledger. So an act recorded through one surface (e.g. a member declaring a skill via the MCP `declare_skill` tool) updates only that surface's in-memory ledger + the on-disk store; the other surface keeps serving the snapshot it loaded at startup until the daemon restarts.

**Observed in the field:** a fleet machine declared a skill via MCP. `GET /tools/query_chapter` (MCP ledger) reflected it immediately (`last_ledger_index` advanced), but `GET /admin/ledger` (REST ledger) did **not** — the read-only operator dashboard silently lagged committed state until a restart. Counts disagreed across surfaces for the same chapter.

## Fix

Build a **single** `Arc<Mutex<HubLedger>>` in `run_serve` and hand the same handle to both `McpState` and `RestState`, via a new `open_with_law_and_ledger` constructor — mirroring how `shared_law` is already shared. All three surfaces (MCP, REST, admin) now read/write one ledger, so a write through any surface is immediately visible to the others.

Also removed the now-unused `open` / `open_with_law` constructors on both states (no callers across `src`, tests, or examples; `hub-daemon` is a binary crate so `pub` grants no external API). Net `hub-daemon` build warnings **2 → 0**.

## Verification

- `cargo build --release` — `hub-daemon` builds clean (0 warnings; remaining warnings are pre-existing in `web4-core` / `web4-trust-core`).
- `cargo test --release` — **118 passed, 0 failed**.
- Manual: `POST /tools/declare_skill` then immediately `GET /admin/ledger` — the new entry appears **without** a daemon restart (was stale before this change).

## Notes

- Behavior-only change to daemon state wiring; no schema, ledger format, or API surface changes.
- The MVP write-auth model (writes accepted from any client and signed as Sovereign) is unchanged and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)