### PR TITLE
spec(C65): remediate 7 autonomous C64 findings on entity-types.md — A.1+B1 complete the C26-H1 birth-cert match (exist→presence + witness colon), A.2+B5 clear resolved-C25-H1 staleness, B3/B4/B6 table+vocab slips

### DIFF
--- a/web4-standard/core-spec/entity-types.md
+++ b/web4-standard/core-spec/entity-types.md
@@ -30,9 +30,9 @@ The following entity types are recognized in Web4:
 | **Oracle** | External data providers | Price feeds, Law Oracle, weather data | Responsive/Delegative | Active (delivers results) |
 | **Accumulator** | Broadcast listeners and recorders | Presence validators, history indexers | Responsive | Passive (stores data) |
 | **Dictionary** | Living semantic bridges managing compression-trust | Medical-legal translator, AI model bridges, cultural interpreters | Responsive/Agentic | Active (translates) |
-| **Hybrid** | Entities combining multiple types | Human-AI teams, cyborg systems | Mixed | Active |
+| **Hybrid** | Entities combining multiple types | Human-AI teams, cyborg systems | Agentic/Responsive/Delegative | Active |
 | **Policy** | Governance rules as living entities with IRP-backed evaluation | Enterprise safety rules, access policies, compliance frameworks | Responsive/Delegative | Active |
-| **Infrastructure** | Physical passive resources | Buildings, roads, machinery, tools | Passive | Passive |
+| **Infrastructure** | Physical passive resources | Buildings, roads, machinery, tools | None | Passive |
 
 ### 2.2 Entity Behavioral Modes
 
@@ -88,7 +88,7 @@ In addition to behavioral modes, entities are classified by their **energy metab
   ```
   ATP (charged) → Maintenance → ADP (discharged)
       ↓
-  ADP SLASHED (permanently consumed)
+  ADP CONSUMED (permanently, via maintenance)
       ↓
   NO reputation updates
       ↓
@@ -99,7 +99,7 @@ In addition to behavioral modes, entities are classified by their **energy metab
   - Storage resources (databases, file systems)
   - Non-autonomous devices (sensors, actuators)
   - Accumulators (passive data collection)
-- **Key Property**: ADP slashed (consumed), no reputation updates
+- **Key Property**: ADP consumed (permanently destroyed via maintenance), no reputation updates. This routine maintenance discharge is distinct from the punitive, authority-executed *slashing* of `atp-adp-cycle.md` §2.4 (evidence-gated destruction of ATP for law violations).
 - **Reputation Metric**: Utilization frequency × effectiveness by Active Resources
 
 #### The Efficiency Forcing Function
@@ -148,9 +148,9 @@ One of Web4's most radical innovations is treating roles not as labels but as en
   "lawOracle": "lct:web4:oracle:law:...",
   "lawVersion": "v1.2.0",
   "birthTimestamp": "2025-09-14T12:00:00Z",
-  "witnesses": ["lct:web4:witness1", "lct:web4:witness2"],
+  "witnesses": ["lct:web4:witness:1", "lct:web4:witness:2"],
   "genesisBlock": "block:12345",
-  "rights": ["exist", "interact", "accumulate_reputation"],
+  "rights": ["presence", "interact", "accumulate_reputation"],
   "obligations": ["abide_law", "respect_quorum"],
   "ledgerProof": "hash:sha256:...",
   "parentEntity": "lct:web4:parent:..."
@@ -278,7 +278,7 @@ For the role-LCT pairing mechanics see §3.4, "Role-Agent Pairing," above; for t
 
 > **See also**: `society-roles.md` for the full society-roles taxonomy (base-mandatory, context-mandatory, optional) with fractal-composability semantics. The roles enumerated below are the SAL-specific subset; the broader taxonomy in `society-roles.md` includes additional functional roles (Policy-Entity, Treasurer, Administrator, Archivist, etc.) that are base-mandatory for every Web4 society.
 >
-> **Note (do not conflate the two "sevens")**: The seven subsections below (Society, Authority, Law Oracle, Witness, Auditor, Agent, Client) are the **SAL-specific roles**. They are a *different set* from the seven **base-mandatory** roles defined in `society-roles.md` §2 (Sovereign, Law Oracle, Policy-Entity, Treasurer, Administrator, Archivist, Citizen) — the two sets overlap only on **Law Oracle**. The equal count is coincidental, not a correspondence. (The canonical home of the base-mandatory role list is an open design question; see C25-H1.)
+> **Note (subsection count vs role count; SAL roles vs base-mandatory roles)**: §4 has seven subsections, but §4.1 (Society) describes an *entity-type context* (§2.1), **not** a role an entity fills — so there are **six** SAL-specific roles below (Authority, Law Oracle, Witness, Auditor, Agent, Client) plus the Society context that hosts them. These six roles are a *different set* from the **base-mandatory** roles defined in `society-roles.md` §2 (Sovereign, Law Oracle, Policy-Entity, Treasurer, Administrator, Archivist, Citizen) — the two sets overlap only on **Law Oracle**. The canonical home of the base-mandatory role list is **`society-roles.md` §2** (resolved per `SOCIETY_SPECIFICATION.md` §1.2.5 / C51, which attributes the base-mandatory roles to that section); the remaining open item is only the role-*name* reconciliation (SAL "Authority Role" vs society-roles "Sovereign"), not the list's home.
 
 ### 4.1 Society (entity-type capabilities)
 **Society** is an *entity type* (§2.1), not a role an entity fills — it is included here because the SAL-specific roles below are hosted *within* a society and depend on these capabilities. A **Society** is a delegative entity with:
@@ -301,9 +301,11 @@ The **Authority** role within a society:
 > sub-authority position in SAL's delegation tree (`web4-society-authority-law.md` §3.3,
 > `authorityRole web4:delegatesTo subAuthorityRole`). It is **not** the root of the
 > delegation tree; SAL §3.1 names the *root* "Authority Role" LCT, and `society-roles.md`
-> §2.1 names the society's final/root authority **"Sovereign"**. Reconciling the role
-> *name* across these specs (SAL "Authority Role" vs society-roles "Sovereign") is an open
-> design question (see C25-H1); this note fixes only the scoped-vs-root reading.
+> §2.1 names the society's final/root authority **"Sovereign"**. The canonical *home* of
+> the base-mandatory role list is settled — `society-roles.md` §2, per
+> `SOCIETY_SPECIFICATION.md` §1.2.5 / C51 (formerly C25-H1) — so what remains open is only
+> reconciling the role *name* across these specs (SAL "Authority Role" vs society-roles
+> "Sovereign"); this note fixes only the scoped-vs-root reading.
 
 ### 4.3 Law Oracle Role
 A specialized oracle that:
@@ -490,7 +492,7 @@ Roles have unique interaction patterns:
 #### Citizen Role (Special Case)
 - **Automatically pairs**: With every new entity at creation
 - **Cannot be revoked**: Permanent birth certificate pairing
-- **Provides base rights**: Exist, interact, accumulate reputation
+- **Provides base rights**: Presence, interact, accumulate reputation
 - **Context-specific**: Nation-citizen, platform-citizen, network-citizen
 
 #### Other Roles


### PR DESCRIPTION
## C65 — Remediation of the 7 autonomous C64 findings on `entity-types.md`

Paired remediation for the merged **C64 audit** (PR #342, `docs/audits/C64-entity-types-2nd-delta-2026-06-16.md`). Applies exactly the **7 autonomous-actionable** findings from §D; cross-track and design-q findings are held for operator/other tracks.

**Diff: +13/−11, `entity-types.md` only** (< +58 → focused self-check, not full mini-audit).

### Findings applied
| ID | Sev | Change |
|----|-----|--------|
| **A.1** (flagship) | — | birth-cert `rights[0]` value `"exist"`→`"presence"` (§3.1 L153) + prose "Exist"→"Presence" (§6.2 L493) — aligns VALUE to SAL §2.2 canonical. C26-H1 had fixed only the KEYS. |
| **B1** (pairs A.1) | MED | §3.1 witness IDs `witness1/2`→`witness:1/:2` colon form — matches SAL §2.2 L55 + own §4.7 L394. **A.1+B1 jointly make the §3.1 "matches canonical §2.2" provenance note literally true.** |
| **A.2** | — | §4 preamble L281 + §4.2 note L305 stop citing **C25-H1 as "open"** — the role-list home is RESOLVED downstream (`society-roles.md` §2 per `SOCIETY_SPECIFICATION.md` §1.2.5 / C51 #318). Only the role-*name* reconciliation (Authority Role vs Sovereign) remains open. |
| **B5** (folded w/ A.2) | LOW | "seven SAL-specific roles" (miscounted Society, a non-role per §4.1) → "**six** roles + Society context". |
| **B3** | MED | Hybrid Mode `Mixed` (undefined in §2.2) → `Agentic/Responsive/Delegative` slash-notation. |
| **B4** | LOW | Infrastructure Mode column `Passive` (mode-vs-energy slip) → `None`. |
| **B6** | LOW | §2.3 `slashed`→`consumed` + one-line note distinguishing routine maintenance discharge from atp-adp §2.4 punitive slashing. |

### Self-check (cross-spec claims re-verified against the live corpus)
- SAL §2.2 L57 `rights: ["presence", …]`, L55 colon witnesses → A.1/B1 now match ✅
- entity-types own §4.7 L394 colon form → B1 internally consistent ✅
- `society-roles.md` §2 = "Base-Mandatory Roles" §2.1–§2.7 (the exact 7 named) ✅
- `SOCIETY_SPECIFICATION.md` §1.2.5 L60 attributes those 7 to society-roles §2 → A.2 cite accurate ✅
- C26 provenance note (L160) now true at key + value + format level
- No cross-track / design-q leak; C23-H1 field-set design-Q untouched

### Out of scope (routed, NOT touched)
- **Cross-track**: A.3/B13 (LCT-ID → C24-H1), B2 (SDK Device per-instance energy), B7 (dictionary trust-config key → dictionary-entities owner), B12 (atp-adp §4.2 cross-ref nicety)
- **Design-q (operator)**: B9 (Task non-R6 metabolism), B10 (Policy LCT JSON example), B11 (SAGE/IRP optionality framing)

Closes the `entity-types.md` **C8→C26→C64→C65** cycle. Next AUDIT (C66) = oldest never-delta'd of {C30 errors, C31 security-framework} → errors first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)