### PR TITLE
remediate(C39): apply autonomous-actionable findings to society-roles.md

### DIFF
--- a/web4-standard/core-spec/society-roles.md
+++ b/web4-standard/core-spec/society-roles.md
@@ -1,7 +1,7 @@
 # Society Roles Specification
 
 **Status**: Core Specification v0.1.0 (DRAFT)
-**Date**: 2026-05-13
+**Date**: 2026-06-08
 **Category**: Society Structure
 **Extends**: `SOCIETY_SPECIFICATION.md` (single-society structural requirements)
 **Companion to**: `entity-types.md` (taxonomy of entities that can fill roles), `inter-society-protocol.md` (inter-society interactions)
@@ -48,7 +48,7 @@ Roles a society MAY define when its needs warrant, but that are not required for
 
 ## 2. Base-Mandatory Roles
 
-Every Web4-compliant society MUST have these seven roles filled. A single entity MAY fill multiple roles in a small society (e.g., a solo founder fills Sovereign + Treasurer + Administrator + Archivist + Citizen simultaneously). The roles must exist; how many entities fill them is per-society scale.
+Every Web4-compliant society MUST have these seven roles filled. A single entity MAY fill multiple roles in a small society (e.g., a solo founder fills all seven — Sovereign + Law Oracle + Policy-Entity + Treasurer + Administrator + Archivist + Citizen — simultaneously). The roles must exist; how many entities fill them is per-society scale.
 
 ### 2.1 Sovereign
 
@@ -178,7 +178,7 @@ Every Web4-compliant society MUST have these seven roles filled. A single entity
 **Example filling entities**: Human, AI, Organization, Society (when one society is citizen of another in fractal nesting), any Agentic or Delegative entity
 
 **Notes**:
-- Citizenship is universal across Web4 entities; the citizen-role mechanics are detailed in `entity-types.md` §3.1
+- Citizenship is universal across Web4 entities; the citizen-role principle and structure are detailed in `entity-types.md` §3.1, and the pairing mechanics (prerequisite check, permanence, termination) in §3.4
 - Every entity in a Web4 society holds Citizen as its base role; additional roles are paired on top
 
 ## 3. Context-Mandatory Roles
@@ -322,7 +322,7 @@ For Web4 specifically, this enables:
 
 | Society scale | Role-filling pattern |
 |---|---|
-| Solo founder | One entity (human) fills 6+ of 7 base-mandatory roles |
+| Solo founder | One entity (human) fills all 7 base-mandatory roles (Policy-Entity decisions may be AI-assisted) |
 | Small team (~5-20 members) | Each role typically one entity; some entities wear multiple hats |
 | Medium organization (~50-500) | Each role is one team / sub-organization |
 | Large enterprise (~1000+) | Each role is a sub-society; the society itself is a federation of role-societies |
@@ -367,8 +367,8 @@ T3 trust scores for the society as a whole (in inter-society contexts) are deriv
 |---|---|
 | `SOCIETY_SPECIFICATION.md` | Specifies structural requirements (Law Oracle, Ledger, Treasury, Society LCT); this spec specifies the roles that operate on those structures |
 | `entity-types.md` | Lists entity types with example roles each can fill; this spec lists roles with example entities each can be filled by (the symmetric dual) |
-| `inter-society-protocol.md` | Inter-society interactions reference the Diplomat role (§2.2 federation genesis). This spec's §6.2 defines semantic viability criteria that constrain role composition. ATP measurement witnessing (§4.6) involves the Witness role at the resource attestation layer. Bidirectional dependency. |
-| `mcp-protocol.md` | MCP actions consume the role taxonomy directly: Policy-Entity signs action decisions (§7.3), Witness co-signs high-consequence actions (§7.5), Archivist persists audit bundles (§7.3), Treasurer negotiates exchange rates (§7.7). |
+| `inter-society-protocol.md` | Inter-society interactions reference the Diplomat role (`inter-society-protocol.md` §2.2 federation genesis). That spec's §6.2 defines semantic viability criteria that constrain role composition. ATP measurement witnessing (`inter-society-protocol.md` §4.6) involves the Witness role at the resource attestation layer. Bidirectional dependency. |
+| `mcp-protocol.md` | MCP actions consume the role taxonomy directly: Policy-Entity signs action decisions (§7.3), Witness co-signs high-consequence actions (§7.3; selection governed by §7.5), Archivist persists audit bundles (§7.3), Treasurer negotiates exchange rates (§7.7, WIP v0.1.0-draft). |
 | `web4-society-authority-law.md` | The SAL spec defines Citizen, Authority, Law Oracle, Witness, and Auditor from the Society–Authority–Law perspective with detailed normative requirements (birth certificates, delegation chains, ledger interfaces, audit transcripts). This spec provides the role taxonomy; SAL provides the operational protocol for a subset of those roles. |
 | `r6-framework.md` | R6 actions are dispatched through Administrator, evaluated by Policy-Entity, witnessed by Witness, recorded by Archivist |
 | `r7-framework.md` | R7 actions add Reputation back-propagation through the same role chain |


### PR DESCRIPTION
## C39 Remediation — `society-roles.md`

Paired remediation for the merged **C39 audit** (PR #286, `1a2d5a58`). Applies all **5 autonomous-actionable** findings in 3 cohesive groups + BC#15 date bump. **One file** (`web4-standard/core-spec/society-roles.md`), corrections only — no new normative content.

### Group 1 — §7 table accuracy
- **F1 (MED)** — §7 `inter-society-protocol.md` row: `"This spec's §6.2"` → `"That spec's §6.2"` (the row's subject is `inter-society-protocol.md`, so "that spec" now resolves correctly); bare §2.2/§4.6 qualified with the explicit filename. **Closes the C7-M4-residual [[remediation-introduced-regression]]** — the C7 remediation copied a reciprocal sentence from inter-society-protocol.md without rebinding the possessive, so the section-number holds-check passed while the deixis silently broke. (Reinforces the regression checklist's new deixis/possessive item.)
- **F2 (LOW)** — §7 `mcp-protocol.md` row: Witness co-signing cite §7.5 → **§7.3** (the requirement-establishing MUST, mcp L398; §7.5 governs *selection* and back-refs §7.3). Annotated `(§7.3; selection governed by §7.5)`.
- **F3 (LOW)** — §7 mcp row: Treasurer §7.7 cite annotated `(§7.7, WIP v0.1.0-draft)`.

### Group 2 — editorial harmonization
- **F4 (INFO)** — §2.7 citizen-mechanics cite §3.1 → §3.1 (principle/structure) **+ §3.4** (pairing mechanics).
- **F5 (LOW)** — solo-founder role count stated three ways (§2 "e.g." 5 roles / §5 "6+" / §5.1 lists 7) harmonized to **all 7** (§2 example expanded; §5 table "6+ of 7" → "all 7, Policy-Entity decisions may be AI-assisted").

### Group 3 — date hygiene (BC#15)
- Header `Date: 2026-05-13` → `2026-06-08`. §9 acknowledgment historical date (`2026-05-13` dialogue with dp) **left untouched**.

### Deferred (operator / cross-track — NOT this turn)
- **D1/D2** canonical 7-role home (carry-C25-H1) — operator-gated; the real fix lives in `SOCIETY_SPECIFICATION.md` §1.2.5 (its citation to ISP §6.2 is factually broken regardless of canonical-home choice).
- **D3** Policy-Entity casing (carry-C35-F9) — operator naming decision; this file's hyphenation deliberately unchanged (it is the cited authority for the hyphenated role-name form).

**Policy review**: APPROVED first-pass. Reviewer independently verified F2 (Witness MUST at mcp §7.3 L398; §7.5 back-refs it) and F1 (society-roles.md §6 is a flat checklist with no §6.2).

The C7→C39 society-roles audit-remediation pair is now both halves complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)