### PR TITLE
hub: runtime unlock slot + stub-console default + rate-limited brute-force protection

### DIFF
--- a/hub/Cargo.lock
+++ b/hub/Cargo.lock
@@ -108,6 +108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +587,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1326,6 +1347,7 @@ dependencies = [
  "hex",
  "hub-lib",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1884,6 +1906,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2221,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3189,6 +3243,7 @@ dependencies = [
 name = "web4-core"
 version = "0.2.0"
 dependencies = [
+ "argon2",
  "base64",
  "chacha20poly1305",
  "chrono",
@@ -3202,6 +3257,7 @@ dependencies = [
  "thiserror 1.0.69",
  "uuid",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -3289,6 +3345,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -27,6 +27,7 @@ use axum::{
 };
 use hub_lib::events::HubEvent;
 use hub_lib::init::load_society;
+use hub_lib::signer::RemoteSigner; // signer_kind() — signer is now a concrete SwappableSigner
 use hub_lib::state::HubState;
 
 use crate::rest::RestState;

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -106,6 +106,18 @@ enum Command {
         path: PathBuf,
     },
 
+    /// The **stub-console unlock plugin**: unlock a locked, running hub by
+    /// presenting the tier-1 passphrase. Prompts for the passphrase (or reads
+    /// `HUB_PASSPHRASE`), **uses it once and never stores it**, and POSTs it to
+    /// the hub's local-only `/unlock` slot (127.0.0.1), promoting it locked →
+    /// unlocked in place. Run this on the hub host. Empty (just Enter) = the
+    /// explicit NULL-passphrase choice.
+    Unlock {
+        /// Port the hub is serving on (default 8770).
+        #[arg(long, default_value = "8770")]
+        port: u16,
+    },
+
     /// V2-7 helper: build + print a SignedEnvelope for a given payload.
     ///
     /// Reads a keypair from an IdentityFile, signs (signer_lct_id ||
@@ -487,6 +499,7 @@ async fn main() -> Result<()> {
             run_gen_lct(output, entity_type.into()).await
         }
         Some(Command::SealIdentity { path }) => run_seal_identity(path).await,
+        Some(Command::Unlock { port }) => run_unlock(port).await,
         Some(Command::EnvelopeSign { identity, nonce, payload }) => {
             run_envelope_sign(identity, nonce, payload).await
         }
@@ -935,9 +948,15 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
     println!("  Stop:         Ctrl-C");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // `into_make_service_with_connect_info` exposes the peer `SocketAddr` to
+    // handlers (the unlock slot uses it to enforce loopback-only). Other
+    // handlers are unaffected.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
 
     println!("hub serve — shut down cleanly");
     Ok(())
@@ -1103,6 +1122,57 @@ async fn run_seal_identity(path: PathBuf) -> Result<()> {
     }
     println!("  The plaintext private key is no longer on disk. Keep the passphrase safe.");
     Ok(())
+}
+
+/// The stub-console unlock plugin: prompt for the passphrase (never store it)
+/// and present it to a locked, running hub's local `/unlock` slot.
+async fn run_unlock(port: u16) -> Result<()> {
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Resolve the hub's LCT id from tier-0 discovery (served while locked).
+    let info: serde_json::Value = client
+        .get(format!("{base}/.well-known/web4-hub.json"))
+        .send()
+        .await
+        .with_context(|| format!("contacting hub at {base} — is `hub serve` running?"))?
+        .error_for_status()
+        .context("hub discovery endpoint returned an error")?
+        .json()
+        .await
+        .context("parsing hub discovery JSON")?;
+    let hub_id = info
+        .get("hub_lct_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("discovery JSON had no hub_lct_id"))?
+        .to_string();
+
+    // Prompt for the passphrase here, in OUR UI — use it once, never store it.
+    // (HUB_PASSPHRASE is honored too, including an explicit empty value.)
+    let passphrase = require_passphrase("the running hub")?;
+
+    let resp = client
+        .post(format!("{base}/v1/hubs/{hub_id}/unlock"))
+        .json(&serde_json::json!({ "passphrase": passphrase }))
+        .send()
+        .await
+        .context("submitting unlock to the hub")?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or_else(|_| serde_json::json!({}));
+
+    if status.is_success() {
+        println!("Hub unlocked ✓  ({})", body.get("status").and_then(|v| v.as_str()).unwrap_or("unlocked"));
+        if let Some(sov) = body.get("sovereign_lct_id").and_then(|v| v.as_str()) {
+            println!("  Sovereign LCT: {sov}");
+        }
+        println!("  The hub is now serving citizen-tier+ requests. The passphrase was not stored.");
+        Ok(())
+    } else {
+        let msg = body.get("error").and_then(|v| v.as_str())
+            .or_else(|| body.get("message").and_then(|v| v.as_str()))
+            .unwrap_or("unlock refused");
+        anyhow::bail!("unlock failed ({status}): {msg}");
+    }
 }
 
 async fn run_gen_lct(output: PathBuf, entity_type: EntityType) -> Result<()> {

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -28,12 +28,13 @@
 
 use anyhow::Result;
 use axum::{
-    extract::{Path, State},
+    extract::{ConnectInfo, Path, State},
     http::StatusCode,
     response::{IntoResponse, Json},
     routing::{get, post},
     Router,
 };
+use std::net::SocketAddr;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -48,8 +49,9 @@ use hub_lib::identity::IdentityFile;
 use hub_lib::init::load_society;
 use hub_lib::law::{Decision, DecisionOutcome, Law, R6Request};
 use hub_lib::ledger::HubLedger;
-use hub_lib::signer::{HestiaCallbackSigner, LocalKeypairSigner, LockedSigner, RemoteSigner, SignIntent};
+use hub_lib::signer::{HestiaCallbackSigner, LocalKeypairSigner, LockedSigner, RemoteSigner, SignIntent, SwappableSigner};
 use hub_lib::state::HubState;
+use hub_lib::unlock_gate::{GateDecision, UnlockGate};
 
 #[derive(Clone)]
 pub struct RestState {
@@ -57,10 +59,13 @@ pub struct RestState {
     pub hub_id: Uuid,
     pub hub_name: String,
     pub sovereign_lct_id: Uuid,
-    /// The signer abstraction. LocalKeypairSigner for MVP-compat chapters
-    /// (keypair in process); HestiaCallbackSigner for Hestia-mode
-    /// chapters (hub holds NO keys; signs via Hestia HTTP callback).
-    pub signer: Arc<dyn RemoteSigner>,
+    /// The signer abstraction, behind a `SwappableSigner` so the hub can be
+    /// promoted **locked → unlocked at runtime** (the unlock slot swaps the
+    /// `LockedSigner` for the real `LocalKeypairSigner` in place — no restart).
+    /// Inner kind: LocalKeypairSigner for MVP-compat chapters (keypair in
+    /// process); HestiaCallbackSigner for Hestia-mode chapters (hub holds NO
+    /// keys; signs via Hestia HTTP callback); LockedSigner while sealed.
+    pub signer: Arc<SwappableSigner>,
     pub ledger: Arc<Mutex<HubLedger>>,
     pub nonces: Arc<NonceStore>,
     /// Public-key resolver for envelope signature verification.
@@ -85,11 +90,21 @@ pub struct RestState {
     /// Outstanding OID4VCI `c_nonce`s minted at `/nonce`, consumed at
     /// `/credential` (the hub as society-scale *issuer* of membership creds).
     pub vci_nonces: Arc<Mutex<std::collections::HashSet<String>>>,
-    /// Vault lock state. `true` when the Sovereign identity is encrypted and no
-    /// passphrase was available at startup: the hub runs a degraded **no-LCT
-    /// tier** surface (tier-0 reads only) and refuses everything citizen-tier+
-    /// until unlocked. The signer is a `LockedSigner` (denies all key ops).
-    pub locked: bool,
+    /// Rate limiter for the unlock slot (`POST /unlock`). The passphrase is
+    /// still required; this caps online guessing (min interval + max
+    /// consecutive failures + lockout), since anyone who can reach the unlock
+    /// UI could still feed it attempts.
+    pub unlock_gate: Arc<UnlockGate>,
+}
+
+impl RestState {
+    /// Whether the vault is sealed. The lock state **is** the kind of the
+    /// currently-installed signer — a `LockedSigner` (set at startup when the
+    /// Sovereign identity is encrypted and no passphrase was available) means
+    /// degraded no-LCT-tier mode; the unlock slot swaps in the real signer.
+    pub fn is_locked(&self) -> bool {
+        matches!(self.signer.signer_kind(), hub_lib::signer::SignerKind::Locked)
+    }
 }
 
 /// True if the identity at `path` is an encrypted vault (W4VT) **and** no
@@ -196,12 +211,13 @@ impl RestState {
             }
         }
 
+        let _ = locked; // lock state now derives from the installed signer kind
         Ok(Self {
             paths,
             hub_id: society.lct_id,
             hub_name: society.name.clone(),
             sovereign_lct_id,
-            signer,
+            signer: Arc::new(SwappableSigner::new(signer)),
             ledger,
             nonces: Arc::new(NonceStore::new()),
             resolver: Arc::new(tokio::sync::RwLock::new(resolver)),
@@ -209,7 +225,7 @@ impl RestState {
             constellations: Arc::new(hub_lib::constellation::ConstellationGate::new()),
             vp_requests: Arc::new(Mutex::new(std::collections::HashMap::new())),
             vci_nonces: Arc::new(Mutex::new(std::collections::HashSet::new())),
-            locked,
+            unlock_gate: Arc::new(UnlockGate::default_policy()),
         })
     }
 
@@ -233,6 +249,151 @@ impl RestState {
         *self.law.write().await = new_law;
         Ok(version)
     }
+
+    /// The **unlock slot** (tier-1 ignition via the stub-console / passphrase
+    /// plugin). Rate-limited; opens the encrypted Sovereign identity with
+    /// `passphrase` and, on success, **promotes the hub in place** locked →
+    /// unlocked: the real `LocalKeypairSigner` is swapped into the
+    /// `SwappableSigner` and the Sovereign pubkey is seeded into the resolver,
+    /// with no restart. The passphrase is used here and dropped — never stored.
+    /// `now` is unix-seconds (injected for deterministic rate-limit tests).
+    pub async fn try_unlock(&self, passphrase: &str, now: i64) -> UnlockOutcome {
+        if !self.is_locked() {
+            return UnlockOutcome::NotLocked;
+        }
+        // Cap online guessing first — the passphrase is still required, but
+        // anyone who reaches this slot could feed it attempts.
+        match self.unlock_gate.check(now) {
+            GateDecision::Allow => {}
+            GateDecision::TooSoon { retry_after_secs }
+            | GateDecision::LockedOut { retry_after_secs } => {
+                return UnlockOutcome::RateLimited { retry_after_secs };
+            }
+        }
+        // Re-derive the encrypted identity path from config.
+        let config = match hub_lib::hub::HubConfig::load(self.paths.config()) {
+            Ok(c) => c,
+            Err(e) => return UnlockOutcome::Unsupported(format!("config load failed: {e}")),
+        };
+        let lct_path = match config.sovereign.mode() {
+            Ok(SovereignMode::Local { lct_path }) => lct_path,
+            Ok(_) => {
+                return UnlockOutcome::Unsupported(
+                    "hub is not in local-vault mode; passphrase unlock does not apply".into(),
+                )
+            }
+            Err(e) => return UnlockOutcome::Unsupported(format!("sovereign mode: {e}")),
+        };
+        // Attempt to open the encrypted identity with the passphrase.
+        match IdentityFile::load_encrypted(&lct_path, passphrase) {
+            Ok(identity) => {
+                let kp = match identity.keypair() {
+                    Ok(k) => k,
+                    Err(e) => {
+                        // A successful decrypt but unusable key is not a bad
+                        // guess — don't count it against the rate limit.
+                        return UnlockOutcome::Unsupported(format!(
+                            "identity decrypted but has no usable keypair: {e}"
+                        ));
+                    }
+                };
+                let lct = identity.lct.clone();
+                // Promote: install the real signer in place, then make the
+                // Sovereign pubkey verifiable.
+                self.signer
+                    .swap(Arc::new(LocalKeypairSigner::new(lct.id, kp)));
+                self.resolver.write().await.insert(lct.clone());
+                self.unlock_gate.record_success();
+                tracing::warn!(
+                    sovereign_lct = %lct.id,
+                    "VAULT UNLOCKED via passphrase (stub-console slot) — hub promoted locked → unlocked"
+                );
+                UnlockOutcome::Unlocked { sovereign_lct_id: lct.id }
+            }
+            Err(_) => {
+                self.unlock_gate.record_failure(now);
+                tracing::warn!("vault unlock attempt FAILED (wrong passphrase or corrupt vault)");
+                UnlockOutcome::WrongPassphrase
+            }
+        }
+    }
+}
+
+/// Result of a vault-unlock attempt via the unlock slot.
+pub enum UnlockOutcome {
+    /// Promoted locked → unlocked; the real signer is now installed.
+    Unlocked { sovereign_lct_id: Uuid },
+    /// The hub was already unlocked — nothing to do.
+    NotLocked,
+    /// The passphrase didn't open the vault (counted against the rate limit).
+    WrongPassphrase,
+    /// Refused by the rate limiter — wait `retry_after_secs`.
+    RateLimited { retry_after_secs: i64 },
+    /// This hub can't be unlocked by passphrase (e.g. Hestia-mode, or a
+    /// config/identity problem) — not a bad guess.
+    Unsupported(String),
+}
+
+/// `POST /v1/hubs/:hub_id/unlock` — the **stub-console unlock slot**.
+///
+/// Privileged + **local-only**: a locked hub accepts an unlock attempt only
+/// from a loopback caller (the stub-console plugin runs on the hub host and
+/// connects to `127.0.0.1`). Combined with the rate limiter, this is the honest
+/// answer to "a local process could unlock it": the process still needs the
+/// passphrase, and *we* control how it's obtained (our UI) and that it's used
+/// once and discarded. Remote callers are refused before any attempt is counted.
+async fn unlock(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    State(s): State<RestState>,
+    Json(req): Json<UnlockRequest>,
+) -> Result<Json<UnlockResponse>, ApiError> {
+    if !peer.ip().is_loopback() {
+        return Err(ApiError {
+            status: StatusCode::FORBIDDEN,
+            message: "unlock is local-only — present the passphrase from the hub host (127.0.0.1)"
+                .to_string(),
+        });
+    }
+    match s.try_unlock(&req.passphrase, Utc::now().timestamp()).await {
+        UnlockOutcome::Unlocked { sovereign_lct_id } => Ok(Json(UnlockResponse {
+            unlocked: true,
+            status: "unlocked".into(),
+            sovereign_lct_id: Some(sovereign_lct_id),
+            retry_after_secs: None,
+        })),
+        UnlockOutcome::NotLocked => Ok(Json(UnlockResponse {
+            unlocked: true,
+            status: "already_unlocked".into(),
+            sovereign_lct_id: Some(s.sovereign_lct_id),
+            retry_after_secs: None,
+        })),
+        UnlockOutcome::WrongPassphrase => Err(ApiError {
+            status: StatusCode::UNAUTHORIZED,
+            message: "unlock failed: wrong passphrase".to_string(),
+        }),
+        UnlockOutcome::RateLimited { retry_after_secs } => Err(ApiError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            message: format!("unlock rate-limited; retry after {retry_after_secs}s"),
+        }),
+        UnlockOutcome::Unsupported(m) => Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            message: format!("unlock not applicable: {m}"),
+        }),
+    }
+}
+
+#[derive(Deserialize)]
+struct UnlockRequest {
+    /// The tier-1 ignition passphrase. May be empty (explicit NULL passphrase).
+    passphrase: String,
+}
+
+#[derive(Serialize)]
+struct UnlockResponse {
+    unlocked: bool,
+    status: String,
+    sovereign_lct_id: Option<Uuid>,
+    retry_after_secs: Option<i64>,
 }
 
 pub fn router(state: RestState) -> Router {
@@ -252,6 +413,9 @@ pub fn router(state: RestState) -> Router {
         .route("/v1/hubs/:hub_id/vp/response", post(vp_response))
         // tier-0: the hub's law is readable even while the vault is locked
         .route("/v1/hubs/:hub_id/law", get(read_hub_law))
+        // the unlock slot (stub-console / passphrase): local-only + rate-limited.
+        // Promotes a locked hub → unlocked in place (swaps in the real signer).
+        .route("/v1/hubs/:hub_id/unlock", post(unlock))
         .route("/v1/auth/challenge", post(issue_challenge))
         // Hub-named routes (canonical; chapter→hub rename mirrored on
         // Hestia side at hestia@c3932a8 — back-compat /v1/chapters/*
@@ -696,7 +860,7 @@ async fn submit_event(
     }
     // Acts require the Sovereign signer (to witness them) — unavailable while
     // the vault is locked.
-    if s.locked {
+    if s.is_locked() {
         return Err(locked_error());
     }
 
@@ -1004,7 +1168,7 @@ async fn channel_request(
     }
     // The sealed channel is citizen-tier+; a locked vault has no signer to
     // open/seal it. Refuse cleanly (tier-0 only while locked).
-    if s.locked {
+    if s.is_locked() {
         return Err(locked_error());
     }
 
@@ -3261,8 +3425,10 @@ norms:
 
     #[tokio::test]
     async fn locked_vault_refuses_citizen_tier_but_serves_tier0_law() {
-        let (_tmp, mut state) = fresh_rest_state(None).await;
-        state.locked = true; // simulate a sealed vault (no signer)
+        let (_tmp, state) = fresh_rest_state(None).await;
+        // Simulate a sealed vault: swap in a LockedSigner (denies all key ops).
+        state.signer.swap(Arc::new(LockedSigner::new(state.sovereign_lct_id)));
+        assert!(state.is_locked());
 
         // Citizen-tier sealed channel → 503 (refused before any crypto).
         let req = ChannelRequest {
@@ -3282,5 +3448,78 @@ norms:
             .await
             .expect("law is tier-0 readable while locked");
         assert!(law.0.get("law").is_some());
+    }
+
+    /// Seal the hub's Sovereign identity at rest with `pass`, then simulate a
+    /// locked startup. Returns the state for unlock-slot tests.
+    async fn locked_state_sealed_with(pass: &str) -> (tempfile::TempDir, RestState) {
+        let (tmp, state) = fresh_rest_state(None).await;
+        let config = hub_lib::hub::HubConfig::load(state.paths.config()).unwrap();
+        let lct_path = match config.sovereign.mode().unwrap() {
+            SovereignMode::Local { lct_path } => lct_path,
+            _ => panic!("expected local-vault mode"),
+        };
+        IdentityFile::load_auto(&lct_path)
+            .unwrap()
+            .save_encrypted(&lct_path, pass)
+            .unwrap();
+        state.signer.swap(Arc::new(LockedSigner::new(state.sovereign_lct_id)));
+        assert!(state.is_locked());
+        (tmp, state)
+    }
+
+    #[tokio::test]
+    async fn unlock_slot_promotes_locked_hub_with_the_right_passphrase() {
+        let pass = "correct horse battery staple";
+        let (_tmp, state) = locked_state_sealed_with(pass).await;
+        let now = 1_700_000_000;
+
+        // A wrong passphrase is refused and does NOT unlock.
+        assert!(matches!(
+            state.try_unlock("nope", now).await,
+            UnlockOutcome::WrongPassphrase
+        ));
+        assert!(state.is_locked(), "a bad guess must not unlock");
+
+        // The right passphrase (past the min interval) promotes the hub in place.
+        match state.try_unlock(pass, now + 5).await {
+            UnlockOutcome::Unlocked { sovereign_lct_id } => {
+                assert_eq!(sovereign_lct_id, state.sovereign_lct_id)
+            }
+            _ => panic!("the right passphrase must unlock"),
+        }
+        assert!(!state.is_locked(), "right passphrase promotes locked → unlocked");
+        assert!(
+            state.signer.public_key().is_some(),
+            "the swapped-in real signer exposes the Sovereign pubkey"
+        );
+
+        // Idempotent: unlocking an unlocked hub is a no-op.
+        assert!(matches!(
+            state.try_unlock(pass, now + 10).await,
+            UnlockOutcome::NotLocked
+        ));
+    }
+
+    #[tokio::test]
+    async fn unlock_slot_rate_limits_repeated_wrong_guesses() {
+        let pass = "open sesame";
+        let (_tmp, state) = locked_state_sealed_with(pass).await;
+
+        // Five consecutive wrong guesses (each past the 2 s min interval).
+        let mut t = 1_700_000_000;
+        for _ in 0..5 {
+            assert!(matches!(
+                state.try_unlock("wrong", t).await,
+                UnlockOutcome::WrongPassphrase
+            ));
+            t += 3;
+        }
+        // The 6th attempt is locked out — even with the CORRECT passphrase.
+        match state.try_unlock(pass, t).await {
+            UnlockOutcome::RateLimited { retry_after_secs } => assert!(retry_after_secs > 0),
+            _ => panic!("expected a lockout after 5 consecutive failures"),
+        }
+        assert!(state.is_locked(), "lockout holds the vault closed");
     }
 }

--- a/hub/hub-lib/src/lib.rs
+++ b/hub/hub-lib/src/lib.rs
@@ -40,6 +40,7 @@ pub mod dynamodb_store;
 pub mod signer;
 pub mod state;
 pub mod store;
+pub mod unlock_gate;
 
 /// Crate version, exposed for `hub --version`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/hub/hub-lib/src/signer.rs
+++ b/hub/hub-lib/src/signer.rs
@@ -36,6 +36,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use std::sync::Arc;
 use web4_core::crypto::{KeyPair, PublicKey, SignatureBytes};
 use web4_core::pair_channel::{self, Sealed};
 
@@ -412,6 +413,66 @@ impl RemoteSigner for LockedSigner {
     fn channel_open(&self, _peer: &PublicKey, _pair_id: Uuid, _sealed_b64: &str)
         -> std::result::Result<Vec<u8>, SignError> {
         Err(SignError::Denied("hub vault is locked".to_string()))
+    }
+}
+
+// ============================================================================
+// SwappableSigner — lets the hub promote itself locked → unlocked at runtime
+// ============================================================================
+
+/// A `RemoteSigner` whose backing signer can be **swapped at runtime**, behind
+/// an internal lock. The hub installs one of these as its signer so a locked
+/// hub (backed by a `LockedSigner`) can be **ignited in place** — once an
+/// operator presents the passphrase (the stub-console unlock slot) the real
+/// `LocalKeypairSigner` is swapped in and every subsequent key op succeeds,
+/// with no restart and no change at any call site (`s.signer.sign(..)` is
+/// unchanged; it just delegates to whatever is currently installed).
+///
+/// The swap is the only mutable thing — the lock state of the hub *is* the kind
+/// of the currently-installed inner signer (`signer_kind() == Locked`).
+pub struct SwappableSigner {
+    inner: std::sync::RwLock<Arc<dyn RemoteSigner>>,
+}
+
+impl SwappableSigner {
+    pub fn new(initial: Arc<dyn RemoteSigner>) -> Self {
+        Self { inner: std::sync::RwLock::new(initial) }
+    }
+    /// Promote (or demote) the backing signer. Used by the unlock slot to swap
+    /// a `LockedSigner` for the real `LocalKeypairSigner` once ignited.
+    pub fn swap(&self, new: Arc<dyn RemoteSigner>) {
+        *self.inner.write().expect("swappable signer lock poisoned") = new;
+    }
+    fn current(&self) -> Arc<dyn RemoteSigner> {
+        self.inner.read().expect("swappable signer lock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl RemoteSigner for SwappableSigner {
+    async fn sign(
+        &self,
+        actor_lct_id: Uuid,
+        signing_bytes: &[u8],
+        intent: &SignIntent,
+    ) -> std::result::Result<SignatureBytes, SignError> {
+        // Snapshot the Arc, then drop the lock before the await point.
+        let cur = self.current();
+        cur.sign(actor_lct_id, signing_bytes, intent).await
+    }
+    fn signer_kind(&self) -> SignerKind {
+        self.current().signer_kind()
+    }
+    fn public_key(&self) -> Option<PublicKey> {
+        self.current().public_key()
+    }
+    fn channel_seal(&self, peer: &PublicKey, pair_id: Uuid, plaintext: &[u8])
+        -> std::result::Result<String, SignError> {
+        self.current().channel_seal(peer, pair_id, plaintext)
+    }
+    fn channel_open(&self, peer: &PublicKey, pair_id: Uuid, sealed_b64: &str)
+        -> std::result::Result<Vec<u8>, SignError> {
+        self.current().channel_open(peer, pair_id, sealed_b64)
     }
 }
 

--- a/hub/hub-lib/src/unlock_gate.rs
+++ b/hub/hub-lib/src/unlock_gate.rs
@@ -1,0 +1,156 @@
+//! Rate limiter for vault-unlock attempts (the stub-console / passphrase path).
+//!
+//! The unlock slot does not remove the need for the passphrase — a privileged
+//! unlock plugin is more secure because *we* control how the passphrase is
+//! obtained (prompted in our UI) and what we do with it (use-then-discard,
+//! never stored). But anyone who can reach that UI could still *feed it
+//! guesses*. So, independent of how the secret is obtained, the unlock path is
+//! gated: a **minimum interval** between attempts, a **maximum number of
+//! consecutive failures**, and a **lockout** once that cap is hit. This is the
+//! "usual number of tries + minimum time between attempts" backstop against
+//! online brute force.
+//!
+//! Time is passed in explicitly (`now`, unix seconds) so the policy is
+//! deterministically testable; production callers pass `Utc::now().timestamp()`.
+
+use std::sync::Mutex;
+
+/// What the gate decided about an attempt right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Proceed with the unlock attempt; the caller MUST then report the outcome
+    /// via [`UnlockGate::record_failure`] or [`UnlockGate::record_success`].
+    Allow,
+    /// Too soon after the previous attempt — wait `retry_after_secs`.
+    TooSoon { retry_after_secs: i64 },
+    /// Locked out after too many consecutive failures — wait `retry_after_secs`.
+    LockedOut { retry_after_secs: i64 },
+}
+
+#[derive(Debug, Default)]
+struct GateState {
+    consecutive_fails: u32,
+    last_attempt: Option<i64>,
+    locked_out_until: Option<i64>,
+}
+
+/// A small, thread-safe attempt limiter. One per hub (shared via `Arc`).
+#[derive(Debug)]
+pub struct UnlockGate {
+    inner: Mutex<GateState>,
+    max_fails: u32,
+    min_interval_secs: i64,
+    lockout_secs: i64,
+}
+
+impl UnlockGate {
+    pub fn new(max_fails: u32, min_interval_secs: i64, lockout_secs: i64) -> Self {
+        Self {
+            inner: Mutex::new(GateState::default()),
+            max_fails,
+            min_interval_secs,
+            lockout_secs,
+        }
+    }
+
+    /// The default policy: **5** consecutive failures, **2 s** minimum between
+    /// attempts, **5-minute** lockout once the cap is hit.
+    pub fn default_policy() -> Self {
+        Self::new(5, 2, 300)
+    }
+
+    /// Check whether an attempt is allowed *now*, and (if allowed) stamp it as
+    /// the latest attempt so the min-interval applies to the next one. Returns
+    /// the reason + retry hint when refused.
+    pub fn check(&self, now: i64) -> GateDecision {
+        let mut g = self.inner.lock().expect("unlock gate poisoned");
+        if let Some(until) = g.locked_out_until {
+            if now < until {
+                return GateDecision::LockedOut { retry_after_secs: until - now };
+            }
+            // Lockout elapsed — clear it and the failure streak.
+            g.locked_out_until = None;
+            g.consecutive_fails = 0;
+        }
+        if let Some(last) = g.last_attempt {
+            let elapsed = now - last;
+            if elapsed < self.min_interval_secs {
+                return GateDecision::TooSoon { retry_after_secs: self.min_interval_secs - elapsed };
+            }
+        }
+        g.last_attempt = Some(now);
+        GateDecision::Allow
+    }
+
+    /// Record a failed attempt; trips the lockout once the cap is reached.
+    pub fn record_failure(&self, now: i64) {
+        let mut g = self.inner.lock().expect("unlock gate poisoned");
+        g.consecutive_fails += 1;
+        g.last_attempt = Some(now);
+        if g.consecutive_fails >= self.max_fails {
+            g.locked_out_until = Some(now + self.lockout_secs);
+        }
+    }
+
+    /// Record a successful unlock; clears all rate-limit state.
+    pub fn record_success(&self) {
+        let mut g = self.inner.lock().expect("unlock gate poisoned");
+        *g = GateState::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_interval_between_attempts_is_enforced() {
+        let g = UnlockGate::new(5, 2, 300);
+        assert_eq!(g.check(1000), GateDecision::Allow);
+        // 1s later — too soon (need 2s).
+        assert_eq!(g.check(1001), GateDecision::TooSoon { retry_after_secs: 1 });
+        // 2s after the first allowed attempt — fine again.
+        assert_eq!(g.check(1002), GateDecision::Allow);
+    }
+
+    #[test]
+    fn lockout_after_max_consecutive_failures() {
+        let g = UnlockGate::new(3, 0, 300); // 0 min-interval to isolate the fail cap
+        for i in 0..3 {
+            let now = 2000 + i;
+            assert_eq!(g.check(now), GateDecision::Allow);
+            g.record_failure(now);
+        }
+        // 3 fails reached (last at t=2002 → locked until 2302) → locked out.
+        match g.check(2002) {
+            GateDecision::LockedOut { retry_after_secs } => assert_eq!(retry_after_secs, 300),
+            other => panic!("expected lockout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lockout_expires_then_allows_again() {
+        let g = UnlockGate::new(2, 0, 300);
+        for i in 0..2 {
+            assert_eq!(g.check(3000 + i), GateDecision::Allow);
+            g.record_failure(3000 + i);
+        }
+        assert!(matches!(g.check(3001), GateDecision::LockedOut { .. }));
+        // After the lockout window (last fail t=3001 → until 3301), attempts resume.
+        assert_eq!(g.check(3301), GateDecision::Allow);
+    }
+
+    #[test]
+    fn success_resets_the_failure_streak() {
+        let g = UnlockGate::new(3, 0, 300);
+        g.check(4000);
+        g.record_failure(4000);
+        g.check(4001);
+        g.record_failure(4001);
+        g.record_success();
+        // Streak cleared; a fresh failure doesn't immediately lock out.
+        assert_eq!(g.check(4002), GateDecision::Allow);
+        g.record_failure(4002);
+        assert_eq!(g.check(4003), GateDecision::Allow); // only 1 fail since reset
+    }
+}


### PR DESCRIPTION
## What

A locked hub can now be **promoted locked → unlocked at runtime** by presenting the tier-1 passphrase — no restart. This is the generic **unlock slot**: the unlock *mechanism* is pluggable (a stub-console passphrase prompt today; M-of-N quorum / hardware later, as private plugins), and a locked hub with no unlock plugin simply runs degraded tier-0 — a safe default.

## Why

Locked-mode (#335) let a vault-locked hub start in a degraded tier-0 state, but there was no way to *leave* that state without a restart-with-passphrase. This adds the missing transition, and does it as a clean seam rather than a one-off.

## How

- **`SwappableSigner`** (hub-lib) — a `RemoteSigner` whose backing signer can be swapped in place. The hub always installs one; the **lock state *is* the installed signer's kind** (`Locked` vs real), so the old `RestState.locked: bool` is gone and `is_locked()` is the single source of truth. Unlock swaps the `LockedSigner` for the real `LocalKeypairSigner` — every `s.signer.*` call site is unchanged.
- **`UnlockGate`** (hub-lib) — rate limiter: minimum interval between attempts, maximum consecutive failures, then lockout. The passphrase is still required; this caps **online guessing**, because anyone who can reach the unlock UI could still feed it attempts. Deterministic (injected unix-seconds) → 4 unit tests.
- **`RestState::try_unlock(passphrase, now)`** — rate-limited; opens the encrypted Sovereign identity, and on success swaps in the real signer + seeds the resolver with the Sovereign pubkey. The passphrase is used once and never stored.
- **`POST /v1/hubs/:id/unlock`** — privileged + **local-only** (loopback peer enforced via `ConnectInfo`; remote callers refused before any attempt is counted) + gated.
- **`hub unlock` CLI** — the stub-console plugin: resolves `hub_lct_id` from tier-0 discovery, prompts for the passphrase (`HUB_PASSPHRASE` honored; empty = explicit NULL), POSTs to `127.0.0.1`, never stores it.

## Safety / blast radius

Live hubs that start with `HUB_PASSPHRASE` are **unaffected** — they start unlocked and the slot only activates when locked. The signing hot path now routes through `SwappableSigner` (a thin delegating wrapper); covered by the existing 16 daemon + 149 lib tests.

## Tests

- Unlock promotes a locked hub with the right passphrase, is idempotent, and a wrong guess never unlocks.
- 5 consecutive wrong guesses lock out **even the correct passphrase**.
- Gate: min-interval, lockout-after-N, lockout-expiry, success-resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
