### PR TITLE
hub: membox cart is a pure index (no member PII at rest)

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -1736,7 +1736,11 @@ async fn dispatch_channel(
             let requested = inner.args.get("top_k").and_then(|v| v.as_u64()).map(|n| n as usize);
             let effective = scope.effective_limit(requested.or(Some(12))).unwrap_or(12);
             let temperature = inner.args.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.0);
-            let hits = membox_find_members(query, effective, temperature).await?;
+            let mut hits = membox_find_members(query, effective, temperature).await?;
+            // The cart is a pure index: the sidecar returns {member_lct, score}.
+            // Re-attach member name from the hub's authoritative (encrypted)
+            // registry here — member PII lives once, in the hub, not the cart.
+            enrich_member_hits(&mut hits, &state.members);
             Ok(serde_json::json!({
                 "results": hits,
                 "total": hits.len(),
@@ -1889,6 +1893,27 @@ async fn dispatch_channel(
             }))
         }
         other => Err(ApiError::bad_request(format!("unknown or non-channel tool: {other}"))),
+    }
+}
+
+/// Re-attach member display data (name) to the index-only hits returned by the
+/// membox cart, looked up from the authoritative registry. The cart holds no
+/// PII — just `member_lct` + embedding — so the hub is the single source of
+/// member identity; unknown/absent LCTs are left as-is (lct + score only).
+fn enrich_member_hits(
+    hits: &mut [serde_json::Value],
+    members: &std::collections::BTreeMap<Uuid, hub_lib::state::Member>,
+) {
+    for hit in hits.iter_mut() {
+        if let Some(lct) = hit
+            .get("member_lct")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+        {
+            if let Some(name) = members.get(&lct).and_then(|m| m.name.clone()) {
+                hit["name"] = serde_json::json!(name);
+            }
+        }
     }
 }
 
@@ -3911,6 +3936,31 @@ norms:
 
     fn loopback() -> ConnectInfo<SocketAddr> {
         ConnectInfo("127.0.0.1:0".parse().unwrap())
+    }
+
+    #[test]
+    fn find_members_hits_are_enriched_from_the_registry_not_the_cart() {
+        use std::collections::{BTreeMap, BTreeSet};
+        let lct = Uuid::new_v4();
+        let mut members = BTreeMap::new();
+        members.insert(lct, hub_lib::state::Member {
+            lct_id: lct,
+            name: Some("Sprout".into()),
+            skills: BTreeSet::new(),
+            profile: BTreeMap::new(),
+        });
+        // Index-only hits, exactly as the slim cart/sidecar returns them.
+        let unknown = Uuid::new_v4();
+        let mut hits = vec![
+            serde_json::json!({ "member_lct": lct.to_string(), "score": 0.91 }),
+            serde_json::json!({ "member_lct": unknown.to_string(), "score": 0.42 }),
+        ];
+        enrich_member_hits(&mut hits, &members);
+        // Known member: name re-attached from the registry; score preserved.
+        assert_eq!(hits[0]["name"], serde_json::json!("Sprout"));
+        assert_eq!(hits[0]["score"], serde_json::json!(0.91));
+        // Unknown LCT: left as index-only (no fabricated name).
+        assert!(hits[1].get("name").is_none());
     }
 
     #[tokio::test]

--- a/hub/membox/ingest.py
+++ b/hub/membox/ingest.py
@@ -63,15 +63,16 @@ def member_passage(m: dict) -> str:
     return passage
 
 
-def member_tags(m: dict, passage: str) -> dict:
-    """Forward-compat provenance (item 2 of the three adds). profile_version is
-    a content hash so it changes exactly when a member's profile changes."""
-    profile = m.get("profile") or {}
+def member_index_entry(m: dict, passage: str) -> dict:
+    """The cart is a pure INDEX, not a copy of member data. We persist only the
+    minimal map: passage-index → member_lct, plus a content-hash for cache
+    invalidation. NO name, profile text, skills, or pair purpose — those live
+    once in the hub's (encrypted) registry and are re-attached by the hub at
+    query time. `profile_version` is a one-way sha256 of the passage (changes
+    exactly when a member's profile changes), not the content itself."""
     return {
         "member_lct": m.get("lct_id"),
-        "name": m.get("name"),
         "profile_version": hashlib.sha256(passage.encode()).hexdigest()[:12],
-        "last_pair_purpose": profile.get("last_pair_purpose"),
     }
 
 
@@ -95,20 +96,28 @@ def main() -> int:
 
     import cartridge_builder as cb
 
+    # The member prose is used ONLY to compute embeddings — it exists in RAM for
+    # the duration of this process and is never persisted. The cart stores the
+    # opaque member_lct as each passage's "text", so the cart on disk is a pure
+    # index (embeddings + lct ids), carrying no member PII at rest.
     passages = [member_passage(m) for m in members]
-    tags = [member_tags(m, p) for m, p in zip(members, passages)]
+    index = [member_index_entry(m, p) for m, p in zip(members, passages)]
+    cart_text = [str(m.get("lct_id") or "") for m in members]
 
     print(f"embedding {len(passages)} member passages with pinned Nomic model...", flush=True)
     embeddings = cb.embed_texts(passages)
 
     os.makedirs(args.out, exist_ok=True)
-    cart_path, size_mb, fingerprint = cb.save_cartridge(args.out, args.name, embeddings, passages)
+    # Persist the cart with opaque LCTs as the stored text — NOT the prose.
+    cart_path, size_mb, fingerprint = cb.save_cartridge(args.out, args.name, embeddings, cart_text)
 
-    # The forward-compat provenance sidecar, passage-index aligned (== local_addr
-    # in search results). The sidecar maps a hit back to its member_lct via this.
+    # Slim index sidecar, passage-index aligned (== local_addr in search
+    # results): maps a hit back to its member_lct. No names / profile text — the
+    # hub re-attaches those from its authoritative encrypted registry.
     meta_path = os.path.join(args.out, f"{args.name}.members.json")
     with open(meta_path, "w") as f:
-        json.dump({"fingerprint": fingerprint, "members": tags}, f, indent=2)
+        json.dump({"fingerprint": fingerprint, "members": index}, f, indent=2)
+    tags = index  # for the summary print below
 
     print(f"cart:  {cart_path}  ({size_mb:.2f} MB, fingerprint {fingerprint})")
     print(f"meta:  {meta_path}  ({len(tags)} members)")

--- a/hub/membox/sidecar.py
+++ b/hub/membox/sidecar.py
@@ -10,7 +10,10 @@ search (cosine + Hamming + keyword rerank) membot ships.
 Endpoints (localhost only — the hub mediates all external access):
   GET  /health                      -> {ok, cart, n_members, fingerprint}
   POST /find_members {query, top_k, temperature}
-        -> {results: [{member_lct, name, score, tags}], total}
+        -> {results: [{member_lct, score}], total}
+        The cart is a pure index (embeddings + opaque member_lct); the sidecar
+        returns only LCT + score. Member name/profile live once in the hub's
+        encrypted registry and are re-attached there — no PII flows through here.
 
 temperature is accepted now (locked v1 contract: ship the knob from day one)
 but the underlying multi_cart.search doesn't expose settle-noise yet, so v1 is
@@ -49,11 +52,12 @@ def do_search(query: str, top_k: int) -> list[dict]:
     for r in res.get("results", []):
         addr = r.get("local_addr")
         meta = members[addr] if isinstance(addr, int) and 0 <= addr < len(members) else {}
+        # The cart is a pure index: return only the opaque member_lct + score.
+        # The hub re-attaches name/profile from its authoritative encrypted
+        # registry — no member PII lives in or flows through this sidecar.
         out.append({
             "member_lct": meta.get("member_lct"),
-            "name": meta.get("name"),
             "score": float(r.get("score", 0.0)),
-            "tags": meta,
         })
     # Drop hits we couldn't attribute to a member_lct (defensive).
     return [r for r in out if r["member_lct"]]


### PR DESCRIPTION
## What

After encrypting `hub.db` at rest (#343), the membox discovery cart was still a **plaintext copy of the same member data** — names + profile prose in `*.cart.npz`/`*.members.json` — re-exposing exactly what the DB encryption protects. Per dp's framing (*if it's the same data, why hold it twice?*), the fix is **removal, not encrypting the duplicate**: hold the data once (encrypted `hub.db`), keep only the **index** in the cart.

## How

- **`ingest.py`** — member prose is embedded **in RAM only, never persisted**. The cart stores the opaque `member_lct` as each passage's text; `members.json` is slimmed to `{member_lct, profile_version}`. No names, profile text, skills, or pair purposes at rest (`profile_version` is a one-way sha256 for cache invalidation).
- **`sidecar.py`** — `/find_members` returns `{member_lct, score}` only. No PII lives in or flows through the sidecar.
- **`rest.rs`** — the `find_members` slot re-attaches member `name` from the hub's authoritative (encrypted) registry via `enrich_member_hits()`. Unknown LCTs stay index-only (no fabricated identity).

## Verified live

Rebuilt the cart on HUB: passages are now opaque LCTs, `members.json` is name-free, the sidecar returns `lct+score`, the hub re-attaches names. Both services healthy after redeploy.

## Tests

`find_members_hits_are_enriched_from_the_registry_not_the_cart` (name re-attached for known LCT, score preserved, unknown LCT left bare). 19 daemon + 150 lib green.

## Follow-up (membot)

A companion forum note to Andy/Waving Cat recommends **encrypting cart contents by default** in membot — the general case, since most carts bake real content + embeddings into a plaintext `.npz`, and every consumer otherwise has to strip/wrap themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
