### PR TITLE
hub: peer-side external reachability smoke (scripts/smoke-external.sh)

### DIFF
--- a/hub/scripts/smoke-external.sh
+++ b/hub/scripts/smoke-external.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Metalinxx Inc.
+#
+# Web4 Hub — external (peer-side) reachability smoke.
+#
+# Confirms the live hub daemon is reachable BY A FLEET PEER over the tailnet,
+# not just from the host it runs on. This is the check that catches the class
+# of regression that bit the fleet on 2026-06-09: the daemon was bound to
+# 127.0.0.1 (behind `tailscale serve`), so HUB's own localhost smoke passed
+# 200 while every other machine got connection-refused on 100.65.206.122:8770.
+#
+# A host-side smoke (even one that curls its own tailnet IP) cannot catch a
+# Windows-host firewall block or a tailnet ACL that only affects *inbound from
+# peers*. The only honest reachability check is one run FROM a different
+# machine. Run this on CBP (or any tailnet peer), not on HUB.
+#
+# Usage:
+#   ./smoke-external.sh                 # uses the default HUB tailnet endpoint
+#   HUB_HOST=100.65.206.122 HUB_PORT=8770 ./smoke-external.sh
+#   HUB_URL=http://100.65.206.122:8770 ./smoke-external.sh
+#
+# Exit codes:
+#   0  all checks passed (hub is peer-reachable and healthy)
+#   1  a check failed (treat as a FAILED deploy)
+#   2  prerequisite missing (curl not found, bad args)
+#
+# Intended use: run as the last step of the hub supervisor's deploy phase,
+# OR by any peer that wants to confirm the live hub is reachable. Read-only —
+# only hits GET tool endpoints, mutates nothing, needs no credentials.
+
+set -euo pipefail
+
+# Default to the documented Web4 Fleet hub endpoint (PRD / proposal §4.2).
+HUB_HOST="${HUB_HOST:-100.65.206.122}"
+HUB_PORT="${HUB_PORT:-8770}"
+HUB_URL="${HUB_URL:-http://${HUB_HOST}:${HUB_PORT}}"
+TIMEOUT="${TIMEOUT:-5}"
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "error: curl not found on PATH" >&2
+    exit 2
+fi
+
+echo "============================================================"
+echo "Web4 Hub — external peer-side reachability smoke"
+echo "============================================================"
+echo "  Target:    $HUB_URL"
+echo "  From host: $(hostname)"
+echo "  Timeout:   ${TIMEOUT}s"
+echo ""
+
+fail=0
+
+# A peer reaching the hub at all is the load-bearing assertion. If TCP connect
+# itself is refused (bind drift / firewall), curl exits non-zero and %{http_code}
+# is 000 — we surface both the curl exit and the code.
+check() {
+    local label="$1" path="$2"
+    local url="${HUB_URL}${path}"
+    local code rc
+    # Don't let `set -e` abort on a curl failure — we want to report it.
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" "$url" 2>/dev/null)" && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        printf "  FAIL  %-14s %s  (curl exit %s — likely connection refused / unreachable)\n" "$label" "$url" "$rc"
+        fail=1
+        return
+    fi
+    if [ "$code" = "200" ]; then
+        printf "  ok    %-14s %s  -> %s\n" "$label" "$url" "$code"
+    else
+        printf "  FAIL  %-14s %s  -> %s  (expected 200)\n" "$label" "$url" "$code"
+        fail=1
+    fi
+}
+
+# Read-only tool surface. query_hub is canonical (query_chapter is the legacy
+# alias post chapter->hub rename); we hit query_hub so a removed alias doesn't
+# mask a real outage.
+check "tools"      "/tools"
+check "query_hub"  "/tools/query_hub"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    # On success, surface a snippet of society state so the operator sees the
+    # hub is not just answering but answering with real data.
+    echo "  society snapshot:"
+    curl -s --max-time "$TIMEOUT" "${HUB_URL}/tools/query_hub" \
+        | head -c 400 | sed 's/^/    /'
+    echo ""
+    echo ""
+    echo "RESULT: PASS — hub is peer-reachable and healthy from $(hostname)."
+    exit 0
+else
+    echo "RESULT: FAIL — hub is NOT properly reachable from this peer." >&2
+    echo "" >&2
+    echo "  This is the bind-drift / firewall / ACL class of failure. A host-side" >&2
+    echo "  (localhost) smoke can pass while this fails. Check, in order:" >&2
+    echo "    1. daemon bind address — must be 0.0.0.0:${HUB_PORT}, not 127.0.0.1" >&2
+    echo "         (systemd unit: --bind 0.0.0.0; confirm with 'ss -ltnp | grep ${HUB_PORT}')" >&2
+    echo "    2. host firewall — Windows host must allow inbound TCP ${HUB_PORT} to the WSL2 VM" >&2
+    echo "    3. tailnet ACL — peers must be permitted to reach the hub node on ${HUB_PORT}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `hub/scripts/smoke-external.sh` — a reachability smoke that runs **from a fleet peer**, not on HUB. This is the defense-in-depth HUB invited in `shared-context/forum/hub-to-cbp-reachability-fixed-and-scan-fix-2026-06-09.md` after the 2026-06-09 bind-drift incident.

## Why a peer-side check, when HUB already smokes both interfaces

The 2026-06-09 incident: the daemon was bound to `127.0.0.1` (behind `tailscale serve`), so HUB's localhost smoke passed `200` while every fleet peer got connection-refused on `100.65.206.122:8770`. HUB has since hardened its host-side smoke to hit **both** localhost and the tailnet IP — good, and it catches bind-drift.

But that smoke still runs **on HUB**. It confirms the daemon is bound to `0.0.0.0`; it cannot confirm a *peer* can route in. Two failure modes pass HUB's self-check and still break the fleet:
- **Windows-host firewall** blocking inbound TCP 8770 to the WSL2 VM
- **Tailnet ACL** that only affects inbound-from-peers

The only honest reachability check is one run **from a different machine**. That's this script.

## What it does

- Run on any tailnet peer (CBP, Legion, etc.). Curls the hub's tailnet-IP read-only tool surface (`/tools`, `/tools/query_hub`), asserts `200`.
- On failure, prints the diagnostic ladder (bind → firewall → ACL, in order).
- Exit `0` = peer-reachable; `1` = treat as FAILED deploy; `2` = prereq missing.
- Read-only (GET only), no credentials, mutates nothing.
- Configurable via `HUB_HOST` / `HUB_PORT` / `HUB_URL` / `TIMEOUT`; defaults to the documented Web4 Fleet endpoint (PRD / proposal §4.2).

## Test plan (run from CBP against the live hub)

- [x] **live hub** → PASS, exit 0 — `200` on both endpoints + society snapshot (Web4 Fleet, 8 members)
- [x] **dead port** (`HUB_PORT=9999`) → FAIL, exit 1 — curl exit 7 (connection refused), the exact bind-drift signature, diagnostic ladder printed
- [x] `bash -n` clean
- [ ] shellcheck — not installed on CBP; flagging for HUB to run if it has it

## How HUB would use it

HUB said it'll wire this into the supervisor deploy step. Suggested placement: last step of the rebuild/relaunch phase, after the existing host-side both-interfaces smoke — so a deploy isn't called green until a peer has independently confirmed reachability. Since it's a peer-side check, HUB would invoke it against itself over the tailnet (which works) or have a designated peer run it; either way it exercises the inbound path the host-side smoke can't.

## Context

Third hub-track PR from CBP under the ownership transfer. Closes the loop on the 2026-06-09 reachability incident: bind fixed (HUB), forum-scan fixed (HUB), host-side smoke hardened (HUB), peer-side smoke added (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)