### PR TITLE
feat(hub): request_intro — the consent half of member discovery

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -581,6 +581,12 @@ fn event_summary(event: &HubEvent) -> String {
         HubEvent::MemberKeyPinned { member_lct_id, .. } => {
             format!("Channel key pinned for {}", short(member_lct_id))
         }
+        HubEvent::IntroRequested { from_lct, to_lct, .. } => {
+            format!("Intro requested {} → {}", short(from_lct), short(to_lct))
+        }
+        HubEvent::IntroResponded { intro_id, accepted, .. } => {
+            format!("Intro {} {}", short(intro_id), if *accepted { "accepted" } else { "declined" })
+        }
         HubEvent::MemberProfileUpdated { member_lct_id, fields, .. } => {
             let keys: Vec<&str> = fields.keys().map(|k| k.as_str()).collect();
             format!("Profile update ({}) by {}", html_escape(&keys.join(", ")), short(member_lct_id))

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -866,6 +866,97 @@ async fn dispatch_channel(
             status: StatusCode::NOT_IMPLEMENTED,
             message: "walk_members is reserved for membot's Walk-as-MCP (not yet shipped)".to_string(),
         }),
+        // ---- introductions (the consent half of discovery) ----
+        // Both halves ride the sealed channel, so by construction both parties
+        // hold pinned channel keys by the time an intro is accepted — which is
+        // exactly what makes the mutual-approval payoff (each side getting the
+        // other's pubkey for a direct member↔member pair_channel) possible.
+        "request_intro" => {
+            let to: Uuid = inner.args.get("to").and_then(|v| v.as_str())
+                .and_then(|s| s.parse().ok())
+                .ok_or_else(|| ApiError::bad_request("request_intro requires 'to' (member LCT uuid)".to_string()))?;
+            // purpose is optional free text — and ledger-witnessed; keep it brief.
+            let purpose = inner.args.get("purpose").and_then(|v| v.as_str()).map(String::from);
+            if to == caller_lct_id {
+                return Err(ApiError::bad_request("cannot request an intro to yourself".to_string()));
+            }
+            if !state.members.contains_key(&to) {
+                return Err(ApiError::bad_request(format!("{to} is not a member of this hub")));
+            }
+            let dup = state.intros.values().any(|i| {
+                i.status == hub_lib::state::IntroStatus::Pending
+                    && i.from_lct == caller_lct_id
+                    && i.to_lct == to
+            });
+            if dup {
+                return Err(ApiError::bad_request("an intro to that member is already pending".to_string()));
+            }
+            let intro_id = Uuid::new_v4();
+            let event = HubEvent::IntroRequested {
+                intro_id,
+                from_lct: caller_lct_id,
+                to_lct: to,
+                purpose,
+            };
+            let (index, _hash) = commit_pair_event(s, event).await?;
+            Ok(serde_json::json!({ "intro_id": intro_id, "status": "pending", "entry_index": index }))
+        }
+        "list_intros" => {
+            // Only intros the caller is a party to — never the full table.
+            let mine: Vec<serde_json::Value> = state.intros.values()
+                .filter(|i| i.from_lct == caller_lct_id || i.to_lct == caller_lct_id)
+                .map(|i| {
+                    let mut v = serde_json::json!({
+                        "intro_id": i.id,
+                        "from_lct": i.from_lct,
+                        "to_lct": i.to_lct,
+                        "purpose": i.purpose,
+                        "status": i.status,
+                    });
+                    // The mutual-approval payoff: once accepted, each party
+                    // gets the OTHER party's pinned pubkey — everything a
+                    // direct member↔member pair_channel needs.
+                    if i.status == hub_lib::state::IntroStatus::Accepted {
+                        let peer = if i.from_lct == caller_lct_id { i.to_lct } else { i.from_lct };
+                        v["peer_lct"] = serde_json::json!(peer);
+                        v["peer_pubkey_hex"] = serde_json::json!(state.member_pubkeys.get(&peer));
+                    }
+                    v
+                })
+                .collect();
+            Ok(serde_json::json!({ "intros": mine, "total": mine.len() }))
+        }
+        "respond_intro" => {
+            let intro_id: Uuid = inner.args.get("intro_id").and_then(|v| v.as_str())
+                .and_then(|s| s.parse().ok())
+                .ok_or_else(|| ApiError::bad_request("respond_intro requires 'intro_id'".to_string()))?;
+            let accept = inner.args.get("accept").and_then(|v| v.as_bool())
+                .ok_or_else(|| ApiError::bad_request("respond_intro requires 'accept' (bool)".to_string()))?;
+            let intro = state.intros.get(&intro_id)
+                .ok_or_else(|| ApiError::bad_request(format!("unknown intro {intro_id}")))?;
+            if intro.to_lct != caller_lct_id {
+                return Err(ApiError {
+                    status: StatusCode::FORBIDDEN,
+                    message: "only the intro's target may respond".to_string(),
+                });
+            }
+            if intro.status != hub_lib::state::IntroStatus::Pending {
+                return Err(ApiError::bad_request("intro is already resolved".to_string()));
+            }
+            let from = intro.from_lct;
+            let event = HubEvent::IntroResponded { intro_id, responded_by: caller_lct_id, accepted: accept };
+            let (index, _hash) = commit_pair_event(s, event).await?;
+            let mut out = serde_json::json!({
+                "intro_id": intro_id,
+                "status": if accept { "accepted" } else { "declined" },
+                "entry_index": index,
+            });
+            if accept {
+                out["peer_lct"] = serde_json::json!(from);
+                out["peer_pubkey_hex"] = serde_json::json!(state.member_pubkeys.get(&from));
+            }
+            Ok(out)
+        }
         other => Err(ApiError::bad_request(format!("unknown or non-channel tool: {other}"))),
     }
 }
@@ -2449,5 +2540,77 @@ norms:
         assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
 
         std::env::remove_var("WEB4_MEMBOX_URL");
+    }
+
+    /// Seal+send one channel call for an admitted member; open the response.
+    async fn member_call(
+        state: &RestState,
+        me: &KeyPair,
+        my_lct: Uuid,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> Result<serde_json::Value, ApiError> {
+        let hub_pub = state.signer.public_key().unwrap();
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(me, &hub_pub, pid, tool, args);
+        let resp = channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: my_lct, pair_id: pid, sealed, caller_pubkey_hex: None,
+        })).await?;
+        Ok(open_resp(me, &hub_pub, pid, &resp.0.sealed))
+    }
+
+    #[tokio::test]
+    async fn intro_full_loop_mutual_approval_exchanges_pubkeys() {
+        let (_tmp, state) = fresh_rest_state(None).await; // open admission
+        let hub_pub = state.signer.public_key().unwrap();
+
+        // Admit Alice and Bob over the channel (pins their pubkeys).
+        let (alice, alice_lct) = (KeyPair::generate(), Uuid::new_v4());
+        let (bob, bob_lct) = (KeyPair::generate(), Uuid::new_v4());
+        for (kp, lct, name) in [(&alice, alice_lct, "Alice"), (&bob, bob_lct, "Bob")] {
+            let pid = Uuid::new_v4();
+            let sealed = seal_req(kp, &hub_pub, pid, "request_citizenship",
+                serde_json::json!({ "name": name }));
+            channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+                caller_lct_id: lct, pair_id: pid, sealed,
+                caller_pubkey_hex: Some(kp.verifying_key().to_hex()),
+            })).await.expect("admitted");
+        }
+
+        // Alice requests an intro to Bob.
+        let out = member_call(&state, &alice, alice_lct, "request_intro",
+            serde_json::json!({ "to": bob_lct, "purpose": "collab on evals" })).await.unwrap();
+        assert_eq!(out["status"], serde_json::json!("pending"));
+        let intro_id = out["intro_id"].as_str().unwrap().to_string();
+
+        // Duplicate pending request is rejected.
+        let dup = member_call(&state, &alice, alice_lct, "request_intro",
+            serde_json::json!({ "to": bob_lct })).await;
+        assert!(dup.is_err(), "duplicate pending intro must be rejected");
+
+        // Bob sees it pending; Alice can't respond to her own request.
+        let bob_list = member_call(&state, &bob, bob_lct, "list_intros", serde_json::json!({})).await.unwrap();
+        assert_eq!(bob_list["total"], serde_json::json!(1));
+        assert_eq!(bob_list["intros"][0]["status"], serde_json::json!("pending"));
+        let not_target = member_call(&state, &alice, alice_lct, "respond_intro",
+            serde_json::json!({ "intro_id": intro_id, "accept": true })).await;
+        assert!(not_target.is_err(), "only the target may respond");
+
+        // Bob accepts → gets Alice's pinned pubkey in the response.
+        let acc = member_call(&state, &bob, bob_lct, "respond_intro",
+            serde_json::json!({ "intro_id": intro_id, "accept": true })).await.unwrap();
+        assert_eq!(acc["status"], serde_json::json!("accepted"));
+        assert_eq!(acc["peer_pubkey_hex"], serde_json::json!(alice.verifying_key().to_hex()));
+
+        // Alice's list now shows accepted + Bob's pinned pubkey — everything a
+        // direct member↔member pair_channel needs.
+        let alice_list = member_call(&state, &alice, alice_lct, "list_intros", serde_json::json!({})).await.unwrap();
+        assert_eq!(alice_list["intros"][0]["status"], serde_json::json!("accepted"));
+        assert_eq!(alice_list["intros"][0]["peer_pubkey_hex"], serde_json::json!(bob.verifying_key().to_hex()));
+
+        // Already-resolved: a second response is rejected.
+        let again = member_call(&state, &bob, bob_lct, "respond_intro",
+            serde_json::json!({ "intro_id": intro_id, "accept": false })).await;
+        assert!(again.is_err(), "resolved intro can't be re-responded");
     }
 }

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -88,6 +88,27 @@ pub enum HubEvent {
         declared_by: Uuid,
     },
 
+    /// A member asked the hub to introduce them to another member (the
+    /// consent half of member discovery: find_members returns LCTs, an intro
+    /// connects them only if BOTH agree). Travels only over the sealed
+    /// channel. `purpose` is optional free text — note it is ledger-witnessed.
+    IntroRequested {
+        intro_id: Uuid,
+        from_lct: Uuid,
+        to_lct: Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        purpose: Option<String>,
+    },
+
+    /// The target of an intro accepted or declined it. On acceptance each
+    /// party may retrieve the other's pinned channel pubkey (list_intros) —
+    /// which is everything a member↔member pair_channel needs.
+    IntroResponded {
+        intro_id: Uuid,
+        responded_by: Uuid,
+        accepted: bool,
+    },
+
     /// Pin (or rotate) a member's channel public key after admission. Fills the
     /// enrollment gap for members admitted without `member_pubkey_hex` (the
     /// pre-V2-12 / CLI-bootstrap path): without a pinned key the member cannot
@@ -285,6 +306,8 @@ impl HubEvent {
             Self::CharterAmended { .. } => "charter_amended",
             Self::MemberSkillDeclared { .. } => "member_skill_declared",
             Self::MemberKeyPinned { .. } => "member_key_pinned",
+            Self::IntroRequested { .. } => "intro_requested",
+            Self::IntroResponded { .. } => "intro_responded",
             Self::MemberProfileUpdated { .. } => "member_profile_updated",
             Self::LawAmended { .. } => "law_amended",
             Self::CouncilMemberAdded { .. } => "council_member_added",

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -39,6 +39,10 @@ pub struct HubState {
     /// envelopes until re-added with a pubkey.
     pub member_pubkeys: BTreeMap<Uuid, String>,
 
+    /// Member↔member introductions (the consent half of discovery).
+    /// Projected from IntroRequested/IntroResponded.
+    pub intros: BTreeMap<Uuid, Intro>,
+
     /// V2-9 Phase 1: Sovereign Council holders beyond the founding
     /// Sovereign. Empty for single-Sovereign chapters. Each holder
     /// can sign chapter acts as a co-Sovereign; their pubkey is in
@@ -161,6 +165,27 @@ pub struct Member {
     pub profile: BTreeMap<String, String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IntroStatus {
+    Pending,
+    Accepted,
+    Declined,
+}
+
+/// A member↔member introduction. Created by `request_intro` over the sealed
+/// channel; resolved by the target via `respond_intro`. On acceptance, each
+/// party can retrieve the other's pinned pubkey — all a direct member↔member
+/// pair_channel needs.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Intro {
+    pub id: Uuid,
+    pub from_lct: Uuid,
+    pub to_lct: Uuid,
+    pub purpose: Option<String>,
+    pub status: IntroStatus,
+}
+
 impl HubState {
     /// Build the projection from a ledger.
     pub fn project(ledger: &HubLedger) -> Self {
@@ -226,6 +251,24 @@ impl HubState {
                 // ignored, same stance as the skill arm above.
                 if self.members.contains_key(member_lct_id) {
                     self.member_pubkeys.insert(*member_lct_id, member_pubkey_hex.clone());
+                }
+            }
+            HubEvent::IntroRequested { intro_id, from_lct, to_lct, purpose } => {
+                self.intros.entry(*intro_id).or_insert(Intro {
+                    id: *intro_id,
+                    from_lct: *from_lct,
+                    to_lct: *to_lct,
+                    purpose: purpose.clone(),
+                    status: IntroStatus::Pending,
+                });
+            }
+            HubEvent::IntroResponded { intro_id, responded_by, accepted } => {
+                // Only the target may resolve, and only once (first response
+                // wins; dispatch enforces this too — projection is defensive).
+                if let Some(intro) = self.intros.get_mut(intro_id) {
+                    if intro.status == IntroStatus::Pending && *responded_by == intro.to_lct {
+                        intro.status = if *accepted { IntroStatus::Accepted } else { IntroStatus::Declined };
+                    }
                 }
             }
             HubEvent::MemberProfileUpdated { member_lct_id, fields, .. } => {


### PR DESCRIPTION
**Completes the AIC discovery loop**: `find_members` returns ranked LCTs; an intro connects two members **only if both agree**.

All three tools ride the **sealed channel** (citizen-gated). Because both halves require pinned channel keys, both parties necessarily have them by acceptance — which enables the mutual-approval payoff: **each side receives the other's pinned pubkey**, everything a direct member↔member `pair_channel` needs. The hub brokers consent; it never holds the resulting member↔member channel.

## Tools
- **`request_intro {to, purpose?}`** — validates member-target / not-self / no duplicate pending; Sovereign-commits `IntroRequested`.
- **`list_intros {}`** — only intros the caller is a party to (never the full table); accepted intros carry `peer_lct` + `peer_pubkey_hex`.
- **`respond_intro {intro_id, accept}`** — target-only, pending-only; acceptance returns the requestor's pubkey.

## Plumbing
`IntroRequested`/`IntroResponded` events (ledger-witnessed; `purpose` optional + documented as witnessed), `Intro` projection (defensive: target-only resolve, first response wins), admin-dashboard summaries.

## Tests
Full-loop E2E with real sealed crypto: admit Alice+Bob → request → dup-reject → pending visible to target → non-target can't respond → accept → **mutual pubkey exchange** → re-response rejected. **133 lib + 9 daemon pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)