### PR TITLE
remediate(C49): apply 6 autonomous C48 findings to r6-framework.md

### DIFF
--- a/web4-standard/core-spec/r6-framework.md
+++ b/web4-standard/core-spec/r6-framework.md
@@ -67,7 +67,7 @@ Each component is essential and together they form a complete, deterministic act
     "v3InRole": {
       "veracity": 0.92,
       "validity": 0.88,
-      "value": 0.85
+      "valuation": 0.85
     }
   }
 }
@@ -206,10 +206,10 @@ Each component is essential and together they form a complete, deterministic act
     },
     "tensorUpdates": {
       "t3": {"training": +0.01},
-      "v3": {"veracity": +0.02, "validity": 1.0}
+      "v3": {"veracity": +0.02, "validity": +0.01}
     },
     "attestations": [
-      {"witness": "lct:web4:...", "signature": "...", "timestamp": "..."}
+      {"lct": "lct:web4:...", "signature": "...", "timestamp": "..."}
     ],
     "ledgerProof": {
       "txHash": "0x...",
@@ -220,6 +220,8 @@ Each component is essential and together they form a complete, deterministic act
 }
 ```
 
+**Note**: The `tensorUpdates` object shown here is the single-party form. Multi-party actions (e.g., agency-delegated actions affecting both agent and client) use the per-entity array form shown in §5.5.
+
 ## 2. R6 Transaction Flow
 
 ### 2.1 Pre-execution Validation
@@ -227,7 +229,7 @@ Each component is essential and together they form a complete, deterministic act
 def validate_r6_action(r6_action):
     # 1. Verify actor has required role
     if not verify_role_pairing(r6_action.role):
-        raise InvalidRole("Actor not paired with specified role")
+        raise RoleUnauthorized("Actor not paired with specified role")
 
     # 2. Check for agency delegation if acting as agent
     if r6_action.request.get('proofOfAgency'):
@@ -242,11 +244,11 @@ def validate_r6_action(r6_action):
 
     # 4. Verify resource availability (including agency caps)
     if not check_resources(r6_action.resource.required):
-        raise InsufficientResources("Cannot fulfill resource requirements")
+        raise ResourceInsufficient("Cannot fulfill resource requirements")
 
     # 5. Validate references
     if not verify_references(r6_action.reference):
-        raise InvalidReference("Referenced precedents/witnesses invalid")
+        raise ReferenceInvalid("Referenced precedents/witnesses invalid")
 
     # 6. Lock resources (escrow)
     escrow_lock = lock_resources(r6_action.resource.escrow)
@@ -356,7 +358,7 @@ The R6 framework integrates tightly with the Society-Authority-Law layer:
 ## 4. R6 Security Properties
 
 ### 4.1 Determinism
-Given the same R6 inputs **and execution outcome**, the settlement (resource accounting, tensor updates, ledger entry) must be identical across all valid implementations. The determinism guarantee applies to the R6 framework's processing, not to the underlying action execution which may depend on external factors (hardware, network state, nondeterministic algorithms).
+Given the same R6 inputs **and execution outcome**, the settlement (resource accounting, tensor updates, ledger entry) must be identical across all valid implementations. The determinism guarantee applies to the R6 framework's settlement processing, not to the underlying action execution — which may depend on external factors (hardware, network state, nondeterministic algorithms) — nor to the measured resource consumption recorded in the Result.
 
 ### 4.2 Non-repudiation
 All R6 actions are signed and recorded on the immutable ledger with witness attestations.


### PR DESCRIPTION
## C49 Remediation — r6-framework.md (closes the C12→C48→C49 cycle)

Applies all 6 AUTONOMOUS findings from the merged C48 audit (#310, `docs/audits/C48-r6-framework-audit-2026-06-10.md`). 1 file, +9/−7. Policy review: **APPROVED first-pass** (2 execution notes, both honored).

### Applied
| Finding | Edit |
|---|---|
| **C48-M1** (MED) | §1.2 `v3InRole` `"value"` → `"valuation"` — canonical V3 vocabulary (Terminology Protection); matches r7 + SDK `Role.v3_in_role`. Last `v3InRole` holdout after C34/C35/C44-C45. The §1.1/§5.2 constraint `{type, value}` keys are **untouched** (C48-DQ-constraint; SDK `from_dict` accepts `value` legacy alias). |
| **C48-M2** (MED) | §1.6 attestation key `"witness"` → `"lct"` — matches r6's own §1.4, all 5 r7 attestation sites, SDK. Exact r6-mirror of C46-M2 (fixed in r7 by #309). |
| **C48-M3** (MED) | §2.1 `InvalidRole`/`InsufficientResources`/`InvalidReference` → `RoleUnauthorized`/`ResourceInsufficient`/`ReferenceInvalid` (r6's own §7 catalog + SDK spelling). `InvalidAgency`/`AgencyScopeViolation` deliberately NOT renamed — that's C48-DQ-agency (operator taxonomy decision). |
| **C48-L1** (LOW) | §1.6 `"validity": 1.0` → `"validity": +0.01` (absolute-as-delta fixed; plain delta, no semantics prose per exec note). |
| **C48-L2** (LOW) | §4.1 Determinism second sentence harmonized with r7 §4.1 ("settlement processing", em-dash structure, "nor to the measured resource consumption recorded in the Result"). **Deliberate residual**: lead phrase `and execution outcome` retained (r7 uses `and the same Result`) for intra-r6 consistency with §6 MUST-3 and §9 — recorded so the next delta audit doesn't re-flag it as drift. |
| **C48-L3** (LOW) | §1.6 one-line note: single-party `tensorUpdates` object here; multi-party actions use the §5.5 per-entity array form. |

### NOT self-resolved (operator)
- **C48-DQ-agency** (= carry-C46-agency): agency error classes have no §7/SDK home — paired r6+r7+SDK decision.
- **C48-DQ-errors** (= carry-C30): §7 class model ↔ `errors.md` `W4_ERR_*` canonicity.
- **C48-DQ-constraint** (= carry-C46 §C #4): constraint shape / `"100/hour"` string / type-name registry.

### Cross-track (untouched here)
- **C48-CT-failure**: r7-side — r6 is the correct side; reconcile r7 §2.2 at r7's next pass.
- **C48-CT-id**: `resource:web4:`/`mcp:web4://tool/*`/`agy:` → data-formats SSOT pass.

Verification: grep clean for all three old error names and `"witness":`; diff reviewed line-by-line against the audit's Disposition Ledger. With #309 (r7) + this PR (r6), the sibling specs now agree on V3 `valuation`, attestation `lct` keys, and §7/SDK error-name spelling.

Session log: `private-context/autonomous-sessions/legion-web4-20260611-000001-session.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)