### PR TITLE
refactor(hub): finish chapter→hub rename in code (store/init/query/db)

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -346,7 +346,7 @@ async fn council(State(s): State<RestState>) -> Result<Html<String>, AdminError>
     let projected = HubState::project(&*ledger);
     drop(ledger);
     let proposals = {
-        let store = hub_lib::store::open_chapter_store(&s.paths.root)
+        let store = hub_lib::store::open_hub_store(&s.paths.root)
             .map_err(|e| AdminError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         store.list_proposals().await
             .map_err(|e| AdminError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
@@ -477,8 +477,8 @@ async fn pairs(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
 }
 
 async fn law(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
-    use hub_lib::store::open_chapter_store;
-    let store = open_chapter_store(&s.paths.root)?;
+    use hub_lib::store::open_hub_store;
+    let store = open_hub_store(&s.paths.root)?;
     let yaml = store.read_law().await?;
 
     let mut body = String::from("<h2>Chapter law</h2>");

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 
 use hub_lib::hub::HubConfig;
 use hub_lib::identity::IdentityFile;
-use hub_lib::init::{init_chapter, verify_chapter, InitArgs, InitResult};
+use hub_lib::init::{init_hub, verify_hub, InitArgs, InitResult};
 use hub_lib::session::HubSession;
 use uuid::Uuid;
 use web4_core::lct::EntityType;
@@ -38,7 +38,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Initialize a new chapter society in the given directory.
+    /// Initialize a new hub society in the given directory.
     ///
     /// Two modes:
     /// - **Local mode** (MVP-compatible): pass `--sovereign-lct PATH` to a
@@ -48,7 +48,7 @@ enum Command {
     ///   The hub holds NO keypair; Genesis is signed by Hestia via the
     ///   callback URL.
     Init {
-        /// Human-readable chapter name (e.g. "Lisbon Chapter").
+        /// Human-readable hub name (e.g. "Lisbon Chapter").
         name: String,
 
         /// **Local mode**: path to the Sovereign IdentityFile (LCT + keypair).
@@ -186,7 +186,7 @@ enum Command {
     /// entry's hash matches recomputation, prev-hash chain is unbroken,
     /// indices are sequential. Errors loudly if any entry is tampered.
     VerifyLedger {
-        /// Path to the chapter directory.
+        /// Path to the hub directory.
         hub_dir: PathBuf,
     },
 
@@ -198,7 +198,7 @@ enum Command {
     /// suffixes so they remain recoverable. Runs verify-ledger on the
     /// migrated chapter before returning success.
     Migrate {
-        /// Path to the chapter directory.
+        /// Path to the hub directory.
         hub_dir: PathBuf,
 
         /// Target backend: `file` or `sqlite`.
@@ -257,7 +257,7 @@ enum Command {
         member_lct_id: Uuid,
     },
 
-    /// Record a chapter event (demo night, workshop, etc.).
+    /// Record a hub event (demo night, workshop, etc.).
     RecordEvent {
         hub_dir: PathBuf,
         /// Short event kind (e.g. "demo_night", "workshop").
@@ -278,7 +278,7 @@ enum Command {
 
     /// Set (or amend) the chapter's law from a YAML file (V2-8).
     /// Validates the YAML against the chapter-law schema, writes it
-    /// to the chapter store, and appends a LawAmended event to the
+    /// to the hub store, and appends a LawAmended event to the
     /// ledger for audit.
     SetLaw {
         hub_dir: PathBuf,
@@ -297,7 +297,7 @@ enum Command {
 
     /// Write the starter chapter-law template to a file the operator
     /// can review + edit, then apply via `hub set-law`. Doesn't touch
-    /// any chapter directly.
+    /// any hub directly.
     InitLaw {
         /// Where to write the starter YAML (e.g. ./hub-law.yaml).
         #[arg(default_value = "./hub-law.yaml")]
@@ -822,7 +822,7 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
     // the same in-memory snapshot, and so the REST reload-law endpoint
     // refreshes both surfaces in one call.
     let initial_law = {
-        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
+        let store = hub_lib::store::open_hub_store(&hub_dir)?;
         match store.read_law().await? {
             Some(yaml) => Some(hub_lib::law::Law::parse_and_validate(&yaml)?),
             None => None,
@@ -834,7 +834,7 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
     // (previously each surface loaded its own ledger at startup and only
     // reconverged on restart).
     let shared_ledger = {
-        let store = hub_lib::store::open_chapter_store(&hub_dir)?;
+        let store = hub_lib::store::open_hub_store(&hub_dir)?;
         std::sync::Arc::new(tokio::sync::Mutex::new(
             hub_lib::ledger::HubLedger::open(store).await?,
         ))
@@ -877,7 +877,7 @@ async fn shutdown_signal() {
 }
 
 async fn run_verify_ledger(hub_dir: PathBuf) -> Result<()> {
-    let result = verify_chapter(&hub_dir).await?;
+    let result = verify_hub(&hub_dir).await?;
     println!("Ledger verified.");
     println!("  Chapter dir:    {}", result.hub_dir.display());
     println!("  Chapter name:   {}", result.hub_name);
@@ -891,7 +891,7 @@ async fn run_migrate(hub_dir: PathBuf, to: String) -> Result<()> {
     let target = hub_lib::store::BackendKind::from_str(&to)
         .context("parsing --to")?;
     println!("Migrating {} → {}", hub_dir.display(), target.as_str());
-    let result = hub_lib::store::migrate_chapter(&hub_dir, target).await
+    let result = hub_lib::store::migrate_hub(&hub_dir, target).await
         .context("migrating chapter")?;
     if result.source_backend == result.target_backend {
         println!("Source backend is already {}; nothing to do.", target.as_str());
@@ -908,7 +908,7 @@ async fn run_migrate(hub_dir: PathBuf, to: String) -> Result<()> {
     }
     println!();
     println!("Verifying migrated chapter end-to-end ...");
-    let verify = verify_chapter(&hub_dir).await
+    let verify = verify_hub(&hub_dir).await
         .context("post-migration ledger verification failed")?;
     println!("Ledger verified on {} backend.", target.as_str());
     println!("  Entries:        {}", verify.entries);
@@ -933,7 +933,7 @@ async fn run_init(
     let result = match (sovereign_lct, sovereign_hestia) {
         (Some(path), None) => {
             // Local mode
-            init_chapter(InitArgs {
+            init_hub(InitArgs {
                 hub_name: name,
                 hub_dir,
                 sovereign_lct_path: path,
@@ -945,7 +945,7 @@ async fn run_init(
             let lct_id = sovereign_lct_id.expect("clap requires_all");
             let pubkey_hex = sovereign_pubkey.expect("clap requires_all");
             println!("hub init: Hestia mode — Genesis will be signed by {}", callback_url);
-            hub_lib::init::init_chapter_hestia(hub_lib::init::HestiaInitArgs {
+            hub_lib::init::init_hub_hestia(hub_lib::init::HestiaInitArgs {
                 hub_name: name,
                 hub_dir,
                 sovereign_lct_id: lct_id,
@@ -974,7 +974,7 @@ async fn run_init(
             }
             println!();
             println!("Next: in sprint 2 this is where you'd start recording events.");
-            println!("      For now, inspect the chapter dir or run `hub init {} ...` again",
+            println!("      For now, inspect the hub dir or run `hub init {} ...` again",
                      "<same-name>");
             println!("      to verify idempotency.");
         }
@@ -1161,7 +1161,7 @@ mod tests {
     fn slugify_handles_common_cases() {
         assert_eq!(slugify("Lisbon Chapter"), "lisbon-chapter");
         assert_eq!(slugify("NYC Chapter #1"), "nyc-chapter-1");
-        // Unicode letters survive via char::is_alphanumeric — fine for chapter dirs.
+        // Unicode letters survive via char::is_alphanumeric — fine for hub dirs.
         assert_eq!(slugify("São Paulo"), "são-paulo");
         assert_eq!(slugify("東京"), "東京");
         assert_eq!(slugify("   spaces   "), "spaces");

--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -10,7 +10,7 @@
 //!
 //! Tools:
 //! - GET  /tools                 → list available tools + descriptions
-//! - GET  /tools/query_chapter   → chapter identity + role-fill snapshot + recent events
+//! - GET  /tools/query_hub      → hub identity + role-fill snapshot + recent events
 //! - GET  /tools/list_members    → all current members (projected from ledger)
 //! - GET  /tools/find_skill      → ?q=...  case-insensitive skill search
 //! - POST /tools/add_member      → {member_lct_id, name?} — records MemberAdded
@@ -111,7 +111,9 @@ impl McpState {
 pub fn router(state: McpState) -> Router {
     Router::new()
         .route("/tools", get(list_tools))
-        .route("/tools/query_chapter", get(query_chapter))
+        .route("/tools/query_hub", get(query_hub))
+        // Back-compat alias for pre-rename clients (was query_chapter).
+        .route("/tools/query_chapter", get(query_hub))
         .route("/tools/list_members", get(list_members))
         .route("/tools/find_skill", get(find_skill))
         .route("/tools/add_member", post(add_member))
@@ -164,20 +166,20 @@ struct ToolDescriptor {
 
 async fn list_tools() -> Json<Vec<ToolDescriptor>> {
     Json(vec![
-        ToolDescriptor { name: "query_chapter",  method: "GET",  description: "Chapter identity + role-fill + recent events" },
-        ToolDescriptor { name: "list_members",   method: "GET",  description: "Current chapter members" },
+        ToolDescriptor { name: "query_hub",       method: "GET",  description: "Hub identity + role-fill + recent events" },
+        ToolDescriptor { name: "list_members",   method: "GET",  description: "Current hub members" },
         ToolDescriptor { name: "find_skill",     method: "GET",  description: "Find members by skill (substring, case-insensitive). ?q=..." },
         ToolDescriptor { name: "add_member",     method: "POST", description: "Add a new member" },
         ToolDescriptor { name: "assign_role",    method: "POST", description: "Assign a role to a member" },
-        ToolDescriptor { name: "record_event",   method: "POST", description: "Record a chapter event (demo night, workshop, etc.)" },
+        ToolDescriptor { name: "record_event",   method: "POST", description: "Record a hub event (demo night, workshop, etc.)" },
         ToolDescriptor { name: "declare_skill",  method: "POST", description: "Declare a skill for a member" },
     ])
 }
 
-// ---------- GET /tools/query_chapter ----------
+// ---------- GET /tools/query_hub (alias: /tools/query_chapter) ----------
 
 #[derive(Serialize)]
-struct QueryChapterResponse {
+struct QueryHubResponse {
     hub_name: String,
     founding_sovereign_lct_id: Option<Uuid>,
     charter_hash: Option<String>,
@@ -187,7 +189,7 @@ struct QueryChapterResponse {
     head_hash: String,
 }
 
-async fn query_chapter(State(s): State<McpState>) -> Result<Json<QueryChapterResponse>, ApiError> {
+async fn query_hub(State(s): State<McpState>) -> Result<Json<QueryHubResponse>, ApiError> {
     let ledger = s.ledger.lock().await;
     let state = HubState::project(&ledger);
     let society = load_society(s.paths.root.clone()).await?;
@@ -195,7 +197,7 @@ async fn query_chapter(State(s): State<McpState>) -> Result<Json<QueryChapterRes
         .map(|(k, v)| (k.clone(), v.filling_entity_lct_id))
         .collect();
     let member_count = state.member_count();
-    Ok(Json(QueryChapterResponse {
+    Ok(Json(QueryHubResponse {
         hub_name: state.hub_name,
         founding_sovereign_lct_id: state.founding_sovereign_lct_id,
         charter_hash: state.charter_hash,
@@ -291,7 +293,7 @@ async fn assign_role(
     // Update the persisted society role-fill (web4-core enforces authority and
     // owns the role LCT), then witness the act in the ledger with that LCT.
     // Without the society update the assignment never showed as filled.
-    let mut store = hub_lib::store::open_chapter_store(&s.paths.root)
+    let mut store = hub_lib::store::open_hub_store(&s.paths.root)
         .map_err(ApiError::internal)?;
     let mut society = store.read_society().await
         .map_err(ApiError::internal)?
@@ -384,7 +386,7 @@ async fn append_with_sovereign(
             Decision::Allow => { /* proceed */ }
             Decision::Deny => {
                 return Err(ApiError::forbidden(format!(
-                    "act denied by chapter law (norm: {})",
+                    "act denied by hub law (norm: {})",
                     outcome.winning_norm.as_deref().unwrap_or("?")
                 )));
             }

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -164,7 +164,7 @@ impl RestState {
     /// restarting hub serve.
     pub async fn reload_law(&self) -> anyhow::Result<String> {
         use anyhow::Context;
-        let store = hub_lib::store::open_chapter_store(&self.paths.root)
+        let store = hub_lib::store::open_hub_store(&self.paths.root)
             .context("opening store for law reload")?;
         let new_law: Option<Law> = match store.read_law().await? {
             Some(ref yaml) => Some(Law::parse_and_validate(yaml)
@@ -470,7 +470,7 @@ async fn submit_event(
                 return Err(ApiError {
                     status: StatusCode::FORBIDDEN,
                     message: format!(
-                        "act denied by chapter law (norm: {})",
+                        "act denied by hub law (norm: {})",
                         outcome.winning_norm.as_deref().unwrap_or("?")
                     ),
                 });
@@ -716,7 +716,7 @@ async fn submit_join(
                 return Err(ApiError {
                     status: StatusCode::FORBIDDEN,
                     message: format!(
-                        "membership denied by chapter law (norm: {})",
+                        "membership denied by hub law (norm: {})",
                         outcome.winning_norm.as_deref().unwrap_or("?")
                     ),
                 });
@@ -1065,21 +1065,21 @@ async fn get_proposal(
 // awaits here.
 
 async fn persist_proposal(s: &RestState, proposal: &CouncilProposal) -> Result<(), ApiError> {
-    let mut store = hub_lib::store::open_chapter_store(&s.paths.root)
+    let mut store = hub_lib::store::open_hub_store(&s.paths.root)
         .map_err(ApiError::internal)?;
     store.write_proposal(proposal).await
         .map_err(ApiError::internal)
 }
 
 async fn read_proposal(s: &RestState, id: Uuid) -> Result<Option<CouncilProposal>, ApiError> {
-    let store = hub_lib::store::open_chapter_store(&s.paths.root)
+    let store = hub_lib::store::open_hub_store(&s.paths.root)
         .map_err(ApiError::internal)?;
     store.read_proposal(id).await
         .map_err(ApiError::internal)
 }
 
 async fn read_all_proposals(s: &RestState) -> Result<Vec<CouncilProposal>, ApiError> {
-    let store = hub_lib::store::open_chapter_store(&s.paths.root)
+    let store = hub_lib::store::open_hub_store(&s.paths.root)
         .map_err(ApiError::internal)?;
     store.list_proposals().await
         .map_err(ApiError::internal)
@@ -1384,7 +1384,7 @@ async fn submit_pair_request(
             Decision::Deny => {
                 return Err(ApiError {
                     status: StatusCode::FORBIDDEN,
-                    message: "pair_request denied by chapter law".into(),
+                    message: "pair_request denied by hub law".into(),
                 });
             }
             Decision::Escalate => {
@@ -1653,7 +1653,7 @@ async fn post_pair_message(
         ephemeral_pub_hex: None,
     };
     {
-        let mut store = hub_lib::store::open_chapter_store(&s.paths.root)
+        let mut store = hub_lib::store::open_hub_store(&s.paths.root)
             .map_err(ApiError::internal)?;
         store.append_pair_message(&msg).await
             .map_err(ApiError::internal)?;
@@ -1712,7 +1712,7 @@ async fn get_pair_messages(
             return Err(ApiError::not_found(format!("pair {} not found", pair_id)));
         }
     }
-    let store = hub_lib::store::open_chapter_store(&s.paths.root)
+    let store = hub_lib::store::open_hub_store(&s.paths.root)
         .map_err(ApiError::internal)?;
     let messages = store.list_pair_messages(pair_id, q.since).await
         .map_err(ApiError::internal)?;

--- a/hub/hub-lib/src/charter.rs
+++ b/hub/hub-lib/src/charter.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Metalinxx Inc.
 
-//! Chapter charter — the constitutional document of a chapter society.
+//! Chapter charter — the constitutional document of a hub society.
 //!
 //! Sprint 1: minimal charter with chapter name, founding date, Sovereign LCT
 //! reference, a free-text preamble, and an empty rules list. The charter
@@ -21,13 +21,13 @@ use web4_core::crypto::sha256_hex;
 /// Schema version of the on-disk charter file. Bump on breaking changes.
 pub const CHARTER_SCHEMA_VERSION: &str = "0.1";
 
-/// A chapter charter — minimal MVP shape.
+/// A hub charter — minimal MVP shape.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Charter {
     /// Schema version. Bump when fields change incompatibly.
     pub schema_version: String,
 
-    /// Human-readable chapter name (e.g. "Lisbon Chapter").
+    /// Human-readable hub name (e.g. "Lisbon Chapter").
     pub hub_name: String,
 
     /// When the charter was founded.
@@ -107,7 +107,7 @@ fn default_preamble(hub_name: &str) -> String {
          federation-capable, and accountable to its members through \
          witnessed action. Members hold portable identity (LCT) and \
          accrue reputation (T3/V3) by attested contribution. The \
-         chapter operates by chapter law, signed by the Sovereign and \
+         chapter operates by hub law, signed by the Sovereign and \
          amendable through the witnessed process the law itself defines.",
         name = hub_name
     )

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Metalinxx Inc.
 
-//! Chapter event types.
+//! Hub event types.
 //!
 //! These are the *domain* events a chapter records — distinct from
 //! `web4_core::ledger::LedgerEvent` which is about LCT anchoring (mint /
-//! status-change). The hub's HubLedger records the chapter's social
+//! status-change). The hub's HubLedger records the hub's social
 //! and governance actions on top of (and alongside) any LCT anchoring
 //! that web4-core handles.
 //!
@@ -25,7 +25,7 @@ use web4_core::role::SocietyRole;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum HubEvent {
-    /// First entry in any chapter ledger. Established at chapter init.
+    /// First entry in any hub ledger. Established at chapter init.
     Genesis {
         hub_name: String,
         charter_hash: String,
@@ -72,7 +72,7 @@ pub enum HubEvent {
         held_at: DateTime<Utc>,
     },
 
-    /// The chapter charter was amended. `new_charter_hash` is the post-amendment
+    /// The hub charter was amended. `new_charter_hash` is the post-amendment
     /// hash. Must be signed by the Sovereign.
     CharterAmended {
         new_charter_hash: String,
@@ -239,10 +239,11 @@ pub enum PairRevocationKind {
     Voluntary,
     /// The pair's `expires_at` was reached. Auto-cleanup; trust-neutral.
     Expired,
-    /// Chapter law force-revoked (norm fired with `decision: deny` for
+    /// Hub law force-revoked (norm fired with `decision: deny` for
     /// continued pair existence, or escalation outcome). Trust signal:
     /// pair was deemed inappropriate by the society.
-    ChapterLaw,
+    #[serde(alias = "chapter_law")]
+    HubLaw,
     /// One party's LCT key rotated; derived shared secrets are no
     /// longer valid. Trust-neutral; re-pair to continue.
     KeyRotation,

--- a/hub/hub-lib/src/hub.rs
+++ b/hub/hub-lib/src/hub.rs
@@ -13,10 +13,10 @@
 //! └── ledger.jsonl         # witnessed event log (sprint 2 populates)
 //! ```
 //!
-//! The Sovereign LCT lives OUTSIDE the chapter dir — the operator points
+//! The Sovereign LCT lives OUTSIDE the hub dir — the operator points
 //! at it via `[sovereign].lct_path` in config.toml. This separation
 //! protects the private key material from being checked into version
-//! control alongside the chapter dir.
+//! control alongside the hub dir.
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -217,7 +217,7 @@ impl HubConfig {
     }
 }
 
-/// File-path helper bound to a chapter directory.
+/// File-path helper bound to a hub directory.
 #[derive(Clone, Debug)]
 pub struct HubPaths {
     pub root: PathBuf,
@@ -233,7 +233,7 @@ impl HubPaths {
     pub fn society(&self) -> PathBuf { self.root.join("society.json") }
     pub fn ledger(&self) -> PathBuf { self.root.join("ledger.jsonl") }
 
-    /// True if the chapter dir contains a society — i.e. has been initialized.
+    /// True if the hub dir contains a society — i.e. has been initialized.
     pub fn is_initialized(&self) -> bool {
         self.society().exists()
     }

--- a/hub/hub-lib/src/init.rs
+++ b/hub/hub-lib/src/init.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Metalinxx Inc.
 
-//! `hub init` logic — bootstrap a chapter society.
+//! `hub init` logic — bootstrap a hub society.
 //!
 //! Flow:
-//! 1. Validate chapter dir doesn't already contain a society (idempotent).
+//! 1. Validate hub dir doesn't already contain a society (idempotent).
 //! 2. Load the Sovereign identity (LCT + keypair) from the path given.
 //! 3. Compose a founding charter (Charter::found), hash it.
 //! 4. Bootstrap a web4_core::Society — wires all 7 base-mandatory roles with
@@ -25,7 +25,7 @@ use crate::hub::{HubConfig, HubPaths};
 use crate::charter::Charter;
 use crate::identity::IdentityFile;
 use crate::ledger::{build_lookup, HubLedger};
-use crate::store::{open_chapter_store, open_chapter_store_with, BackendKind};
+use crate::store::{open_hub_store, open_hub_store_with, BackendKind};
 
 /// Roles the founder fills at genesis per V2-1 architecture.
 ///
@@ -79,7 +79,7 @@ fn role_key_for(role: &SocietyRole) -> String {
 /// Outcome of an `init` call.
 #[derive(Debug)]
 pub enum InitResult {
-    /// Newly initialized — fresh chapter ready to use.
+    /// Newly initialized — fresh hub ready to use.
     Initialized {
         society_lct_id: Uuid,
         hub_dir: PathBuf,
@@ -95,14 +95,14 @@ pub enum InitResult {
 
 /// Parameters for chapter initialization.
 pub struct InitArgs {
-    /// Human-readable chapter name (e.g. "Lisbon Chapter").
+    /// Human-readable hub name (e.g. "Lisbon Chapter").
     pub hub_name: String,
 
     /// Where the chapter will live on disk.
     pub hub_dir: PathBuf,
 
     /// Path to the Sovereign identity file (see IdentityFile).
-    /// For Local-mode init only — Hestia-mode uses [`init_chapter_with_signer`]
+    /// For Local-mode init only — Hestia-mode uses [`init_hub_with_signer`]
     /// and doesn't need a local IdentityFile.
     pub sovereign_lct_path: PathBuf,
 
@@ -127,15 +127,15 @@ pub struct HestiaInitArgs {
 }
 
 /// Run the init flow.
-pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
+pub async fn init_hub(args: InitArgs) -> Result<InitResult> {
     let paths = HubPaths::new(&args.hub_dir);
 
     // 1. Idempotency check — through the store, not the filesystem directly.
-    // open_chapter_store auto-detects existing backend (sqlite if chapter.db
+    // open_hub_store auto-detects existing backend (sqlite if chapter.db
     // present, else file).
     if args.hub_dir.exists() {
-        let probe_store = open_chapter_store(&args.hub_dir)
-            .context("opening chapter store for idempotency probe")?;
+        let probe_store = open_hub_store(&args.hub_dir)
+            .context("opening hub store for idempotency probe")?;
         if let Some(existing) = probe_store.read_society().await
             .context("probing for existing society")? {
             return Ok(InitResult::AlreadyInitialized {
@@ -148,7 +148,7 @@ pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
     }
 
     std::fs::create_dir_all(&args.hub_dir)
-        .with_context(|| format!("creating chapter dir {}", args.hub_dir.display()))?;
+        .with_context(|| format!("creating hub dir {}", args.hub_dir.display()))?;
 
     // 2. Load Sovereign identity. NOTE per architecture commitment #8:
     // identity-file-as-secret-store is the MVP bootstrap pattern; secrets
@@ -168,8 +168,8 @@ pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
 
     // Open the real store for the requested backend (default: file).
     let backend = args.storage.unwrap_or(BackendKind::File);
-    let mut store = open_chapter_store_with(&args.hub_dir, backend)
-        .with_context(|| format!("opening chapter store with backend {:?}", backend))?;
+    let mut store = open_hub_store_with(&args.hub_dir, backend)
+        .with_context(|| format!("opening hub store with backend {:?}", backend))?;
     tracing::info!(backend = backend.as_str(), "chapter storage backend selected");
 
     // 3. Compose + hash founding charter; write through store.
@@ -209,11 +209,11 @@ pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
     config.save(paths.config())
         .with_context(|| format!("writing config to {}", paths.config().display()))?;
 
-    // 7. Initialize the chapter ledger via store + write Genesis entry.
+    // 7. Initialize the hub ledger via store + write Genesis entry.
     // Genesis is signed by the Sovereign; subsequent events get signed by
     // their respective actors.
     let mut ledger = HubLedger::open(store).await
-        .context("opening chapter ledger via store")?;
+        .context("opening hub ledger via store")?;
     let sovereign_keypair = sovereign.keypair()
         .context("reconstructing Sovereign keypair for Genesis signing")?;
     ledger.write_genesis(
@@ -221,7 +221,7 @@ pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
         &sovereign_keypair,
         args.hub_name.clone(),
         society.charter_hash.clone(),
-    ).await.context("writing Genesis entry to chapter ledger")?;
+    ).await.context("writing Genesis entry to hub ledger")?;
 
     tracing::info!(
         society_lct_id = %society_lct_id,
@@ -229,7 +229,7 @@ pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
         hub_dir = %args.hub_dir.display(),
         roles_wired = role_lcts.len(),
         ledger_entries = ledger.len(),
-        "chapter society bootstrapped"
+        "hub society bootstrapped"
     );
 
     Ok(InitResult::Initialized {
@@ -242,11 +242,11 @@ pub async fn init_chapter(args: InitArgs) -> Result<InitResult> {
 /// Load an already-initialized chapter's society state. Routes through
 /// the storage backend abstraction, so works against any backend.
 pub async fn load_society(hub_dir: impl AsRef<Path>) -> Result<Society> {
-    let store = open_chapter_store(hub_dir.as_ref())
-        .context("opening chapter store")?;
+    let store = open_hub_store(hub_dir.as_ref())
+        .context("opening hub store")?;
     store.read_society().await
         .context("reading society via store")?
-        .ok_or_else(|| anyhow::anyhow!("no society found in chapter store"))
+        .ok_or_else(|| anyhow::anyhow!("no society found in hub store"))
 }
 
 /// Run the Hestia-mode init flow. The hub holds NO Sovereign keypair;
@@ -254,7 +254,7 @@ pub async fn load_society(hub_dir: impl AsRef<Path>) -> Result<Society> {
 ///
 /// Per architecture commitment #8: secrets live in Hestia's vault.
 /// This entry point is the canonical Hestia-mode bootstrap.
-pub async fn init_chapter_hestia(args: HestiaInitArgs) -> Result<InitResult> {
+pub async fn init_hub_hestia(args: HestiaInitArgs) -> Result<InitResult> {
     use crate::signer::{HestiaCallbackSigner, RemoteSigner, SignIntent};
     use web4_core::crypto::SignatureBytes;
 
@@ -262,8 +262,8 @@ pub async fn init_chapter_hestia(args: HestiaInitArgs) -> Result<InitResult> {
 
     // 1. Idempotency check.
     if args.hub_dir.exists() {
-        let probe_store = open_chapter_store(&args.hub_dir)
-            .context("opening chapter store for idempotency probe")?;
+        let probe_store = open_hub_store(&args.hub_dir)
+            .context("opening hub store for idempotency probe")?;
         if let Some(existing) = probe_store.read_society().await
             .context("probing for existing society")? {
             return Ok(InitResult::AlreadyInitialized {
@@ -276,7 +276,7 @@ pub async fn init_chapter_hestia(args: HestiaInitArgs) -> Result<InitResult> {
     }
 
     std::fs::create_dir_all(&args.hub_dir)
-        .with_context(|| format!("creating chapter dir {}", args.hub_dir.display()))?;
+        .with_context(|| format!("creating hub dir {}", args.hub_dir.display()))?;
 
     // 2. Synthesize the Sovereign's Lct from the supplied pubkey
     // (no IdentityFile in Hestia mode).
@@ -291,8 +291,8 @@ pub async fn init_chapter_hestia(args: HestiaInitArgs) -> Result<InitResult> {
 
     // 3. Open store.
     let backend = args.storage.unwrap_or(BackendKind::File);
-    let mut store = open_chapter_store_with(&args.hub_dir, backend)
-        .with_context(|| format!("opening chapter store with backend {:?}", backend))?;
+    let mut store = open_hub_store_with(&args.hub_dir, backend)
+        .with_context(|| format!("opening hub store with backend {:?}", backend))?;
 
     // 4. Charter.
     let charter = Charter::found(args.hub_name.clone(), args.sovereign_lct_id);
@@ -322,7 +322,7 @@ pub async fn init_chapter_hestia(args: HestiaInitArgs) -> Result<InitResult> {
 
     // 7. Open ledger + build unsigned Genesis.
     let mut ledger = HubLedger::open(store).await
-        .context("opening chapter ledger via store")?;
+        .context("opening hub ledger via store")?;
     let (unsigned, _ts) = ledger.build_genesis(
         args.sovereign_lct_id,
         args.hub_name.clone(),
@@ -364,7 +364,7 @@ pub async fn init_chapter_hestia(args: HestiaInitArgs) -> Result<InitResult> {
         hub_dir = %args.hub_dir.display(),
         roles_wired = role_lcts.len(),
         ledger_entries = ledger.len(),
-        "Hestia-mode chapter society bootstrapped"
+        "Hestia-mode hub society bootstrapped"
     );
 
     Ok(InitResult::Initialized {
@@ -383,11 +383,11 @@ pub struct VerifyResult {
     pub head_hash: String,
 }
 
-/// Verify the entire chapter ledger end-to-end. For MVP, the only LCT in
+/// Verify the entire hub ledger end-to-end. For MVP, the only LCT in
 /// the lookup is the Sovereign (loaded from config.toml's sovereign.lct_path).
 /// Later sprints will extend the lookup to include member LCTs (extracted
 /// from MemberAdded events).
-pub async fn verify_chapter(hub_dir: impl AsRef<Path>) -> Result<VerifyResult> {
+pub async fn verify_hub(hub_dir: impl AsRef<Path>) -> Result<VerifyResult> {
     let hub_dir = hub_dir.as_ref();
     let paths = HubPaths::new(hub_dir);
 
@@ -415,8 +415,8 @@ pub async fn verify_chapter(hub_dir: impl AsRef<Path>) -> Result<VerifyResult> {
     };
 
     let society = load_society(hub_dir).await.context("loading society")?;
-    let store = open_chapter_store(hub_dir)
-        .context("opening chapter store for verify")?;
+    let store = open_hub_store(hub_dir)
+        .context("opening hub store for verify")?;
     let ledger = HubLedger::open(store).await
         .context("opening ledger via store")?;
     // Build LCT lookup. MVP: just the Sovereign. Extension point: as the
@@ -459,7 +459,7 @@ mod tests {
         let sovereign_path = fresh_sovereign(tmp.path());
         let hub_dir = tmp.path().join("lisbon");
 
-        let result = init_chapter(InitArgs {
+        let result = init_hub(InitArgs {
             hub_name: "Lisbon Chapter".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
@@ -502,7 +502,7 @@ mod tests {
         let sovereign_path = fresh_sovereign(tmp.path());
         let hub_dir = tmp.path().join("lisbon");
 
-        init_chapter(InitArgs {
+        init_hub(InitArgs {
             hub_name: "Lisbon".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
@@ -523,7 +523,7 @@ mod tests {
         let sovereign_path = fresh_sovereign(tmp.path());
         let hub_dir = tmp.path().join("lisbon");
 
-        init_chapter(InitArgs {
+        init_hub(InitArgs {
             hub_name: "Lisbon".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
@@ -537,7 +537,7 @@ mod tests {
         assert!(paths.ledger().exists(), "ledger.jsonl missing");
 
         // Sprint 2: ledger now starts with Genesis entry (not empty)
-        let store = open_chapter_store(&hub_dir).unwrap();
+        let store = open_hub_store(&hub_dir).unwrap();
         let ledger = crate::ledger::HubLedger::open(store).await.unwrap();
         assert_eq!(ledger.len(), 1, "expected single Genesis entry after init");
     }
@@ -548,15 +548,15 @@ mod tests {
         let sovereign_path = fresh_sovereign(tmp.path());
         let hub_dir = tmp.path().join("lisbon");
 
-        init_chapter(InitArgs {
+        init_hub(InitArgs {
             hub_name: "Lisbon".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
             storage: None,
         }).await.unwrap();
 
-        // verify_chapter does end-to-end: config → identity → society → ledger
-        let result = verify_chapter(&hub_dir).await.unwrap();
+        // verify_hub does end-to-end: config → identity → society → ledger
+        let result = verify_hub(&hub_dir).await.unwrap();
         assert_eq!(result.hub_name, "Lisbon");
         assert_eq!(result.entries, 1, "Genesis is the only entry post-init");
         assert!(!result.head_hash.is_empty());
@@ -569,7 +569,7 @@ mod tests {
         let hub_dir = tmp.path().join("lisbon");
 
         // First init
-        let first = init_chapter(InitArgs {
+        let first = init_hub(InitArgs {
             hub_name: "Lisbon".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path.clone(),
@@ -585,7 +585,7 @@ mod tests {
         let society_before = std::fs::read_to_string(hub_dir.join("society.json")).unwrap();
 
         // Second init on same dir
-        let second = init_chapter(InitArgs {
+        let second = init_hub(InitArgs {
             hub_name: "Different Name (should be ignored)".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
@@ -614,7 +614,7 @@ mod tests {
         let sovereign_path = fresh_sovereign(tmp.path());
         let hub_dir = tmp.path().join("lisbon");
 
-        init_chapter(InitArgs {
+        init_hub(InitArgs {
             hub_name: "Lisbon".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
@@ -639,7 +639,7 @@ mod tests {
         let sovereign_path = fresh_sovereign(tmp.path());
         let hub_dir = tmp.path().join("lisbon");
 
-        init_chapter(InitArgs {
+        init_hub(InitArgs {
             hub_name: "Lisbon".into(),
             hub_dir,
             sovereign_lct_path: sovereign_path.clone(),

--- a/hub/hub-lib/src/law.rs
+++ b/hub/hub-lib/src/law.rs
@@ -195,12 +195,12 @@ impl Law {
     /// Parse a YAML law document. Returns the typed Law on success.
     /// Run `Law::validate()` separately for structural checks.
     pub fn from_yaml(s: &str) -> Result<Self> {
-        serde_yaml::from_str(s).context("parsing chapter law YAML")
+        serde_yaml::from_str(s).context("parsing hub law YAML")
     }
 
     /// Serialize back to YAML for storage / display.
     pub fn to_yaml(&self) -> Result<String> {
-        serde_yaml::to_string(self).context("serializing chapter law to YAML")
+        serde_yaml::to_string(self).context("serializing hub law to YAML")
     }
 
     /// Validate per `chapter-law-schema.md` §2 rules 1-10. Errors loudly

--- a/hub/hub-lib/src/ledger.rs
+++ b/hub/hub-lib/src/ledger.rs
@@ -108,7 +108,7 @@ pub struct UnsignedEntry {
     pub signing_bytes: Vec<u8>,
 }
 
-/// Append-only chapter event ledger.
+/// Append-only hub event ledger.
 ///
 /// Owns hash-chain integrity + signing logic. Delegates byte persistence
 /// to a [`HubStore`] — so the ledger works identically against file,

--- a/hub/hub-lib/src/lib.rs
+++ b/hub/hub-lib/src/lib.rs
@@ -6,7 +6,7 @@
 //! Modules (sprints 1-2 landed):
 //! - [`identity`] — on-disk LCT + KeyPair persistence (sprint 1)
 //! - [`charter`] — chapter founding charter (compose, hash, persist) (sprint 1)
-//! - [`chapter`] — chapter directory layout + config.toml (sprint 1)
+//! - [`chapter`] — hub directory layout + config.toml (sprint 1)
 //! - [`events`] — typed chapter event enum (sprint 2)
 //! - [`ledger`] — append-only signed event log w/ hash-chain integrity (sprint 2)
 //! - [`init`] — `hub init` flow: bootstrap society + write Genesis entry (sprint 1+2)

--- a/hub/hub-lib/src/session.rs
+++ b/hub/hub-lib/src/session.rs
@@ -24,7 +24,7 @@ use crate::identity::IdentityFile;
 use crate::init::load_society;
 use crate::ledger::{HubLedger, LedgerEntry};
 use crate::state::{HubState, Member};
-use crate::store::open_chapter_store;
+use crate::store::open_hub_store;
 
 /// One open chapter, ready for ops. Drop to close.
 pub struct HubSession {
@@ -64,10 +64,10 @@ impl HubSession {
                 "loading Sovereign identity from {}", lct_path.display()
             ))?;
         let keypair = sovereign.keypair()?;
-        let store = open_chapter_store(hub_dir)
-            .context("opening chapter store for session")?;
+        let store = open_hub_store(hub_dir)
+            .context("opening hub store for session")?;
         let ledger = HubLedger::open(store).await
-            .context("opening ledger via chapter store")?;
+            .context("opening ledger via hub store")?;
         Ok(Self {
             paths,
             config,
@@ -108,11 +108,11 @@ impl HubSession {
     /// ledger and never folded into the society, so assigned roles never
     /// showed as filled in query_chapter / MCP / the admin dashboard.
     pub async fn assign_role(&mut self, role: SocietyRole, member_lct_id: Uuid) -> Result<&LedgerEntry> {
-        let mut store = open_chapter_store(&self.paths.root)
-            .context("opening chapter store to update role-fill")?;
+        let mut store = open_hub_store(&self.paths.root)
+            .context("opening hub store to update role-fill")?;
         let mut society = store.read_society().await
             .context("reading society state")?
-            .ok_or_else(|| anyhow::anyhow!("society state missing for chapter"))?;
+            .ok_or_else(|| anyhow::anyhow!("society state missing for hub"))?;
         let role_lct_id = society
             .assign_role(role.clone(), member_lct_id, self.sovereign_lct_id)
             .map_err(|e| anyhow::anyhow!("role assignment rejected: {e}"))?;
@@ -154,7 +154,7 @@ impl HubSession {
         let sha = crate::law::Law::sha256_hex_of(yaml);
         self.ledger.store_mut()
             .write_law(yaml).await
-            .context("writing law to chapter store")?;
+            .context("writing law to hub store")?;
         let event = HubEvent::LawAmended {
             new_law_sha256: sha,
             amended_by: self.sovereign_lct_id,
@@ -311,7 +311,7 @@ impl HubSession {
 
 /// Status snapshot for CLI / API consumption.
 #[derive(Debug)]
-pub struct ChapterStatus {
+pub struct HubStatus {
     pub hub_dir: PathBuf,
     pub hub_name: String,
     pub member_count: usize,
@@ -321,10 +321,10 @@ pub struct ChapterStatus {
 }
 
 impl HubSession {
-    pub fn status(&self) -> ChapterStatus {
+    pub fn status(&self) -> HubStatus {
         let state = self.state();
         let member_count = state.member_count();
-        ChapterStatus {
+        HubStatus {
             hub_dir: self.hub_dir().to_path_buf(),
             hub_name: state.hub_name,
             member_count,
@@ -338,16 +338,16 @@ impl HubSession {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::init::{init_chapter, InitArgs};
+    use crate::init::{init_hub, InitArgs};
     use tempfile::tempdir;
     use web4_core::lct::EntityType;
 
-    async fn fresh_chapter() -> (tempfile::TempDir, PathBuf) {
+    async fn fresh_hub() -> (tempfile::TempDir, PathBuf) {
         let tmp = tempdir().unwrap();
         let sovereign_path = tmp.path().join("sovereign.json");
         IdentityFile::generate(EntityType::Human).save(&sovereign_path).unwrap();
         let hub_dir = tmp.path().join("test-chapter");
-        init_chapter(InitArgs {
+        init_hub(InitArgs {
             hub_name: "Test Chapter".into(),
             hub_dir: hub_dir.clone(),
             sovereign_lct_path: sovereign_path,
@@ -358,7 +358,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_and_status_after_init() {
-        let (_tmp, dir) = fresh_chapter().await;
+        let (_tmp, dir) = fresh_hub().await;
         let session = HubSession::open(&dir).await.unwrap();
         let st = session.status();
         assert_eq!(st.hub_name, "Test Chapter");
@@ -368,7 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn end_to_end_session_ops() {
-        let (_tmp, dir) = fresh_chapter().await;
+        let (_tmp, dir) = fresh_hub().await;
         let mut session = HubSession::open(&dir).await.unwrap();
 
         let alice = Uuid::new_v4();
@@ -402,7 +402,7 @@ mod tests {
         // event without updating the persisted society, so the role never
         // showed as filled in query_chapter / MCP / admin. It must now fold
         // into the society role-fill.
-        let (_tmp, dir) = fresh_chapter().await;
+        let (_tmp, dir) = fresh_hub().await;
         let alice = Uuid::new_v4();
         {
             let mut session = HubSession::open(&dir).await.unwrap();
@@ -422,7 +422,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_writes_persist_across_reopen() {
-        let (_tmp, dir) = fresh_chapter().await;
+        let (_tmp, dir) = fresh_hub().await;
         {
             let mut session = HubSession::open(&dir).await.unwrap();
             session.add_member(Uuid::new_v4(), Some("Alice".into())).await.unwrap();

--- a/hub/hub-lib/src/signer.rs
+++ b/hub/hub-lib/src/signer.rs
@@ -51,7 +51,7 @@ pub struct SignIntent {
     pub request_id: Uuid,
     /// Which chapter the entry belongs to.
     pub hub_id: Uuid,
-    /// Human-readable chapter name (for vault policy / UX prompts).
+    /// Human-readable hub name (for vault policy / UX prompts).
     pub hub_name: String,
     /// Which actor (role-filler) the signature is being attributed to.
     pub actor_lct_id: Uuid,

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -643,7 +643,7 @@ mod tests {
             }),
             (alice, &kp, HubEvent::PairingRevoked {
                 pair_id, revoked_by: alice,
-                revocation_kind: PairRevocationKind::ChapterLaw,
+                revocation_kind: PairRevocationKind::HubLaw,
                 reason: Some("second — should be ignored".into()),
             }),
         ]).await;
@@ -754,13 +754,25 @@ mod tests {
 
         let rev = HubEvent::PairingRevoked {
             pair_id, revoked_by: alice,
-            revocation_kind: PairRevocationKind::ChapterLaw,
+            revocation_kind: PairRevocationKind::HubLaw,
             reason: None,
         };
         let rev_json = serde_json::to_string(&rev).unwrap();
         assert!(rev_json.contains("\"kind\":\"pairing_revoked\""));
-        assert!(rev_json.contains("\"revocation_kind\":\"chapter_law\""));
+        // Canonical form after the chapter→hub rename.
+        assert!(rev_json.contains("\"revocation_kind\":\"hub_law\""));
         // No reason -> field skipped
         assert!(!rev_json.contains("\"reason\""));
+
+        // Back-compat: pre-rename ledgers serialized this as "chapter_law";
+        // the serde alias must still deserialize them.
+        let legacy = rev_json.replace("\"hub_law\"", "\"chapter_law\"");
+        let back: HubEvent = serde_json::from_str(&legacy).unwrap();
+        match back {
+            HubEvent::PairingRevoked { revocation_kind, .. } => {
+                assert_eq!(revocation_kind, PairRevocationKind::HubLaw);
+            }
+            _ => panic!("expected PairingRevoked"),
+        }
     }
 }

--- a/hub/hub-lib/src/store.rs
+++ b/hub/hub-lib/src/store.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Metalinxx Inc.
 
-//! Chapter storage backend abstraction (V2-2).
+//! Hub storage backend abstraction (V2-2).
 //!
 //! ## Why this exists
 //!
@@ -12,9 +12,9 @@
 //! for old ledger pages. Different chapters, same hub code path, different
 //! backend bytes.
 //!
-//! The abstraction here is intentionally narrow: chapter charter, chapter
-//! society state, and the chapter event ledger. That is the entire surface
-//! of chapter-owned persistent state. Everything else is either:
+//! The abstraction here is intentionally narrow: hub charter, chapter
+//! society state, and the hub event ledger. That is the entire surface
+//! of hub-owned persistent state. Everything else is either:
 //!
 //! - **Operator-owned config** (`config.toml`) — stays file-based, not part of this trait
 //! - **Secret material** (private keys, vault contents) — per architecture
@@ -24,7 +24,7 @@
 //!
 //! ## Posture (per architecture commitment #8)
 //!
-//! Chapter storage is **secrets-free by design**. Everything in this trait
+//! Hub storage is **secrets-free by design**. Everything in this trait
 //! is signed (for integrity) but not encrypted (for confidentiality of the
 //! data itself). Confidentiality, where needed, comes from the vault's
 //! authority+need-to-know gate at the access boundary — not from sealing
@@ -76,7 +76,7 @@ impl BackendKind {
 
 /// The chapter persistence surface.
 ///
-/// Implementations own the bytes; callers (HubLedger, init_chapter,
+/// Implementations own the bytes; callers (HubLedger, init_hub,
 /// HubSession) own invariants. This trait does **no** crypto or chain
 /// validation — that lives in the ledger module. It does **no** secret
 /// handling — that lives in the vault (Hestia).
@@ -120,7 +120,7 @@ pub trait HubStore: Send + Sync {
     async fn ledger_append(&mut self, entry: &LedgerEntry) -> Result<()>;
 
     /// True iff the ledger has zero entries. Used by callers to detect
-    /// "fresh chapter, needs Genesis" without round-tripping the full list.
+    /// "fresh hub, needs Genesis" without round-tripping the full list.
     async fn ledger_is_empty(&self) -> Result<bool> {
         Ok(self.ledger_load_all().await?.is_empty())
     }
@@ -197,31 +197,41 @@ pub trait HubStore: Send + Sync {
     }
 }
 
-/// Default SQLite filename inside a chapter dir.
-pub const SQLITE_DB_FILENAME: &str = "chapter.db";
+/// Default SQLite filename inside a hub dir.
+pub const SQLITE_DB_FILENAME: &str = "hub.db";
 
-/// Open a `HubStore` for the given chapter dir. Backend selection:
+/// Pre-rename SQLite filename. Hub dirs created before the chapter→hub
+/// rename have `chapter.db`; we keep reading them in place (no forced
+/// migration) so existing deployments don't break.
+pub const SQLITE_DB_FILENAME_LEGACY: &str = "chapter.db";
+
+/// Open a `HubStore` for the given hub dir. Backend selection:
 ///
-/// 1. If `<chapter-dir>/chapter.db` exists → SqliteBackend.
-/// 2. Else if `<chapter-dir>/society.json` (or any MVP file) exists → FileBackend.
-/// 3. Else (fresh chapter) → FileBackend default (MVP-compatible).
+/// 1. If `<hub-dir>/hub.db` exists → SqliteBackend.
+/// 2. Else if `<hub-dir>/chapter.db` exists (pre-rename) → SqliteBackend on it.
+/// 3. Else if `<hub-dir>/society.json` (or any MVP file) exists → FileBackend.
+/// 4. Else (fresh hub) → FileBackend default (MVP-compatible).
 ///
-/// To force a specific backend at create time, use [`open_chapter_store_with`].
-pub fn open_chapter_store(hub_dir: impl AsRef<Path>) -> Result<Box<dyn HubStore>> {
+/// To force a specific backend at create time, use [`open_hub_store_with`].
+pub fn open_hub_store(hub_dir: impl AsRef<Path>) -> Result<Box<dyn HubStore>> {
     let hub_dir = hub_dir.as_ref();
     let paths = HubPaths::new(hub_dir.to_path_buf());
     let db_path = hub_dir.join(SQLITE_DB_FILENAME);
+    let legacy_db_path = hub_dir.join(SQLITE_DB_FILENAME_LEGACY);
 
     if db_path.exists() {
         Ok(Box::new(SqliteBackend::open(&db_path)?))
+    } else if legacy_db_path.exists() {
+        // Pre-rename hub dir — open the legacy chapter.db in place.
+        Ok(Box::new(SqliteBackend::open(&legacy_db_path)?))
     } else {
         Ok(Box::new(FileBackend::new(paths)))
     }
 }
 
-/// Open a `HubStore` for the given chapter dir, forcing the backend
+/// Open a `HubStore` for the given hub dir, forcing the backend
 /// kind. Used by `hub init --storage <kind>` and the migration tool.
-pub fn open_chapter_store_with(
+pub fn open_hub_store_with(
     hub_dir: impl AsRef<Path>,
     kind: BackendKind,
 ) -> Result<Box<dyn HubStore>> {
@@ -231,7 +241,7 @@ pub fn open_chapter_store_with(
         BackendKind::File => Ok(Box::new(FileBackend::new(paths))),
         BackendKind::Sqlite => {
             std::fs::create_dir_all(hub_dir)
-                .with_context(|| format!("creating chapter dir {}", hub_dir.display()))?;
+                .with_context(|| format!("creating hub dir {}", hub_dir.display()))?;
             let db_path = hub_dir.join(SQLITE_DB_FILENAME);
             Ok(Box::new(SqliteBackend::open(&db_path)?))
         }
@@ -667,7 +677,7 @@ impl SqliteBackend {
 // Migration tool
 // ============================================================================
 
-/// Outcome of [`migrate_chapter`]. Caller decides how to surface this.
+/// Outcome of [`migrate_hub`]. Caller decides how to surface this.
 #[derive(Debug)]
 pub struct MigrationResult {
     pub source_backend: BackendKind,
@@ -675,7 +685,7 @@ pub struct MigrationResult {
     pub charter_copied: bool,
     pub society_copied: bool,
     pub ledger_entries_copied: usize,
-    /// Renamed pre-migration artifacts (paths relative to chapter dir),
+    /// Renamed pre-migration artifacts (paths relative to hub dir),
     /// preserved so operators can roll back if needed.
     pub preserved_artifacts: Vec<PathBuf>,
 }
@@ -685,7 +695,7 @@ pub struct MigrationResult {
 /// Algorithm:
 /// 1. Auto-detect source backend at `hub_dir`.
 /// 2. If source == target, no-op (returns OK with zero-copied counters).
-/// 3. Open target backend (forced kind via [`open_chapter_store_with`]).
+/// 3. Open target backend (forced kind via [`open_hub_store_with`]).
 ///    For sqlite, this creates `chapter.db`.
 /// 4. Copy charter (if present) → target.
 /// 5. Copy society (if present) → target.
@@ -695,23 +705,23 @@ pub struct MigrationResult {
 ///    interfere with future auto-detection but remain recoverable.
 ///
 /// The caller (typically `hub migrate` CLI) should run a verify-ledger
-/// pass against the chapter dir after this returns to confirm chain
+/// pass against the hub dir after this returns to confirm chain
 /// integrity is intact on the target backend.
 ///
 /// Note: this function does NOT touch identity files, config.toml, or
 /// anything else outside the chapter storage abstraction. Those stay
 /// where they were.
-pub async fn migrate_chapter(
+pub async fn migrate_hub(
     hub_dir: impl AsRef<Path>,
     target_backend: BackendKind,
 ) -> Result<MigrationResult> {
     let hub_dir = hub_dir.as_ref();
     if !hub_dir.exists() {
-        anyhow::bail!("chapter dir {} does not exist", hub_dir.display());
+        anyhow::bail!("hub dir {} does not exist", hub_dir.display());
     }
 
     // 1. Auto-detect source.
-    let source = open_chapter_store(hub_dir)
+    let source = open_hub_store(hub_dir)
         .context("opening source store for migration")?;
     let source_kind = source.backend_kind();
 
@@ -736,7 +746,7 @@ pub async fn migrate_chapter(
     drop(source);
 
     // 3. Open target.
-    let mut target = open_chapter_store_with(hub_dir, target_backend)
+    let mut target = open_hub_store_with(hub_dir, target_backend)
         .with_context(|| format!("opening target store ({:?})", target_backend))?;
 
     // 4-6. Copy state.
@@ -784,7 +794,10 @@ pub async fn migrate_chapter(
                 preserved.push(backup);
             }
             // SQLite WAL/SHM files if present (after journal_mode=WAL)
-            for sidecar in &["chapter.db-wal", "chapter.db-shm"] {
+            for sidecar in &[
+                format!("{SQLITE_DB_FILENAME}-wal"),
+                format!("{SQLITE_DB_FILENAME}-shm"),
+            ] {
                 let p = hub_dir.join(sidecar);
                 if p.exists() {
                     let backup = hub_dir.join(format!("{}.pre-migration", sidecar));
@@ -1067,23 +1080,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn open_chapter_store_selects_sqlite_when_db_present() {
+    async fn open_hub_store_selects_sqlite_when_db_present() {
         let tmp = tempdir().unwrap();
         let hub_dir = tmp.path().join("test-chapter");
         std::fs::create_dir_all(&hub_dir).unwrap();
         // Create an empty sqlite db
         let _ = SqliteBackend::open(hub_dir.join(SQLITE_DB_FILENAME)).unwrap();
-        // open_chapter_store should now pick sqlite
-        let store = open_chapter_store(&hub_dir).unwrap();
+        // open_hub_store should now pick sqlite
+        let store = open_hub_store(&hub_dir).unwrap();
         assert_eq!(store.backend_kind(), BackendKind::Sqlite);
     }
 
     #[tokio::test]
-    async fn open_chapter_store_defaults_to_file_when_empty_dir() {
+    async fn open_hub_store_reads_legacy_chapter_db_in_place() {
+        // Pre-rename hub dirs have chapter.db (not hub.db). open_hub_store
+        // must still detect + open them as sqlite — no forced migration.
+        let tmp = tempdir().unwrap();
+        let hub_dir = tmp.path().join("legacy-hub");
+        std::fs::create_dir_all(&hub_dir).unwrap();
+        let _ = SqliteBackend::open(hub_dir.join(SQLITE_DB_FILENAME_LEGACY)).unwrap();
+        assert!(!hub_dir.join(SQLITE_DB_FILENAME).exists(), "no hub.db, only legacy chapter.db");
+        let store = open_hub_store(&hub_dir).unwrap();
+        assert_eq!(store.backend_kind(), BackendKind::Sqlite);
+    }
+
+    #[tokio::test]
+    async fn open_hub_store_defaults_to_file_when_empty_dir() {
         let tmp = tempdir().unwrap();
         let hub_dir = tmp.path().join("test-chapter");
         std::fs::create_dir_all(&hub_dir).unwrap();
-        let store = open_chapter_store(&hub_dir).unwrap();
+        let store = open_hub_store(&hub_dir).unwrap();
         assert_eq!(store.backend_kind(), BackendKind::File);
     }
 
@@ -1126,7 +1152,7 @@ mod tests {
         }
 
         // Migrate file → sqlite
-        let result = migrate_chapter(&hub_dir, BackendKind::Sqlite).await.unwrap();
+        let result = migrate_hub(&hub_dir, BackendKind::Sqlite).await.unwrap();
         assert_eq!(result.source_backend, BackendKind::File);
         assert_eq!(result.target_backend, BackendKind::Sqlite);
         assert!(result.charter_copied);
@@ -1136,7 +1162,7 @@ mod tests {
             "source artifacts should be renamed for rollback");
 
         // Auto-detect should now resolve sqlite
-        let after = open_chapter_store(&hub_dir).unwrap();
+        let after = open_hub_store(&hub_dir).unwrap();
         assert_eq!(after.backend_kind(), BackendKind::Sqlite);
 
         // Charter + society + ledger byte-identical
@@ -1159,7 +1185,7 @@ mod tests {
         let hub_dir = tmp.path().join("chap");
         std::fs::create_dir_all(&hub_dir).unwrap();
         // Empty dir → file-backed default
-        let result = migrate_chapter(&hub_dir, BackendKind::File).await.unwrap();
+        let result = migrate_hub(&hub_dir, BackendKind::File).await.unwrap();
         assert_eq!(result.source_backend, result.target_backend);
         assert_eq!(result.ledger_entries_copied, 0);
         assert!(!result.charter_copied);


### PR DESCRIPTION
## Why

The Chapter→Hub rename (web4@5b2e2ea, per dp's rule *"chapter stays in docs as an org-operator, never in code"*) renamed the **types** and `*_id/_dir/_name` identifiers, but left a tail still saying "chapter": a family of **function names**, one **enum variant**, the **MCP query tool**, and the **on-disk SQLite filename**. (This is why one reaches for `ChapterStore` out of habit even though the trait is already `HubStore` — the *factory* is still `open_chapter_store`.)

## Changes

- **Functions:** `open_chapter_store[_with]`→`open_hub_store[_with]`, `init_chapter[_hestia/_with_signer]`→`init_hub*`, `verify_chapter`→`verify_hub`, `migrate_chapter`→`migrate_hub`, `fresh_chapter`→`fresh_hub` (test helper).
- **Types:** `QueryChapterResponse`→`QueryHubResponse`, `ChapterStatus`→`HubStatus`.
- **Enum:** `PairRevocationKind::ChapterLaw`→`HubLaw`, with `#[serde(alias = "chapter_law")]` so pre-rename ledgers still deserialize.
- **MCP tool:** `query_chapter`→`query_hub`; `/tools/query_chapter` kept as a **back-compat route alias**.
- **On-disk SQLite:** canonical **`hub.db`**; `open_hub_store` opens a legacy **`chapter.db`** in place (`SQLITE_DB_FILENAME_LEGACY`) — **no forced migration**, existing deployments keep working.
- **Strings/comments:** user-facing "chapter store/dir/ledger/society/law/event/members" → "hub …". Intentional back-compat aliases kept (`--chapter-dir` clap alias, `[chapter]` serde alias, `chapter-law.yaml` read fallback). Genuine community-chapter prose left per the rename rule.

## Compatibility

Behavior-only. Ledger + wire + on-disk formats unchanged in a breaking way:
- `chapter_law` (serialized) still deserializes via serde alias.
- `/tools/query_chapter` still routes (alias).
- Existing `chapter.db` hub dirs open unchanged.

## Tests

`cargo test --release`: **129 passed.** New:
- `open_hub_store_reads_legacy_chapter_db_in_place` — the migration shim.
- back-compat assertion in `pair_events_serde_round_trip` — legacy `chapter_law` JSON deserializes to `HubLaw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)