### PR TITLE
feat(hub): member↔hub E2E channel endpoint + signer channel ops

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -42,7 +42,7 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use hub_lib::hub::{HubPaths, SovereignMode};
-use hub_lib::envelope::{verify_envelope, Challenge, MapResolver, NonceStore, SignedEnvelope, VerifyError};
+use hub_lib::envelope::{verify_envelope, Challenge, MapResolver, NonceStore, PublicKeyResolver, SignedEnvelope, VerifyError};
 use hub_lib::events::HubEvent;
 use hub_lib::identity::IdentityFile;
 use hub_lib::init::load_society;
@@ -192,6 +192,10 @@ pub fn router(state: RestState) -> Router {
         // aliases dropped 2026-06-08).
         .route("/v1/hubs/:hub_id/events", post(submit_event))
         .route("/v1/hubs/:hub_id/state", get(read_state))
+        // Member↔hub E2E channel: citizen-tier reads/acts travel sealed,
+        // never in the clear. The sealed request authenticates the caller
+        // (AEAD open) AND decrypts in one step; the response is sealed back.
+        .route("/v1/hubs/:hub_id/channel", post(channel_request))
         .route("/v1/hubs/:hub_id/members/join", post(submit_join))
         // V2-9 Phase 2: Sovereign Council proposal + aggregation flow.
         .route("/v1/hubs/:hub_id/council/propose", post(submit_proposal))
@@ -264,6 +268,11 @@ impl From<VerifyError> for ApiError {
 struct WellKnownHubInfo {
     /// The hub's society LCT id (what `hestia hub connect` keys on).
     hub_lct_id: Uuid,
+    /// The hub's LCT public key (hex) — the ECDH peer a member uses to open
+    /// an E2E member↔hub channel. `None` if the signer can't expose it
+    /// (e.g. Hestia mode). Public, integrity-protecting only (not a secret).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hub_pubkey_hex: Option<String>,
     /// API versions this hub serves. v1 today; future versions get
     /// added when the wire shape evolves under semver discipline.
     api_versions: Vec<&'static str>,
@@ -294,6 +303,7 @@ async fn well_known_hub_info(
 ) -> Json<WellKnownHubInfo> {
     Json(WellKnownHubInfo {
         hub_lct_id: s.hub_id,
+        hub_pubkey_hex: s.signer.public_key().map(|pk| pk.to_hex()),
         api_versions: vec!["v1"],
         endpoints: WellKnownEndpoints {
             rest: "/v1",
@@ -623,6 +633,122 @@ async fn read_state(
         head_hash,
         filled_roles,
     }))
+}
+
+// ---------- POST /v1/hubs/{id}/channel (E2E member↔hub channel) ----------
+//
+// Citizen-tier reads/acts never travel in the clear. The member seals a
+// request to the hub's LCT (X25519 ECDH from identity keys → ChaCha20-Poly1305,
+// `web4_core::pair_channel`); the hub opens it (a successful AEAD open both
+// AUTHENTICATES the caller — only the holder of their private key could have
+// sealed it — and decrypts), runs the authz pipeline, and seals the response
+// back. v1 serves citizen-tier reads; PolicyEntity-on-reads + MRH/trust/
+// constellation scoping layer onto `dispatch_channel`.
+
+#[derive(Deserialize)]
+struct ChannelRequest {
+    caller_lct_id: Uuid,
+    pair_id: Uuid,
+    /// base64(nonce ‖ ciphertext) sealed to the hub's LCT pubkey.
+    sealed: String,
+}
+
+#[derive(Serialize)]
+struct ChannelResponse {
+    sealed: String,
+}
+
+/// The decrypted inner request: a tool name + free-form args, mirroring the
+/// MCP read surface.
+#[derive(Deserialize)]
+struct ChannelInner {
+    tool: String,
+    #[serde(default)]
+    args: serde_json::Value,
+}
+
+async fn channel_request(
+    State(s): State<RestState>,
+    Path(hub_id): Path<Uuid>,
+    Json(req): Json<ChannelRequest>,
+) -> Result<Json<ChannelResponse>, ApiError> {
+    if hub_id != s.hub_id {
+        return Err(ApiError::not_found(format!("unknown hub {hub_id}")));
+    }
+
+    // Resolve the caller's pinned LCT pubkey. Unknown LCT → can't open a
+    // channel (members get pinned at join; non-members request citizenship
+    // first). This is the no-LCT/external gate at the channel boundary.
+    let caller_pubkey = {
+        let resolver = s.resolver.read().await;
+        resolver.lookup(req.caller_lct_id).map(|lct| lct.public_key)
+    }
+    .ok_or_else(|| ApiError::unauthorized(
+        "caller LCT is not known to this hub — request citizenship first".to_string(),
+    ))?;
+
+    // Open = authenticate (AEAD proves key possession) + decrypt, in one step.
+    let plaintext = s.signer
+        .channel_open(&caller_pubkey, req.pair_id, &req.sealed)
+        .map_err(|_| ApiError::unauthorized(
+            "channel authentication/decryption failed".to_string(),
+        ))?;
+    let inner: ChannelInner = serde_json::from_slice(&plaintext)
+        .map_err(|e| ApiError::bad_request(format!("malformed channel request: {e}")))?;
+
+    // Authz + dispatch on the decrypted request.
+    let response = dispatch_channel(&s, req.caller_lct_id, inner).await?;
+
+    // Seal the response back over the same channel.
+    let body = serde_json::to_vec(&response)
+        .map_err(|e| ApiError::internal(anyhow::anyhow!("serializing response: {e}")))?;
+    let sealed = s.signer
+        .channel_seal(&caller_pubkey, req.pair_id, &body)
+        .map_err(|e| ApiError::internal(anyhow::anyhow!("sealing response: {e}")))?;
+
+    Ok(Json(ChannelResponse { sealed }))
+}
+
+/// Tier resolution + read dispatch for a decrypted channel request.
+/// v1: only **citizen-tier** (member or Sovereign) may read over the channel,
+/// and only read tools are served. Acts and finer law/MRH/trust gating layer
+/// on here.
+async fn dispatch_channel(
+    s: &RestState,
+    caller_lct_id: Uuid,
+    inner: ChannelInner,
+) -> Result<serde_json::Value, ApiError> {
+    let state = {
+        let ledger = s.ledger.lock().await;
+        HubState::project(&ledger)
+    };
+
+    let is_citizen = state.members.contains_key(&caller_lct_id)
+        || caller_lct_id == s.sovereign_lct_id;
+    if !is_citizen {
+        return Err(ApiError::unauthorized(
+            "citizen tier required for hub queries".to_string(),
+        ));
+    }
+
+    match inner.tool.as_str() {
+        "query_hub" => Ok(serde_json::json!({
+            "hub_name": state.hub_name,
+            "member_count": state.member_count(),
+            "last_ledger_index": state.last_index,
+        })),
+        "list_members" => Ok(serde_json::json!({
+            "members": state.members.values().collect::<Vec<_>>(),
+        })),
+        "find_skill" => {
+            let q = inner.args.get("q").and_then(|v| v.as_str()).unwrap_or("").to_lowercase();
+            let hits: Vec<&hub_lib::state::Member> = state.members.values()
+                .filter(|m| m.skills.iter().any(|sk| sk.contains(&q)))
+                .collect();
+            Ok(serde_json::json!({ "members": hits }))
+        }
+        other => Err(ApiError::bad_request(format!("unknown or non-channel tool: {other}"))),
+    }
 }
 
 // ---------- POST /v1/admin/reload-law ----------

--- a/hub/hub-lib/src/signer.rs
+++ b/hub/hub-lib/src/signer.rs
@@ -36,7 +36,8 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use web4_core::crypto::{KeyPair, SignatureBytes};
+use web4_core::crypto::{KeyPair, PublicKey, SignatureBytes};
+use web4_core::pair_channel::{self, Sealed};
 
 /// Description of what's about to be signed. Vault implementations
 /// (Hestia) use this to apply authority + need-to-know policy AND to
@@ -138,6 +139,25 @@ pub trait RemoteSigner: Send + Sync {
 
     /// What kind of signer this is, for diagnostics + audit.
     fn signer_kind(&self) -> SignerKind;
+
+    /// The hub's own LCT public key, if this signer can expose it. Used in
+    /// discovery so a member can derive the ECDH peer key for a channel.
+    /// `None` when the key isn't locally available (e.g. Hestia mode until
+    /// vault-side channel ops land).
+    fn public_key(&self) -> Option<PublicKey>;
+
+    /// Seal `plaintext` to `peer` over the member↔hub channel, using the
+    /// hub's private key for X25519 ECDH (same `web4_core::pair_channel`
+    /// primitive members use). Returns base64. Hub-side confidentiality:
+    /// citizen-tier responses go out only sealed.
+    fn channel_seal(&self, peer: &PublicKey, pair_id: Uuid, plaintext: &[u8])
+        -> std::result::Result<String, SignError>;
+
+    /// Open a member's sealed request. A successful open authenticates the
+    /// caller (only the holder of `peer`'s private key could have sealed it
+    /// to the hub) AND decrypts in one step.
+    fn channel_open(&self, peer: &PublicKey, pair_id: Uuid, sealed_b64: &str)
+        -> std::result::Result<Vec<u8>, SignError>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -194,6 +214,25 @@ impl RemoteSigner for LocalKeypairSigner {
 
     fn signer_kind(&self) -> SignerKind {
         SignerKind::LocalKeypair
+    }
+
+    fn public_key(&self) -> Option<PublicKey> {
+        Some(self.keypair.verifying_key())
+    }
+
+    fn channel_seal(&self, peer: &PublicKey, pair_id: Uuid, plaintext: &[u8])
+        -> std::result::Result<String, SignError> {
+        let sealed = pair_channel::seal(&self.keypair, peer, pair_id, plaintext)
+            .map_err(|e| SignError::Internal(anyhow!("channel seal: {e}")))?;
+        Ok(sealed.to_base64())
+    }
+
+    fn channel_open(&self, peer: &PublicKey, pair_id: Uuid, sealed_b64: &str)
+        -> std::result::Result<Vec<u8>, SignError> {
+        let sealed = Sealed::from_base64(sealed_b64)
+            .map_err(|e| SignError::Internal(anyhow!("decode sealed: {e}")))?;
+        pair_channel::open(&self.keypair, peer, pair_id, &sealed)
+            .map_err(|e| SignError::Internal(anyhow!("channel open: {e}")))
     }
 }
 
@@ -304,6 +343,26 @@ impl RemoteSigner for HestiaCallbackSigner {
     fn signer_kind(&self) -> SignerKind {
         SignerKind::HestiaCallback
     }
+
+    fn public_key(&self) -> Option<PublicKey> {
+        // Hestia-mode channel sealing (vault-side ECDH) is future work; the
+        // hub doesn't hold the key locally, so it can't expose it here yet.
+        None
+    }
+
+    fn channel_seal(&self, _peer: &PublicKey, _pair_id: Uuid, _plaintext: &[u8])
+        -> std::result::Result<String, SignError> {
+        Err(SignError::Internal(anyhow!(
+            "member↔hub channel sealing is not yet supported in Hestia mode (vault-side ECDH pending)"
+        )))
+    }
+
+    fn channel_open(&self, _peer: &PublicKey, _pair_id: Uuid, _sealed_b64: &str)
+        -> std::result::Result<Vec<u8>, SignError> {
+        Err(SignError::Internal(anyhow!(
+            "member↔hub channel opening is not yet supported in Hestia mode (vault-side ECDH pending)"
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -317,6 +376,46 @@ mod tests {
         let id = IdentityFile::generate(EntityType::Human);
         let kp = id.keypair().unwrap();
         (id, kp)
+    }
+
+    #[test]
+    fn local_signer_channel_round_trips_with_a_member() {
+        // The hub's LocalKeypairSigner and a member each hold an LCT keypair.
+        // A member seals a request to the hub's pubkey; the hub opens it (and
+        // is thereby authenticated to have come from that member's key), then
+        // seals a response the member opens. This is the hub side of the
+        // member↔hub channel (mirror of Hestia's HubChannel test).
+        let hub_id = IdentityFile::generate(EntityType::AiEmbodied);
+        let hub_kp = hub_id.keypair().unwrap();
+        let hub_signer = LocalKeypairSigner::new(hub_id.lct.id, hub_kp);
+        let hub_pub = hub_signer.public_key().expect("local signer exposes pubkey");
+
+        let (_member_id, member_kp) = fresh_actor();
+        let pair_id = Uuid::new_v4();
+
+        // Member → hub.
+        let request = serde_json::to_vec(&json!({"tool": "list_members"})).unwrap();
+        let sealed = web4_core::pair_channel::seal(&member_kp, &hub_pub, pair_id, &request).unwrap();
+        let opened = hub_signer
+            .channel_open(&member_kp.verifying_key(), pair_id, &sealed.to_base64())
+            .unwrap();
+        assert_eq!(opened, request);
+
+        // Hub → member.
+        let resp_b64 = hub_signer
+            .channel_seal(&member_kp.verifying_key(), pair_id, b"{\"members\":[]}")
+            .unwrap();
+        let resp = web4_core::pair_channel::open(
+            &member_kp, &hub_pub, pair_id,
+            &web4_core::pair_channel::Sealed::from_base64(&resp_b64).unwrap(),
+        ).unwrap();
+        assert_eq!(resp, b"{\"members\":[]}");
+
+        // Wrong peer (a third party) cannot open the member's sealed request.
+        let (_other_id, other_kp) = fresh_actor();
+        assert!(hub_signer
+            .channel_open(&other_kp.verifying_key(), pair_id, &sealed.to_base64())
+            .is_err());
     }
 
     fn intent(actor_id: Uuid) -> SignIntent {


### PR DESCRIPTION
Hub side of the **authz + confidentiality** foundation (design: HUB's `proposals/web4-hub-authz-confidentiality-model.md`). Citizen-tier hub traffic travels **sealed over a member↔hub channel — never in the clear** — pairing with Hestia's `HubChannel` (hestia PR #1).

## Changes
- **`RemoteSigner`** gains `public_key()` + `channel_seal` / `channel_open` (`web4_core::pair_channel` — X25519 ECDH from LCT identity keys → ChaCha20-Poly1305). `LocalKeypairSigner` implements them; `HestiaCallbackSigner` errors (vault-side ECDH is future). **The hub's key stays encapsulated in the signer** (Commitment #8) — the endpoint never touches it.
- **Discovery** (`/.well-known/web4-hub.json`) exposes `hub_pubkey_hex` — the ECDH peer key a member needs.
- **`POST /v1/hubs/{id}/channel`** `{ caller_lct_id, pair_id, sealed }`: resolve the caller's pinned pubkey → `channel_open` (a successful AEAD open **authenticates** the caller *and* decrypts, in one step) → authz pipeline → seal the response back.
- **`dispatch_channel`**: tier resolution (v1: citizen = member or Sovereign) + read dispatch (`query_hub` / `list_members` / `find_skill`). PolicyEntity-on-reads + MRH/trust/constellation scoping layer on here; `find_members` rides this once Andy greenlights the membot shape.

## Why it's clean
The channel collapses **authentication + confidentiality** into one primitive — no bearer tokens. An unknown/non-member LCT can't open a channel (the no-LCT/external gate at the boundary). Same `web4_core::pair_channel` primitive as the Hestia side, so they interoperate by construction.

## Tests
`local_signer_channel_round_trips_with_a_member` (member↔hub both directions + third-party-can't-open). **131 passed.** Handler integration test is a follow-up (`rest.rs` currently has no RestState test scaffolding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)