### PR TITLE
feat(hub): member key-enrollment — MemberKeyPinned + hub set-member-key

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -578,6 +578,9 @@ fn event_summary(event: &HubEvent) -> String {
         HubEvent::MemberSkillDeclared { member_lct_id, skill, .. } => {
             format!("Skill \"{}\" by {}", html_escape(skill), short(member_lct_id))
         }
+        HubEvent::MemberKeyPinned { member_lct_id, .. } => {
+            format!("Channel key pinned for {}", short(member_lct_id))
+        }
         HubEvent::MemberProfileUpdated { member_lct_id, fields, .. } => {
             let keys: Vec<&str> = fields.keys().map(|k| k.as_str()).collect();
             format!("Profile update ({}) by {}", html_escape(&keys.join(", ")), short(member_lct_id))

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -306,6 +306,19 @@ enum Command {
         hub_dir: PathBuf,
     },
 
+    /// Pin (or rotate) an existing member's channel public key — the member
+    /// key-enrollment step. Members admitted without a pubkey cannot open the
+    /// sealed channel; the member generates a keypair locally, shares the
+    /// public half, and the Sovereign pins it here. Appends a MemberKeyPinned
+    /// event; restart `hub serve` to re-seed the live resolver.
+    SetMemberKey {
+        hub_dir: PathBuf,
+        /// The member's LCT id.
+        member_lct_id: Uuid,
+        /// Hex-encoded 32-byte Ed25519 public key (the member keeps the secret half).
+        pubkey_hex: String,
+    },
+
     /// Write the starter chapter-law template to a file the operator
     /// can review + edit, then apply via `hub set-law`. Doesn't touch
     /// any hub directly.
@@ -515,6 +528,9 @@ async fn main() -> Result<()> {
             run_set_law(hub_dir, yaml, diff_summary).await
         }
         Some(Command::GetLaw { hub_dir }) => run_get_law(hub_dir).await,
+        Some(Command::SetMemberKey { hub_dir, member_lct_id, pubkey_hex }) => {
+            run_set_member_key(hub_dir, member_lct_id, pubkey_hex).await
+        }
         Some(Command::InitLaw { output, force }) => run_init_law(output, force).await,
         Some(Command::Council { subcommand }) => run_council(subcommand).await,
         Some(Command::Query { subcommand }) => run_query(subcommand).await,
@@ -681,6 +697,18 @@ async fn run_record_event(
     println!("  Attendees:    {}", attended_by.len());
     println!("  Entry index:  {}", entry.index);
     println!("  Entry hash:   {}", entry.entry_hash);
+    Ok(())
+}
+
+async fn run_set_member_key(hub_dir: PathBuf, member_lct_id: Uuid, pubkey_hex: String) -> Result<()> {
+    let mut session = HubSession::open(&hub_dir).await?;
+    let entry = session.set_member_key(member_lct_id, pubkey_hex.clone()).await?;
+    println!("Member key pinned.");
+    println!("  Member LCT:   {member_lct_id}");
+    println!("  Pubkey:       {pubkey_hex}");
+    println!("  Entry index:  {}", entry.index);
+    println!("  Entry hash:   {}", entry.entry_hash);
+    println!("  NOTE: restart `hub serve` so the live resolver re-seeds from the ledger.");
     Ok(())
 }
 

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -88,6 +88,18 @@ pub enum HubEvent {
         declared_by: Uuid,
     },
 
+    /// Pin (or rotate) a member's channel public key after admission. Fills the
+    /// enrollment gap for members admitted without `member_pubkey_hex` (the
+    /// pre-V2-12 / CLI-bootstrap path): without a pinned key the member cannot
+    /// open the sealed channel at all. Sovereign-authorized; the member
+    /// generates the keypair locally and the public half is pinned here.
+    MemberKeyPinned {
+        member_lct_id: Uuid,
+        /// Hex-encoded 32-byte Ed25519 public key.
+        member_pubkey_hex: String,
+        pinned_by: Uuid,
+    },
+
     /// A member updated their profile — free-text fields (e.g. `skills`,
     /// `interests`, and arbitrary expandable keys) used for semantic member
     /// discovery (`find_members`). Self-attested, same authorization as
@@ -272,6 +284,7 @@ impl HubEvent {
             Self::EventRecorded { .. } => "event_recorded",
             Self::CharterAmended { .. } => "charter_amended",
             Self::MemberSkillDeclared { .. } => "member_skill_declared",
+            Self::MemberKeyPinned { .. } => "member_key_pinned",
             Self::MemberProfileUpdated { .. } => "member_profile_updated",
             Self::LawAmended { .. } => "law_amended",
             Self::CouncilMemberAdded { .. } => "council_member_added",

--- a/hub/hub-lib/src/session.rs
+++ b/hub/hub-lib/src/session.rs
@@ -188,6 +188,28 @@ impl HubSession {
         self.append(event).await
     }
 
+    /// Pin (or rotate) an existing member's channel public key — the member
+    /// key-enrollment step for members admitted without `member_pubkey_hex`
+    /// (CLI-bootstrap path). Without a pinned key a member cannot open the
+    /// sealed channel. Validates the hex is a real 32-byte Ed25519 key and
+    /// that the member exists before witnessing the pin.
+    pub async fn set_member_key(&mut self, member_lct_id: Uuid, pubkey_hex: String) -> Result<&LedgerEntry> {
+        // Validate the key parses (reconstructing an Lct exercises the same
+        // path the daemon's resolver uses at startup).
+        crate::hub::hestia_sovereign_lct(member_lct_id, &pubkey_hex)
+            .map_err(|e| anyhow::anyhow!("invalid pubkey hex: {e}"))?;
+        let state = HubState::project(&self.ledger);
+        if !state.members.contains_key(&member_lct_id) {
+            anyhow::bail!("LCT {member_lct_id} is not a member of this hub — add the member first");
+        }
+        let event = HubEvent::MemberKeyPinned {
+            member_lct_id,
+            member_pubkey_hex: pubkey_hex,
+            pinned_by: self.sovereign_lct_id,
+        };
+        self.append(event).await
+    }
+
     /// Update a member's free-text profile fields (skills, interests, +
     /// expandable keys) — the inputs to semantic member discovery. Fields
     /// merge into the existing profile; an empty value clears that field.
@@ -538,5 +560,30 @@ mod tests {
         let st = session.status();
         assert_eq!(st.member_count, 3);
         assert_eq!(st.ledger_entries, 3);
+    }
+
+    #[tokio::test]
+    async fn set_member_key_pins_rotates_and_rejects_bad_input() {
+        use web4_core::crypto::KeyPair;
+        let (_tmp, dir) = fresh_hub().await;
+        let mut session = HubSession::open(&dir).await.unwrap();
+        let alice = Uuid::new_v4();
+        session.add_member(alice, Some("Alice".into())).await.unwrap();
+
+        // Pin: key lands in member_pubkeys (what the daemon resolver seeds from).
+        let k1 = KeyPair::generate().verifying_key().to_hex();
+        session.set_member_key(alice, k1.clone()).await.unwrap();
+        let state = HubState::project(&session.ledger);
+        assert_eq!(state.member_pubkeys.get(&alice), Some(&k1));
+
+        // Rotate: last write wins.
+        let k2 = KeyPair::generate().verifying_key().to_hex();
+        session.set_member_key(alice, k2.clone()).await.unwrap();
+        let state = HubState::project(&session.ledger);
+        assert_eq!(state.member_pubkeys.get(&alice), Some(&k2));
+
+        // Reject: non-member LCT, and garbage hex.
+        assert!(session.set_member_key(Uuid::new_v4(), k2.clone()).await.is_err());
+        assert!(session.set_member_key(alice, "zz".into()).await.is_err());
     }
 }

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -220,6 +220,14 @@ impl HubState {
                 // If member doesn't exist, silently ignore — event predates
                 // their MemberAdded. (Real impl would error or queue.)
             }
+            HubEvent::MemberKeyPinned { member_lct_id, member_pubkey_hex, .. } => {
+                // Pin (or rotate — last write wins) the member's channel key.
+                // Only for existing members: a pin for an unknown LCT is
+                // ignored, same stance as the skill arm above.
+                if self.members.contains_key(member_lct_id) {
+                    self.member_pubkeys.insert(*member_lct_id, member_pubkey_hex.clone());
+                }
+            }
             HubEvent::MemberProfileUpdated { member_lct_id, fields, .. } => {
                 if let Some(member) = self.members.get_mut(member_lct_id) {
                     for (k, v) in fields {


### PR DESCRIPTION
Closes the blocker CBP traced (forum 2026-06-11): membership was bootstrapped key-less, so **no member holds a keypair the hub can authenticate** — the entire sealed-channel surface (`find_members`, `walk_members`, future `request_intro`) was **unreachable by construction**.

## The missing primitive
*"A member generates a keypair and the hub pins the public half"* — CBP's option 1 (Sovereign-run re-pin), the smallest path to a working channel.

- **`HubEvent::MemberKeyPinned`** — pin or rotate (last-write-wins) an existing member's channel key after admission. Sovereign-authorized, ledger-witnessed.
- **Projection** → `member_pubkeys` (what the daemon resolver seeds from at startup); existing members only.
- **`HubSession::set_member_key`** — validates real 32-byte Ed25519 hex + member exists.
- **CLI: `hub set-member-key <HUB_DIR> <MEMBER_LCT> <PUBKEY_HEX>`** (+ admin-dashboard summary). Restart `hub serve` after pinning to re-seed the live resolver.

## Enrollment flow (fleet)
Each machine generates a web4 keypair locally → posts the **public** hex to the forum → HUB pins it (Sovereign key lives here) → daemon restart → that member can open the sealed channel.

## Tests
Pin lands in `member_pubkeys`; rotation last-write-wins; rejects non-member + garbage hex. **133 lib + 8 daemon pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)