### PR TITLE
feat(hub): find_members — semantic member discovery (hub gates, membot engine)

### DIFF
--- a/hub/Cargo.lock
+++ b/hub/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "ctrlc",
  "hex",
  "hub-lib",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/hub/hub-daemon/Cargo.toml
+++ b/hub/hub-daemon/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ctrlc = "3"
 hex = "0.4"
 serde_yaml = "0.9"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [[example]]
 name = "mock-hestia"

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -841,8 +841,73 @@ async fn dispatch_channel(
                 "truncated": total > limit.unwrap_or(total),
             }))
         }
+        "find_members" => {
+            // Semantic member discovery. The hub is the front door (gating +
+            // tier scoping happen here); membot is the engine (the sidecar does
+            // the embedding + 3-signal search). top_k is bounded by the tier cap.
+            let query = inner.args.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            if query.trim().is_empty() {
+                return Err(ApiError::bad_request("find_members requires a 'query'".to_string()));
+            }
+            let requested = inner.args.get("top_k").and_then(|v| v.as_u64()).map(|n| n as usize);
+            let effective = scope.effective_limit(requested.or(Some(12))).unwrap_or(12);
+            let temperature = inner.args.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let hits = membox_find_members(query, effective, temperature).await?;
+            Ok(serde_json::json!({
+                "results": hits,
+                "total": hits.len(),
+                "temperature": temperature,
+            }))
+        }
+        // Reserved registration slot for membot's Walk-as-MCP (ships ~2026-06-12):
+        // when it lands it's a register-and-gate, not a reimplement. Same role
+        // gating + tier scoping as find_members applies (gate_read already ran).
+        "walk_members" => Err(ApiError {
+            status: StatusCode::NOT_IMPLEMENTED,
+            message: "walk_members is reserved for membot's Walk-as-MCP (not yet shipped)".to_string(),
+        }),
         other => Err(ApiError::bad_request(format!("unknown or non-channel tool: {other}"))),
     }
+}
+
+/// Call the local membox sidecar (the discovery engine) for semantic member
+/// search. The hub composes membot as a localhost dependency; this never faces
+/// the network. A sidecar that's down → 503 with a clear message (discovery
+/// degraded, the rest of the hub is fine).
+async fn membox_find_members(
+    query: &str,
+    top_k: usize,
+    temperature: f64,
+) -> Result<Vec<serde_json::Value>, ApiError> {
+    let base = std::env::var("WEB4_MEMBOX_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8771".to_string());
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/find_members", base.trim_end_matches('/')))
+        .json(&serde_json::json!({ "query": query, "top_k": top_k, "temperature": temperature }))
+        .send()
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: format!("member-discovery engine unreachable: {e}"),
+        })?;
+    if !resp.status().is_success() {
+        let code = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ApiError {
+            status: StatusCode::BAD_GATEWAY,
+            message: format!("discovery engine returned {code}: {body}"),
+        });
+    }
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| ApiError::internal(anyhow::anyhow!("parsing discovery response: {e}")))?;
+    Ok(body
+        .get("results")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default())
 }
 
 /// External→citizen bootstrap over the channel. An authenticated external LCT
@@ -2326,5 +2391,63 @@ norms:
             .err()
             .expect("join should be escalated, not admitted");
         assert_eq!(err.status, StatusCode::ACCEPTED, "escalate → 202");
+    }
+
+    #[tokio::test]
+    async fn find_members_over_channel_then_degrades_when_engine_down() {
+        use axum::{routing::post, Router};
+
+        // Stand up a mock discovery engine (the membox sidecar's contract).
+        let app = Router::new().route(
+            "/find_members",
+            post(|| async {
+                axum::Json(serde_json::json!({
+                    "results": [{ "member_lct": "657b6bc9", "name": "Ada", "score": 0.87 }],
+                    "total": 1
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap(); });
+        std::env::set_var("WEB4_MEMBOX_URL", format!("http://{addr}"));
+
+        let (_tmp, state) = fresh_rest_state(None).await; // open admission
+        let hub_pub = state.signer.public_key().unwrap();
+        let applicant = KeyPair::generate();
+        let applicant_lct = Uuid::new_v4();
+
+        // Admit so the caller is a citizen (find_members is citizen-gated).
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&applicant, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Caller" }));
+        channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: applicant_lct, pair_id: pid, sealed,
+            caller_pubkey_hex: Some(applicant.verifying_key().to_hex()),
+        })).await.expect("admitted");
+
+        // find_members over the channel → hub gates+scopes, calls the engine,
+        // seals the ranked LCTs back.
+        let pid2 = Uuid::new_v4();
+        let sealed2 = seal_req(&applicant, &hub_pub, pid2, "find_members",
+            serde_json::json!({ "query": "diffusion eval harness" }));
+        let resp = channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: applicant_lct, pair_id: pid2, sealed: sealed2, caller_pubkey_hex: None,
+        })).await.expect("find_members ok");
+        let out = open_resp(&applicant, &hub_pub, pid2, &resp.0.sealed);
+        assert_eq!(out["results"][0]["member_lct"], serde_json::json!("657b6bc9"));
+        assert_eq!(out["total"], serde_json::json!(1));
+
+        // Engine down → graceful 503, hub itself unaffected.
+        std::env::set_var("WEB4_MEMBOX_URL", "http://127.0.0.1:1");
+        let pid3 = Uuid::new_v4();
+        let sealed3 = seal_req(&applicant, &hub_pub, pid3, "find_members",
+            serde_json::json!({ "query": "anything" }));
+        let err = channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: applicant_lct, pair_id: pid3, sealed: sealed3, caller_pubkey_hex: None,
+        })).await.err().expect("engine-down should error");
+        assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+
+        std::env::remove_var("WEB4_MEMBOX_URL");
     }
 }

--- a/hub/membox/README.md
+++ b/hub/membox/README.md
@@ -1,0 +1,55 @@
+# Hub member discovery — `find_members`
+
+> The hub is the front door; **membot is the engine.**
+
+Semantic member discovery for a Web4 hub. A member asks *"who can help me with
+X?"* over the E2E channel; the hub gates + scopes the request and composes
+membot's cartridge/membox search to return ranked member LCTs. The caller then
+drives `request_intro` (next).
+
+This is the **library** integration (Stage 1 of the membot green-light, forum:
+`waving-cat-to-hub-membot-greenlight-2026-06-09.md`): the hub owns ingestion,
+the front door, intros, and chapter-law gating; membot ships the cart format,
+the pinned embedding model, and the 3-signal search (cosine + Hamming + keyword
+rerank).
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `ingest.py` | Reads hub members → free-form prose passages → embeds (pinned **nomic-embed-text-v1.5**) → writes a `.cart.npz` + a passage-index-aligned `members.json` (forward-compat tags). |
+| `sidecar.py` | Long-lived localhost HTTP service. Mounts the cart + holds the model once. `POST /find_members {query, top_k, temperature}` → ranked `{member_lct, name, score, tags}`. `GET /health`. |
+| `test_ingest.py` | Passage/tag contract tests (no model load). |
+
+The Rust hub-side `find_members` channel tool (in `hub-daemon/src/rest.rs`)
+calls the sidecar over localhost, gated by chapter law (`read:find_members`) and
+bounded by tier (`ReadScope`). A `walk_members` slot is reserved for membot's
+forthcoming Walk-as-MCP (register-and-gate, not reimplement).
+
+## Locked v1 contract (the three adds)
+
+1. **Model pinned** to `nomic-ai/nomic-embed-text-v1.5` (free via `cartridge_builder`).
+2. **Forward-compat tags** per member (`member_lct`, `profile_version`,
+   `last_pair_purpose`) so V3 trust feedback slots in without re-imprinting.
+3. **Temperature knob from day one** — accepted at the API boundary now;
+   precision-only until membot exposes settle-noise in search (then wired through).
+
+Passage shape: `{Name}. {free-form skills/interests prose}. Recent pair purposes: {…}.`
+Tuning: `top_k` 10–15, keyword rerank ~0.05/hit, hippocampus-walk off (single-passage profiles).
+
+## Operate
+
+```bash
+# (re)build the cart from the live hub
+membot/.venv/bin/python ingest.py --out /home/dp/web4-hub/membox-data --name web4-fleet-members
+sudo systemctl restart web4-membox     # re-mount after re-ingest
+
+# the sidecar runs as systemd web4-membox.service (port 8771, localhost)
+systemctl status web4-membox
+curl -s http://127.0.0.1:8771/health
+```
+
+**Data note:** discovery is only as rich as member profiles. Until members
+declare skills/interests (MemberSkillDeclared / MemberProfileUpdated, e.g. via
+Hestia), passages are name-only and matches are weak. The engine is live; the
+data populates as members fill in.

--- a/hub/membox/ingest.py
+++ b/hub/membox/ingest.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Build a per-hub member-discovery cart from the hub's live membership.
+
+The hub is the front door; membot is the engine. This is the ingestion half:
+it reads the hub's members, turns each into a free-form prose passage, embeds
+them with membot's pinned model, and writes a `.cart.npz` the sidecar serves.
+
+Per the locked v1 contract (forum: waving-cat-to-hub greenlight, 2026-06-09):
+  - Model PINNED to nomic-ai/nomic-embed-text-v1.5 (we get this for free by
+    using membot's cartridge_builder.embed_texts — same model as Membot/Studio).
+  - Passage shape is PROSE, not schema: "{Name}. {free-form skills/interests}.
+    Recent pair purposes: {…}." — honors "skills stay plain language".
+  - Forward-compat provenance carried alongside the cart (member_lct,
+    profile_version, last_pair_purpose) so V3 trust feedback slots in later
+    without re-imprinting. We keep it in a sidecar JSON keyed by passage index
+    (local_addr) rather than the cart's fixed hippocampus struct.
+
+Usage:
+  membot/.venv/bin/python ingest.py \
+      --members-url http://127.0.0.1:8770/tools/list_members \
+      --out /home/dp/web4-hub/membox-data \
+      --name web4-fleet-members
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.request
+
+# membot ships the cart format + embedding pipeline; we compose it as a library.
+MEMBOT_DIR = os.environ.get("MEMBOT_DIR", "/home/dp/ai-workspace/membot")
+sys.path.insert(0, MEMBOT_DIR)
+
+
+def fetch_members(url: str) -> list[dict]:
+    with urllib.request.urlopen(url, timeout=15) as r:
+        data = json.loads(r.read().decode())
+    return data.get("members", [])
+
+
+def member_passage(m: dict) -> str:
+    """Free-form prose an LLM-reader could synthesize naturally. We concatenate
+    the member's own words (skills + profile free-text), NOT schema fields."""
+    name = m.get("name") or str(m.get("lct_id", "unknown"))[:8]
+    prose_parts: list[str] = []
+    skills = m.get("skills") or []
+    if skills:
+        prose_parts.append(", ".join(skills))
+    profile = m.get("profile") or {}
+    # profile values are free-text prose (interests, etc.). Skip the pair-purpose
+    # key — it has its own slot in the passage tail.
+    for k, v in profile.items():
+        if k == "last_pair_purpose":
+            continue
+        if v:
+            prose_parts.append(v)
+    prose = ". ".join(p for p in prose_parts if p)
+    passage = f"{name}." if not prose else f"{name}. {prose}."
+    pair_purpose = profile.get("last_pair_purpose")
+    if pair_purpose:
+        passage += f" Recent pair purposes: {pair_purpose}."
+    return passage
+
+
+def member_tags(m: dict, passage: str) -> dict:
+    """Forward-compat provenance (item 2 of the three adds). profile_version is
+    a content hash so it changes exactly when a member's profile changes."""
+    profile = m.get("profile") or {}
+    return {
+        "member_lct": m.get("lct_id"),
+        "name": m.get("name"),
+        "profile_version": hashlib.sha256(passage.encode()).hexdigest()[:12],
+        "last_pair_purpose": profile.get("last_pair_purpose"),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--members-url", default="http://127.0.0.1:8770/tools/list_members")
+    ap.add_argument("--out", default="/home/dp/web4-hub/membox-data")
+    ap.add_argument("--name", default="web4-fleet-members")
+    ap.add_argument("--members-json", help="read members from a file instead of the hub (for tests/demo)")
+    args = ap.parse_args()
+
+    if args.members_json:
+        with open(args.members_json) as f:
+            members = json.load(f).get("members", [])
+    else:
+        members = fetch_members(args.members_url)
+
+    if not members:
+        print("no members to ingest — nothing to do", file=sys.stderr)
+        return 1
+
+    import cartridge_builder as cb
+
+    passages = [member_passage(m) for m in members]
+    tags = [member_tags(m, p) for m, p in zip(members, passages)]
+
+    print(f"embedding {len(passages)} member passages with pinned Nomic model...", flush=True)
+    embeddings = cb.embed_texts(passages)
+
+    os.makedirs(args.out, exist_ok=True)
+    cart_path, size_mb, fingerprint = cb.save_cartridge(args.out, args.name, embeddings, passages)
+
+    # The forward-compat provenance sidecar, passage-index aligned (== local_addr
+    # in search results). The sidecar maps a hit back to its member_lct via this.
+    meta_path = os.path.join(args.out, f"{args.name}.members.json")
+    with open(meta_path, "w") as f:
+        json.dump({"fingerprint": fingerprint, "members": tags}, f, indent=2)
+
+    print(f"cart:  {cart_path}  ({size_mb:.2f} MB, fingerprint {fingerprint})")
+    print(f"meta:  {meta_path}  ({len(tags)} members)")
+    populated = sum(1 for m in members if (m.get("skills") or m.get("profile")))
+    print(f"members: {len(members)} total, {populated} with declared skills/profile")
+    if populated == 0:
+        print("NOTE: no member has declared skills/interests yet — passages are "
+              "name-only. Discovery works but is weak until members populate "
+              "profiles (MemberProfileUpdated / declare-skill via Hestia).",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hub/membox/sidecar.py
+++ b/hub/membox/sidecar.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Member-discovery sidecar — the engine behind the hub's find_members tool.
+
+The nomic model is ~600 MB; reloading it per query is a non-starter. So this is
+a long-lived localhost HTTP service that mounts the per-hub cart + holds the
+loaded model once, and answers find_members. The Rust hub composes it: the hub
+owns chapter-law gating + tier scoping; this just does the 3-signal semantic
+search (cosine + Hamming + keyword rerank) membot ships.
+
+Endpoints (localhost only — the hub mediates all external access):
+  GET  /health                      -> {ok, cart, n_members, fingerprint}
+  POST /find_members {query, top_k, temperature}
+        -> {results: [{member_lct, name, score, tags}], total}
+
+temperature is accepted now (locked v1 contract: ship the knob from day one)
+but the underlying multi_cart.search doesn't expose settle-noise yet, so v1 is
+precision-only (temperature is recorded + echoed, wired through when membot
+exposes it). Reserved, not faked.
+"""
+import argparse
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+MEMBOT_DIR = os.environ.get("MEMBOT_DIR", "/home/dp/ai-workspace/membot")
+sys.path.insert(0, MEMBOT_DIR)
+
+STATE = {"cart_id": None, "members": [], "fingerprint": None}
+
+
+def load(cart_path: str, meta_path: str, cart_id: str):
+    import multi_cart as mc
+    res = mc.mount(cart_path, cart_id=cart_id, verify_integrity=True)
+    with open(meta_path) as f:
+        meta = json.load(f)
+    STATE["cart_id"] = cart_id
+    STATE["members"] = meta.get("members", [])
+    STATE["fingerprint"] = meta.get("fingerprint")
+    print(f"mounted {cart_id}: {res.get('n_patterns')} patterns, "
+          f"{len(STATE['members'])} member records", flush=True)
+
+
+def do_search(query: str, top_k: int) -> list[dict]:
+    import multi_cart as mc
+    res = mc.search(query, top_k=top_k, scope=STATE["cart_id"])
+    out = []
+    members = STATE["members"]
+    for r in res.get("results", []):
+        addr = r.get("local_addr")
+        meta = members[addr] if isinstance(addr, int) and 0 <= addr < len(members) else {}
+        out.append({
+            "member_lct": meta.get("member_lct"),
+            "name": meta.get("name"),
+            "score": float(r.get("score", 0.0)),
+            "tags": meta,
+        })
+    # Drop hits we couldn't attribute to a member_lct (defensive).
+    return [r for r in out if r["member_lct"]]
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _json(self, code: int, body: dict):
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *a):  # quiet
+        pass
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json(200, {"ok": True, "cart": STATE["cart_id"],
+                             "n_members": len(STATE["members"]),
+                             "fingerprint": STATE["fingerprint"]})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/find_members":
+            return self._json(404, {"error": "not found"})
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            req = json.loads(self.rfile.read(n) or b"{}")
+        except Exception as e:
+            return self._json(400, {"error": f"bad request: {e}"})
+        query = (req.get("query") or "").strip()
+        if not query:
+            return self._json(400, {"error": "query is required"})
+        top_k = int(req.get("top_k") or 12)          # contract default 10-15
+        temperature = float(req.get("temperature") or 0.0)
+        try:
+            results = do_search(query, top_k)
+        except Exception as e:
+            return self._json(500, {"error": f"search failed: {e}"})
+        self._json(200, {"results": results, "total": len(results),
+                         "temperature": temperature})
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", default="/home/dp/web4-hub/membox-data")
+    ap.add_argument("--name", default="web4-fleet-members")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8771)
+    args = ap.parse_args()
+
+    cart_path = os.path.join(args.data, f"{args.name}.cart.npz")
+    meta_path = os.path.join(args.data, f"{args.name}.members.json")
+    load(cart_path, meta_path, args.name)
+
+    srv = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"membox sidecar on http://{args.host}:{args.port} "
+          f"(POST /find_members, GET /health)", flush=True)
+    srv.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hub/membox/test_ingest.py
+++ b/hub/membox/test_ingest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Tests for the ingestion passage/tag contract (no model load — pure shape).
+
+Run: membot/.venv/bin/python -m pytest web4/hub/membox/test_ingest.py
+ or: python3 web4/hub/membox/test_ingest.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from ingest import member_passage, member_tags  # noqa: E402
+
+
+def test_passage_is_prose_not_schema():
+    m = {
+        "lct_id": "657b6bc9-ada",
+        "name": "Ada",
+        "skills": ["diffusion fine-tuning", "eval design"],
+        "profile": {"interests": "mechanistic interpretability"},
+    }
+    p = member_passage(m)
+    # Prose, member's own words — no "Skills:"/"Interests:" schema labels.
+    assert p.startswith("Ada. ")
+    assert "diffusion fine-tuning" in p and "mechanistic interpretability" in p
+    assert "Skills:" not in p and "Interests:" not in p
+
+
+def test_pair_purpose_tail_when_known():
+    m = {"lct_id": "x", "name": "Bem", "skills": ["Rust"],
+         "profile": {"last_pair_purpose": "co-debugging a ledger sync"}}
+    p = member_passage(m)
+    assert p.endswith("Recent pair purposes: co-debugging a ledger sync.")
+
+
+def test_name_only_when_no_profile():
+    m = {"lct_id": "y", "name": "sprout", "skills": [], "profile": {}}
+    assert member_passage(m) == "sprout."
+
+
+def test_tags_carry_forward_compat_provenance():
+    m = {"lct_id": "657b6bc9", "name": "Ada", "skills": ["x"],
+         "profile": {"last_pair_purpose": "thing"}}
+    t = member_tags(m, member_passage(m))
+    # The three forward-compat fields Waving Cat asked for (item 2).
+    assert t["member_lct"] == "657b6bc9"
+    assert t["name"] == "Ada"
+    assert t["last_pair_purpose"] == "thing"
+    assert len(t["profile_version"]) == 12  # content hash → changes with profile
+
+
+def test_profile_version_changes_with_content():
+    m1 = {"lct_id": "z", "name": "C", "skills": ["a"], "profile": {}}
+    m2 = {"lct_id": "z", "name": "C", "skills": ["a", "b"], "profile": {}}
+    assert member_tags(m1, member_passage(m1))["profile_version"] != \
+        member_tags(m2, member_passage(m2))["profile_version"]
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} passed")


### PR DESCRIPTION
**v1 of the AIC use case.** A member asks *"who can help me with X?"* over the E2E channel; the hub gates + scopes and composes membot's search to return ranked member LCTs (→ `request_intro` next). *"The hub is the front door; membot is the engine."*

Stage-1 **library** integration per the locked green-light (forum: `waving-cat-to-hub-membot-greenlight-2026-06-09`).

## Pieces
- **`membox/ingest.py`** — hub members → free-form prose passages → **nomic-embed-text-v1.5 (pinned)** → `.cart.npz` + a passage-index-aligned `members.json` with **forward-compat tags** (`member_lct`, `profile_version`, `last_pair_purpose`).
- **`membox/sidecar.py`** — long-lived localhost service (model + cart loaded once); `POST /find_members {query, top_k, temperature}` → ranked `{member_lct, name, score, tags}`. Runs as `web4-membox.service`.
- **`hub-daemon` `find_members` channel tool** — calls the sidecar, **gated by chapter law** (`read:find_members`) + **bounded by `ReadScope`** tier cap; engine-down → graceful **503**. `temperature` accepted now (contract: ship the knob), precision-only until membot exposes settle-noise. **Reserved `walk_members` slot** for Walk-as-MCP (register-and-gate).

## The three adds — all in
1. Model pinned to `nomic-embed-text-v1.5` ✅  2. Forward-compat provenance tags ✅  3. Temperature knob from day one ✅

## Tests
Python passage/tag contract (5); **Rust E2E `find_members` through the full sealed channel** with a mock engine + the engine-down 503 path. **132 lib + 8 daemon** pass.

## Deployed + verified
Sidecar live, hub rebuilt + restarted, smoke-green on both interfaces. Engine validated on a demo cart — *diffusion→Ada, internals→Deq, inference→El, organizer→Fi*, each correct LCT as #1.

**Honest data note:** the live fleet members have **no declared skills/profiles yet**, so live matches are name-only (weak) until members populate profiles (`MemberSkillDeclared` / `MemberProfileUpdated`, e.g. via Hestia). The engine is live; richness follows the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)