### PR TITLE
fix(hub): persist role-fill on assign_role (was ledger-only)

### DIFF
--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -246,14 +246,13 @@ enum Command {
         reason: Option<String>,
     },
 
-    /// Assign a role to a member.
+    /// Assign a role to a member. The role LCT is society-managed (created
+    /// on first fill, reused on rotation) — no role-lct-id argument needed.
     AssignRole {
         hub_dir: PathBuf,
         /// One of: sovereign | law_oracle | policy_entity | treasurer
         /// | administrator | archivist | citizen | witness | auditor.
         role: String,
-        /// The role LCT id (taken from `hub init` output or `hub status`).
-        role_lct_id: Uuid,
         /// The member LCT id.
         member_lct_id: Uuid,
     },
@@ -489,8 +488,8 @@ async fn main() -> Result<()> {
         Some(Command::RemoveMember { hub_dir, member_lct_id, reason }) => {
             run_remove_member(hub_dir, member_lct_id, reason).await
         }
-        Some(Command::AssignRole { hub_dir, role, role_lct_id, member_lct_id }) => {
-            run_assign_role(hub_dir, role, role_lct_id, member_lct_id).await
+        Some(Command::AssignRole { hub_dir, role, member_lct_id }) => {
+            run_assign_role(hub_dir, role, member_lct_id).await
         }
         Some(Command::RecordEvent { hub_dir, event_kind, title, attended_by }) => {
             run_record_event(hub_dir, event_kind, title, attended_by).await
@@ -641,15 +640,13 @@ async fn run_remove_member(hub_dir: PathBuf, member_lct_id: Uuid, reason: Option
 async fn run_assign_role(
     hub_dir: PathBuf,
     role: String,
-    role_lct_id: Uuid,
     member_lct_id: Uuid,
 ) -> Result<()> {
     let parsed = parse_role(&role)?;
     let mut session = HubSession::open(&hub_dir).await?;
-    let entry = session.assign_role(parsed.clone(), role_lct_id, member_lct_id).await?;
+    let entry = session.assign_role(parsed.clone(), member_lct_id).await?;
     println!("Role assigned.");
     println!("  Role:         {:?}", parsed);
-    println!("  Role LCT:     {}", role_lct_id);
     println!("  Member LCT:   {}", member_lct_id);
     println!("  Entry index:  {}", entry.index);
     println!("  Entry hash:   {}", entry.entry_hash);
@@ -807,7 +804,7 @@ async fn run_query(sub: QueryCommand) -> Result<()> {
                 for role in &unfilled {
                     println!("    {:?}", role);
                 }
-                println!("    (assign via `hub assign-role <chapter-dir> <role> <role-lct-id> <member-lct-id>` per chapter law)");
+                println!("    (assign via `hub assign-role <chapter-dir> <role> <member-lct-id>` per chapter law)");
             }
             Ok(())
         }

--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -276,7 +276,11 @@ async fn add_member(
 #[derive(Deserialize)]
 struct AssignRoleRequest {
     role: SocietyRole,
-    role_lct_id: Uuid,
+    /// Ignored if supplied — the role LCT is society-managed. Accepted for
+    /// back-compat with pre-fix clients that sent it.
+    #[serde(default)]
+    #[allow(dead_code)]
+    role_lct_id: Option<Uuid>,
     member_lct_id: Uuid,
 }
 
@@ -284,9 +288,22 @@ async fn assign_role(
     State(s): State<McpState>,
     Json(req): Json<AssignRoleRequest>,
 ) -> Result<Json<EventRecordedResponse>, ApiError> {
+    // Update the persisted society role-fill (web4-core enforces authority and
+    // owns the role LCT), then witness the act in the ledger with that LCT.
+    // Without the society update the assignment never showed as filled.
+    let mut store = hub_lib::store::open_chapter_store(&s.paths.root)
+        .map_err(ApiError::internal)?;
+    let mut society = store.read_society().await
+        .map_err(ApiError::internal)?
+        .ok_or_else(|| ApiError::internal(anyhow::anyhow!("society state missing")))?;
+    let role_lct_id = society
+        .assign_role(req.role.clone(), req.member_lct_id, s.sovereign_lct_id)
+        .map_err(|e| ApiError::forbidden(format!("role assignment rejected: {e}")))?;
+    store.write_society(&society).await.map_err(ApiError::internal)?;
+
     let event = HubEvent::RoleAssigned {
         role: req.role,
-        role_lct_id: req.role_lct_id,
+        role_lct_id,
         assigned_to: req.member_lct_id,
         assigned_by: s.sovereign_lct_id,
     };

--- a/hub/hub-lib/src/session.rs
+++ b/hub/hub-lib/src/session.rs
@@ -100,7 +100,25 @@ impl HubSession {
         self.append(event).await
     }
 
-    pub async fn assign_role(&mut self, role: SocietyRole, role_lct_id: Uuid, member_lct_id: Uuid) -> Result<&LedgerEntry> {
+    /// Assign `role` to `member_lct_id`. Updates the persisted society
+    /// role-fill (web4-core enforces Sovereign/Administrator authority and
+    /// owns the role LCT — created on first fill, reused on rotation) AND
+    /// witnesses the act in the ledger. The role LCT id is society-managed,
+    /// not caller-supplied: previously the act was only appended to the
+    /// ledger and never folded into the society, so assigned roles never
+    /// showed as filled in query_chapter / MCP / the admin dashboard.
+    pub async fn assign_role(&mut self, role: SocietyRole, member_lct_id: Uuid) -> Result<&LedgerEntry> {
+        let mut store = open_chapter_store(&self.paths.root)
+            .context("opening chapter store to update role-fill")?;
+        let mut society = store.read_society().await
+            .context("reading society state")?
+            .ok_or_else(|| anyhow::anyhow!("society state missing for chapter"))?;
+        let role_lct_id = society
+            .assign_role(role.clone(), member_lct_id, self.sovereign_lct_id)
+            .map_err(|e| anyhow::anyhow!("role assignment rejected: {e}"))?;
+        store.write_society(&society).await
+            .context("persisting updated role-fill")?;
+
         let event = HubEvent::RoleAssigned {
             role,
             role_lct_id,
@@ -376,6 +394,30 @@ mod tests {
 
         let st = session.status();
         assert_eq!(st.member_count, 2); // Sovereign + Bob
+    }
+
+    #[tokio::test]
+    async fn assign_role_fills_role_in_society() {
+        // Regression: assign_role used to only append a RoleAssigned ledger
+        // event without updating the persisted society, so the role never
+        // showed as filled in query_chapter / MCP / admin. It must now fold
+        // into the society role-fill.
+        let (_tmp, dir) = fresh_chapter().await;
+        let alice = Uuid::new_v4();
+        {
+            let mut session = HubSession::open(&dir).await.unwrap();
+            session.add_member(alice, Some("Alice".into())).await.unwrap();
+            session.assign_role(SocietyRole::Administrator, alice).await.unwrap();
+        }
+        // Re-read society from the store (what query_chapter / admin read).
+        let society = load_society(&dir).await.unwrap();
+        let admin = society
+            .get_role(&SocietyRole::Administrator)
+            .expect("Administrator role should be filled after assign_role");
+        assert_eq!(
+            admin.filling_entity_lct_id, alice,
+            "Administrator should be filled by the assigned member"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`assign_role` — both the CLI path (`HubSession::assign_role`) and the MCP `/tools/assign_role` handler — only appended a `RoleAssigned` event to the ledger. It never updated the persisted `Society`, and `HubState::project` doesn't fold `RoleAssigned` either. So an assigned role was **witnessed in the ledger but never showed as filled** in `query_chapter`, MCP, or the `/admin/roles` dashboard. Confirmed on the live "Web4 Fleet" hub: `assign-role` returned success + an entry index, but role-fill stayed at sovereign+citizen.

## Fix

Both paths now route the fill through web4-core's `Society::assign_role(role, entity, assigned_by)` — which already enforces Sovereign/Administrator authority and owns the role LCT (created on first fill, reused on rotation) — then persist via `HubStore::write_society`, and witness the act in the ledger with the **society-managed** role LCT.

Consequences:
- The role LCT is society-managed, not operator-supplied. CLI drops its `<role-lct-id>` positional arg → `hub assign-role <dir> <role> <member-lct-id>`.
- The MCP request's `role_lct_id` becomes an ignored, back-compat optional field.

## Test

`assign_role_fills_role_in_society` (hub-lib/src/session.rs) — add a member, assign Administrator, re-read the society from the store, assert the role is filled by that member. Fails before this change.

`cargo test --release`: **128 passed, 0 failed.** Behavior-only — the `RoleAssigned` ledger event shape is unchanged, so existing ledgers parse identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)