### PR TITLE
feat(hub): MemberProfileUpdated — free-text profiles for member discovery

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -578,6 +578,10 @@ fn event_summary(event: &HubEvent) -> String {
         HubEvent::MemberSkillDeclared { member_lct_id, skill, .. } => {
             format!("Skill \"{}\" by {}", html_escape(skill), short(member_lct_id))
         }
+        HubEvent::MemberProfileUpdated { member_lct_id, fields, .. } => {
+            let keys: Vec<&str> = fields.keys().map(|k| k.as_str()).collect();
+            format!("Profile update ({}) by {}", html_escape(&keys.join(", ")), short(member_lct_id))
+        }
         HubEvent::LawAmended { version, diff_summary, .. } => format!(
             "Law → v{}{}",
             html_escape(version),

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -276,6 +276,17 @@ enum Command {
         skill: String,
     },
 
+    /// Update a member's profile fields (for semantic discovery). Pass one or
+    /// more `key=value` pairs, e.g. `skills="..." interests="..."`. An empty
+    /// value clears that field.
+    SetProfile {
+        hub_dir: PathBuf,
+        member_lct_id: Uuid,
+        /// `key=value` pairs (repeatable).
+        #[arg(value_name = "KEY=VALUE", required = true)]
+        fields: Vec<String>,
+    },
+
     /// Set (or amend) the chapter's law from a YAML file (V2-8).
     /// Validates the YAML against the chapter-law schema, writes it
     /// to the hub store, and appends a LawAmended event to the
@@ -496,6 +507,9 @@ async fn main() -> Result<()> {
         }
         Some(Command::DeclareSkill { hub_dir, member_lct_id, skill }) => {
             run_declare_skill(hub_dir, member_lct_id, skill).await
+        }
+        Some(Command::SetProfile { hub_dir, member_lct_id, fields }) => {
+            run_set_profile(hub_dir, member_lct_id, fields).await
         }
         Some(Command::SetLaw { hub_dir, yaml, diff_summary }) => {
             run_set_law(hub_dir, yaml, diff_summary).await
@@ -744,6 +758,25 @@ async fn run_declare_skill(hub_dir: PathBuf, member_lct_id: Uuid, skill: String)
     println!("Skill declared.");
     println!("  Member LCT:   {}", member_lct_id);
     println!("  Skill:        {}", skill);
+    println!("  Entry index:  {}", entry.index);
+    println!("  Entry hash:   {}", entry.entry_hash);
+    Ok(())
+}
+
+async fn run_set_profile(hub_dir: PathBuf, member_lct_id: Uuid, fields: Vec<String>) -> Result<()> {
+    let mut map = std::collections::BTreeMap::new();
+    for pair in &fields {
+        let (k, v) = pair.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!("field {:?} must be key=value", pair)
+        })?;
+        map.insert(k.trim().to_string(), v.to_string());
+    }
+    let keys: Vec<String> = map.keys().cloned().collect();
+    let mut session = HubSession::open(&hub_dir).await?;
+    let entry = session.update_profile(member_lct_id, map).await?;
+    println!("Profile updated.");
+    println!("  Member LCT:   {}", member_lct_id);
+    println!("  Fields:       {}", keys.join(", "));
     println!("  Entry index:  {}", entry.index);
     println!("  Entry hash:   {}", entry.entry_hash);
     Ok(())

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -344,6 +344,10 @@ enum EnvelopeAction {
         member_lct_id: Uuid,
         skill: String,
     },
+    UpdateProfile {
+        member_lct_id: Uuid,
+        fields: std::collections::BTreeMap<String, String>,
+    },
 }
 
 #[derive(Serialize)]
@@ -452,6 +456,22 @@ async fn submit_event(
                 member_lct_id,
                 skill,
                 declared_by: envelope.signer_lct_id,
+            }
+        }
+        EnvelopeAction::UpdateProfile { member_lct_id, fields } => {
+            // Same self-only rule as DeclareSkill: members update only their
+            // own profile (signer == subject); Sovereign may update any
+            // member's (operator convenience / seeding).
+            if !signer_is_sovereign && envelope.signer_lct_id != member_lct_id {
+                return Err(ApiError::unauthorized(format!(
+                    "members may only update their own profile (signer {} != subject {})",
+                    envelope.signer_lct_id, member_lct_id,
+                )));
+            }
+            HubEvent::MemberProfileUpdated {
+                member_lct_id,
+                fields,
+                updated_by: envelope.signer_lct_id,
             }
         }
     };

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -88,6 +88,18 @@ pub enum HubEvent {
         declared_by: Uuid,
     },
 
+    /// A member updated their profile — free-text fields (e.g. `skills`,
+    /// `interests`, and arbitrary expandable keys) used for semantic member
+    /// discovery (`find_members`). Self-attested, same authorization as
+    /// MemberSkillDeclared (signer == subject). `fields` are merged into the
+    /// member's profile; an empty value clears that field. Plain-language by
+    /// design — not schematized.
+    MemberProfileUpdated {
+        member_lct_id: Uuid,
+        fields: std::collections::BTreeMap<String, String>,
+        updated_by: Uuid,
+    },
+
     /// The chapter law was amended (V2-8). The new law's YAML bytes are
     /// stored separately via [`crate::store::HubStore::write_law`];
     /// this event records the amendment in the ledger for audit. The
@@ -260,6 +272,7 @@ impl HubEvent {
             Self::EventRecorded { .. } => "event_recorded",
             Self::CharterAmended { .. } => "charter_amended",
             Self::MemberSkillDeclared { .. } => "member_skill_declared",
+            Self::MemberProfileUpdated { .. } => "member_profile_updated",
             Self::LawAmended { .. } => "law_amended",
             Self::CouncilMemberAdded { .. } => "council_member_added",
             Self::CouncilMemberRemoved { .. } => "council_member_removed",

--- a/hub/hub-lib/src/session.rs
+++ b/hub/hub-lib/src/session.rs
@@ -177,6 +177,22 @@ impl HubSession {
         self.append(event).await
     }
 
+    /// Update a member's free-text profile fields (skills, interests, +
+    /// expandable keys) — the inputs to semantic member discovery. Fields
+    /// merge into the existing profile; an empty value clears that field.
+    pub async fn update_profile(
+        &mut self,
+        member_lct_id: Uuid,
+        fields: std::collections::BTreeMap<String, String>,
+    ) -> Result<&LedgerEntry> {
+        let event = HubEvent::MemberProfileUpdated {
+            member_lct_id,
+            fields,
+            updated_by: self.sovereign_lct_id,
+        };
+        self.append(event).await
+    }
+
     pub async fn add_council_member(
         &mut self,
         member_lct_id: Uuid,
@@ -418,6 +434,29 @@ mod tests {
             admin.filling_entity_lct_id, alice,
             "Administrator should be filled by the assigned member"
         );
+    }
+
+    #[tokio::test]
+    async fn update_profile_merges_into_member_profile() {
+        let (_tmp, dir) = fresh_hub().await;
+        let alice = Uuid::new_v4();
+        {
+            let mut session = HubSession::open(&dir).await.unwrap();
+            session.add_member(alice, Some("Alice".into())).await.unwrap();
+            let mut f = std::collections::BTreeMap::new();
+            f.insert("skills".to_string(), "diffusion fine-tuning, eval harness design".to_string());
+            f.insert("interests".to_string(), "mechanistic interpretability".to_string());
+            session.update_profile(alice, f).await.unwrap();
+            // Second update merges + clears: change interests, drop skills.
+            let mut f2 = std::collections::BTreeMap::new();
+            f2.insert("interests".to_string(), "lowering inference cost".to_string());
+            f2.insert("skills".to_string(), String::new()); // empty clears
+            session.update_profile(alice, f2).await.unwrap();
+        }
+        let st = HubState::project(&HubSession::open(&dir).await.unwrap().ledger);
+        let m = st.members.get(&alice).expect("alice present");
+        assert_eq!(m.profile.get("interests").map(String::as_str), Some("lowering inference cost"));
+        assert!(!m.profile.contains_key("skills"), "empty value should clear the field");
     }
 
     #[tokio::test]

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -155,6 +155,10 @@ pub struct Member {
     pub lct_id: Uuid,
     pub name: Option<String>,
     pub skills: BTreeSet<String>,
+    /// Free-text profile fields (skills, interests, + expandable keys) for
+    /// semantic member discovery. Populated by MemberProfileUpdated events.
+    #[serde(default)]
+    pub profile: BTreeMap<String, String>,
 }
 
 impl HubState {
@@ -180,6 +184,7 @@ impl HubState {
                         lct_id: *founding_sovereign_lct_id,
                         name: Some("Sovereign".into()),
                         skills: BTreeSet::new(),
+                        profile: std::collections::BTreeMap::new(),
                     });
             }
             HubEvent::MemberAdded { member_lct_id, member_name, member_pubkey_hex, .. } => {
@@ -187,6 +192,7 @@ impl HubState {
                     lct_id: *member_lct_id,
                     name: member_name.clone(),
                     skills: BTreeSet::new(),
+                    profile: std::collections::BTreeMap::new(),
                 });
                 if let Some(pk) = member_pubkey_hex {
                     self.member_pubkeys.insert(*member_lct_id, pk.clone());
@@ -214,6 +220,17 @@ impl HubState {
                 // If member doesn't exist, silently ignore — event predates
                 // their MemberAdded. (Real impl would error or queue.)
             }
+            HubEvent::MemberProfileUpdated { member_lct_id, fields, .. } => {
+                if let Some(member) = self.members.get_mut(member_lct_id) {
+                    for (k, v) in fields {
+                        if v.is_empty() {
+                            member.profile.remove(k);
+                        } else {
+                            member.profile.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+            }
             HubEvent::RoleAssigned { .. }
             | HubEvent::EventRecorded { .. }
             | HubEvent::CharterAmended { .. }
@@ -232,6 +249,7 @@ impl HubState {
                     lct_id: *member_lct_id,
                     name: member_name.clone(),
                     skills: BTreeSet::new(),
+                    profile: std::collections::BTreeMap::new(),
                 });
                 // Rebalance N component of threshold if set.
                 if let Some((m, _)) = self.council_threshold {


### PR DESCRIPTION
## Why

First step of the member-discovery work for the AI-Collective use case (design: `private-context/proposals/web4-community-hub-aic-pitch.md`). Members advertise **skills / interests / what they care about** as plain-language, expandable text — the inputs to semantic `find_members` (next PR, the per-hub membot engine).

## Changes

- `HubEvent::MemberProfileUpdated { member_lct_id, fields: BTreeMap<String,String>, updated_by }`. Fields **merge** into the member's profile; an **empty value clears** that field. Plain-language, not schematized.
- `HubState::Member` gains `profile: BTreeMap<String,String>` (`#[serde(default)]`) + a projection arm.
- `HubSession::update_profile`; CLI `hub set-profile <dir> <member> key=value ...`.
- REST self-signed envelope action `UpdateProfile` — same self-only authorization as `DeclareSkill` (signer == subject; Sovereign may seed any member's, for ops/demo).
- Admin ledger summary renders profile updates.

## Compatibility

Additive: new event variant + a `serde(default)` field. No wire/ledger format break — existing ledgers and state parse unchanged.

## Test

`update_profile_merges_into_member_profile` — verifies merge + empty-clears semantics. `cargo test --release`: **130 passed**. CLI smoke verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)