### PR TITLE
feat(hub): encrypt the Sovereign identity at rest — fail-closed vault doctrine

### DIFF
--- a/hub/hub-daemon/Cargo.toml
+++ b/hub/hub-daemon/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 ctrlc = "3"
 hex = "0.4"
+rpassword = "7"
 serde_yaml = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -1050,15 +1050,49 @@ async fn run_init(
     Ok(())
 }
 
+/// Resolve the hub vault passphrase, **fail-closed** — there is no
+/// "use plaintext" outcome. Order: `HUB_PASSPHRASE` env (set, INCLUDING empty =
+/// a deliberate NULL passphrase) → interactive TTY prompt (Enter = NULL) → else
+/// error. The vault doctrine: a private key is never written in the clear, and
+/// "no passphrase" must be an explicit choice, never a silent default that could
+/// propagate and erode the trust foundation.
+fn require_passphrase(purpose: &str) -> Result<String> {
+    use std::io::IsTerminal;
+    if let Some(p) = hub_lib::identity::env_passphrase() {
+        return Ok(p); // set — possibly "" (a deliberate NULL choice)
+    }
+    if std::io::stdin().is_terminal() {
+        let p = rpassword::prompt_password(format!(
+            "Hub vault passphrase for {purpose} (press Enter for NO passphrase — \
+             still encrypted, but openable by anyone): "
+        ))
+        .context("reading passphrase")?;
+        return Ok(p);
+    }
+    anyhow::bail!(
+        "HUB_PASSPHRASE is not set and there is no terminal to prompt — refusing to \
+         write a plaintext private key (vault doctrine). Set HUB_PASSPHRASE; an empty \
+         value is allowed but must be explicit (HUB_PASSPHRASE=)."
+    )
+}
+
 async fn run_gen_lct(output: PathBuf, entity_type: EntityType) -> Result<()> {
     let identity = IdentityFile::generate(entity_type);
-    identity.save(&output)?;
-    println!("Identity generated.");
+    // Always encrypted — production never writes a plaintext private key.
+    let pass = require_passphrase("the new identity")?;
+    identity.save_encrypted(&output, &pass)?;
+    println!("Identity generated (encrypted vault).");
     println!("  File:          {}", output.display());
     println!("  LCT id:        {}", identity.lct.id);
     println!("  Entity type:   {:?}", identity.lct.entity_type);
     println!();
-    println!("This file contains private key material. Protect it (chmod 600 recommended).");
+    if pass.is_empty() {
+        println!("WARNING: empty (NULL) passphrase — the vault is encrypted but openable by");
+        println!("         anyone. Re-key with a real HUB_PASSPHRASE when you can.");
+    } else {
+        println!("Encrypted with HUB_PASSPHRASE. Keep that passphrase safe — without it this");
+        println!("identity is unrecoverable.");
+    }
     Ok(())
 }
 
@@ -1066,7 +1100,7 @@ async fn run_envelope_sign(identity_path: PathBuf, nonce: String, payload_json: 
     use chrono::Utc;
     use hub_lib::envelope::{build_envelope, Challenge};
 
-    let identity = IdentityFile::load(&identity_path)
+    let identity = IdentityFile::load_auto(&identity_path)
         .with_context(|| format!("loading identity from {}", identity_path.display()))?;
     let kp = identity.keypair().context("reconstructing keypair")?;
     let payload: serde_json::Value = serde_json::from_str(&payload_json)
@@ -1103,7 +1137,7 @@ async fn run_pair_encrypt(
     use web4_core::crypto::PublicKey;
     use web4_core::pair_channel::{seal, seal_fs, EphemeralKeyPair, ephemeral_public_from_hex};
 
-    let identity = IdentityFile::load(&identity_path)
+    let identity = IdentityFile::load_auto(&identity_path)
         .with_context(|| format!("loading identity from {}", identity_path.display()))?;
     let kp = identity.keypair().context("reconstructing keypair")?;
 
@@ -1150,7 +1184,7 @@ async fn run_pair_decrypt(
     use web4_core::crypto::PublicKey;
     use web4_core::pair_channel::{open, open_fs, Sealed, EphemeralKeyPair, ephemeral_public_from_hex};
 
-    let identity = IdentityFile::load(&identity_path)
+    let identity = IdentityFile::load_auto(&identity_path)
         .with_context(|| format!("loading identity from {}", identity_path.display()))?;
     let kp = identity.keypair().context("reconstructing keypair")?;
 

--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -86,7 +86,7 @@ impl McpState {
         let society = load_society(&hub_dir).await?;
         let (sovereign_lct_id, signer): (Uuid, Arc<dyn RemoteSigner>) = match config.sovereign.mode()? {
             SovereignMode::Local { lct_path } => {
-                let sovereign = IdentityFile::load(&lct_path)?;
+                let sovereign = IdentityFile::load_auto(&lct_path)?;
                 let kp = sovereign.keypair()?;
                 let signer = Arc::new(LocalKeypairSigner::new(sovereign.lct.id, kp));
                 (sovereign.lct.id, signer)

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -106,7 +106,7 @@ impl RestState {
         // Build the right Sovereign LCT + signer for the chapter's mode.
         let (sovereign_lct, signer): (_, Arc<dyn RemoteSigner>) = match config.sovereign.mode()? {
             SovereignMode::Local { lct_path } => {
-                let sovereign = IdentityFile::load(&lct_path)?;
+                let sovereign = IdentityFile::load_auto(&lct_path)?;
                 let kp = sovereign.keypair()?;
                 let signer = Arc::new(LocalKeypairSigner::new(sovereign.lct.id, kp));
                 (sovereign.lct, signer as Arc<dyn RemoteSigner>)

--- a/hub/hub-lib/src/identity.rs
+++ b/hub/hub-lib/src/identity.rs
@@ -46,7 +46,9 @@ impl IdentityFile {
         }
     }
 
-    /// Save to a JSON file. Caller is responsible for filesystem permissions.
+    /// Plaintext JSON save. **Bootstrap/tests only** — production goes through
+    /// [`save_encrypted`] (the daemon never writes a plaintext private key; see
+    /// the vault doctrine). Caller owns filesystem permissions.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();
         if let Some(parent) = path.parent() {
@@ -70,6 +72,61 @@ impl IdentityFile {
         Ok(identity)
     }
 
+    /// Save the identity into an **encrypted** vault file (W4VT). The Ed25519
+    /// private key never lands on disk in the clear. Keyed by `passphrase` — an
+    /// empty passphrase is permitted (a deliberate operator choice: encrypted
+    /// format with a publicly-derivable key, re-keyable later) but is never a
+    /// silent default. The vault doctrine: production writes only this.
+    pub fn save_encrypted(&self, path: impl AsRef<Path>, passphrase: &str) -> Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent dir {}", parent.display()))?;
+        }
+        let json = serde_json::to_vec(self).context("serializing identity")?;
+        let mut vault = web4_core::vault::Vault::init_force(path.to_path_buf(), passphrase)
+            .map_err(|e| anyhow::anyhow!("creating identity vault {}: {e}", path.display()))?;
+        vault
+            .put_document("identity", "sovereign", json)
+            .map_err(|e| anyhow::anyhow!("writing identity into vault: {e}"))?;
+        Ok(())
+    }
+
+    /// Load an identity from an encrypted vault file.
+    pub fn load_encrypted(path: impl AsRef<Path>, passphrase: &str) -> Result<Self> {
+        let path = path.as_ref();
+        let vault = web4_core::vault::Vault::open(path.to_path_buf(), passphrase)
+            .map_err(|e| anyhow::anyhow!("opening identity vault {}: {e}", path.display()))?;
+        let bytes = vault
+            .get_document("identity", "sovereign")
+            .ok_or_else(|| anyhow::anyhow!("identity vault {} has no identity document", path.display()))?;
+        serde_json::from_slice(bytes).context("parsing identity from vault")
+    }
+
+    /// Smart loader: encrypted vault files start with the `W4VT` magic; legacy
+    /// plaintext identities are JSON. Sniffs and dispatches — encrypted files
+    /// unlock with `HUB_PASSPHRASE` (an explicit empty value is a valid key).
+    /// This is what production call sites use, so a pre-vault plaintext hub keeps
+    /// loading (then migrate it once) and the doctrine path both work behind one
+    /// path. Reading plaintext is allowed (back-compat / migration source); only
+    /// *writing* plaintext is refused.
+    pub fn load_auto(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let raw = std::fs::read(path)
+            .with_context(|| format!("reading identity file {}", path.display()))?;
+        if raw.starts_with(b"W4VT") {
+            let pass = env_passphrase().ok_or_else(|| anyhow::anyhow!(
+                "identity at {} is an encrypted vault — set HUB_PASSPHRASE to unlock it \
+                 (an empty value is allowed: HUB_PASSPHRASE=)",
+                path.display()
+            ))?;
+            Self::load_encrypted(path, &pass)
+        } else {
+            serde_json::from_slice(&raw)
+                .with_context(|| format!("parsing plaintext identity file {}", path.display()))
+        }
+    }
+
     /// Reconstruct the in-memory KeyPair from the stored hex.
     pub fn keypair(&self) -> Result<KeyPair> {
         let bytes = hex::decode(&self.secret_key_hex)
@@ -78,6 +135,16 @@ impl IdentityFile {
             .map_err(|_| anyhow::anyhow!("secret key must be exactly 32 bytes"))?;
         Ok(KeyPair::from_secret_bytes(&arr))
     }
+}
+
+/// Read-side passphrase from the environment. `Some(p)` if `HUB_PASSPHRASE` is
+/// set — **including an empty string**, which is a deliberate no-passphrase
+/// choice (encrypt-with-empty-key), NOT the same as unset. `None` only when the
+/// variable is absent. The distinction is the whole point of the vault
+/// doctrine: the system never silently falls back to plaintext; "no passphrase"
+/// must be chosen explicitly. (Mirrors hestia's `HESTIA_PASSPHRASE`.)
+pub fn env_passphrase() -> Option<String> {
+    std::env::var("HUB_PASSPHRASE").ok()
 }
 
 #[cfg(test)]
@@ -115,5 +182,59 @@ mod tests {
 
         let ai_identity = IdentityFile::generate(EntityType::AiSoftware);
         assert_eq!(ai_identity.lct.entity_type, EntityType::AiSoftware);
+    }
+
+    #[test]
+    fn encrypted_round_trips_and_keeps_the_private_key_off_disk() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sovereign.vault");
+        let id = IdentityFile::generate(EntityType::Human);
+
+        id.save_encrypted(&path, "strong-pass").unwrap();
+        // On disk: W4VT magic, and the secret key hex appears NOWHERE.
+        let raw = std::fs::read(&path).unwrap();
+        assert!(raw.starts_with(b"W4VT"), "must be an encrypted vault file");
+        assert!(!String::from_utf8_lossy(&raw).contains(&id.secret_key_hex),
+            "private key must never be plaintext on disk");
+
+        let loaded = IdentityFile::load_encrypted(&path, "strong-pass").unwrap();
+        assert_eq!(loaded.secret_key_hex, id.secret_key_hex);
+        assert!(IdentityFile::load_encrypted(&path, "wrong").is_err(), "wrong passphrase → fail");
+    }
+
+    #[test]
+    fn empty_passphrase_is_a_valid_deliberate_choice_still_encrypted() {
+        // NULL passphrase (operator pressed return) — still produces an
+        // encrypted vault file, never plaintext. The key is publicly derivable,
+        // but the format is uniform and re-keyable; the point is no plaintext.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("id.vault");
+        let id = IdentityFile::generate(EntityType::Human);
+        id.save_encrypted(&path, "").unwrap();
+        let raw = std::fs::read(&path).unwrap();
+        assert!(raw.starts_with(b"W4VT"), "empty passphrase still encrypts (no plaintext)");
+        let loaded = IdentityFile::load_encrypted(&path, "").unwrap();
+        assert_eq!(loaded.secret_key_hex, id.secret_key_hex);
+    }
+
+    #[test]
+    fn load_auto_sniffs_plaintext_vs_encrypted_and_empty_is_not_unset() {
+        let dir = tempdir().unwrap();
+        let id = IdentityFile::generate(EntityType::Human);
+
+        // Plaintext (legacy / pre-migration) loads with no passphrase.
+        let plain = dir.path().join("plain.json");
+        id.save(&plain).unwrap();
+        assert_eq!(IdentityFile::load_auto(&plain).unwrap().secret_key_hex, id.secret_key_hex);
+
+        // Encrypted (empty passphrase) needs HUB_PASSPHRASE set — and an
+        // explicit empty value unlocks it, while *unset* does not.
+        let enc = dir.path().join("enc.vault");
+        id.save_encrypted(&enc, "").unwrap();
+        std::env::remove_var("HUB_PASSPHRASE");
+        assert!(IdentityFile::load_auto(&enc).is_err(), "unset env must NOT silently open an encrypted vault");
+        std::env::set_var("HUB_PASSPHRASE", ""); // explicit empty = a valid choice
+        assert_eq!(IdentityFile::load_auto(&enc).unwrap().secret_key_hex, id.secret_key_hex);
+        std::env::remove_var("HUB_PASSPHRASE");
     }
 }

--- a/hub/hub-lib/src/init.rs
+++ b/hub/hub-lib/src/init.rs
@@ -154,7 +154,7 @@ pub async fn init_hub(args: InitArgs) -> Result<InitResult> {
     // identity-file-as-secret-store is the MVP bootstrap pattern; secrets
     // belong in Hestia's vault and the file pattern deprecates with
     // V2-7 (Hestia-as-Sovereign). Kept here until that sync point lands.
-    let sovereign = IdentityFile::load(&args.sovereign_lct_path)
+    let sovereign = IdentityFile::load_auto(&args.sovereign_lct_path)
         .with_context(|| format!(
             "loading Sovereign LCT from {}",
             args.sovereign_lct_path.display()
@@ -404,7 +404,7 @@ pub async fn verify_hub(hub_dir: impl AsRef<Path>) -> Result<VerifyResult> {
             } else {
                 hub_dir.join(&lct_path)
             };
-            let identity = IdentityFile::load(&sov_path)
+            let identity = IdentityFile::load_auto(&sov_path)
                 .with_context(|| format!("loading Sovereign identity from {}", sov_path.display()))?;
             identity.lct
         }

--- a/hub/hub-lib/src/session.rs
+++ b/hub/hub-lib/src/session.rs
@@ -59,7 +59,7 @@ impl HubSession {
                 );
             }
         };
-        let sovereign = IdentityFile::load(&lct_path)
+        let sovereign = IdentityFile::load_auto(&lct_path)
             .with_context(|| format!(
                 "loading Sovereign identity from {}", lct_path.display()
             ))?;


### PR DESCRIPTION
The hub's Local-mode identity stored the Ed25519 **private key as plaintext JSON** — the sharpest exposure. Production now never writes a plaintext key.

## The security posture (per dp)
- **Fail-closed, not plaintext-default.** `gen-lct` always `save_encrypted` via `require_passphrase()`. There is no silent-plaintext path — that's exactly what could propagate and erode the trust foundation.
- **NULL passphrase is a deliberate first-class choice, never a default.** `env_passphrase()` returns `Some("")` for an explicit empty `HUB_PASSPHRASE` (≠ unset = `None`); the interactive prompt treats Enter as NULL. An empty passphrase **still encrypts** (uniform, re-keyable format) — never plaintext.
- `require_passphrase`: `HUB_PASSPHRASE` env (incl. empty) → TTY prompt (`rpassword`) → else error. The systemd daemon uses the env; humans get the prompt.

## Mechanism
- `save_encrypted`/`load_encrypted` via `web4_core::vault` (W4VT); `load_auto` sniffs W4VT vs legacy JSON — a pre-vault hub keeps loading (migrate once); reading plaintext OK, **writing** plaintext refused.
- All production load sites (serve/rest, mcp, session, init, CLI) use `load_auto`; library `save()`/`load()` remain for test fixtures only.

## Tests
Encrypted round-trip with a **private-key-never-on-disk** assertion; empty passphrase still encrypts; `load_auto` sniff incl. "explicit empty unlocks, *unset* does not." **145 lib + 13 daemon.**

## Scope
Covers the Sovereign **identity** (the catastrophic exposure). Hub **state** at rest is the follow-on — FileBackend sealing ports cleanly, but the live fleet hub is **Sqlite** (→ SQLCipher / FileBackend migration next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)