### PR TITLE
spec(C67): remediate 3 autonomous C66 findings on errors.md

### DIFF
--- a/web4-standard/core-spec/errors.md
+++ b/web4-standard/core-spec/errors.md
@@ -2,11 +2,11 @@
 
 **Version**: 1
 **Status**: Draft — core protocol error taxonomy (RFC 9457 Problem Details); subsystem specs extend it (see §1).
-**Last-Updated**: 2026-06-04
+**Last-Updated**: 2026-06-17
 
 ---
 
-This document defines the standardized **core protocol** error taxonomy for Web4, based on RFC 9457 Problem Details. It is the single source of truth for core protocol error codes (binding, pairing, witnessing, authorization, cryptography, and protocol errors). Subsystem specifications — Society/Authority Law (`web4-society-authority-law.md` §9), ACP (`acp-framework.md` §10), metering (`web4-metering.md` §6), and MCP cross-society (`mcp-protocol.md` §7.6) — **extend** this taxonomy with additional domain-specific `W4_ERR_*` codes and SHOULD reuse the codes defined here where applicable rather than introducing parallel names. A consistent error format is essential for debugging, interoperability, and providing a good developer experience.
+This document defines the standardized **core protocol** error taxonomy for Web4, based on RFC 9457 Problem Details. It is the single source of truth for core protocol error codes (binding, pairing, witnessing, authorization, cryptography, and protocol errors). Subsystem specifications **extend** this taxonomy with additional domain-specific codes and SHOULD reuse the codes defined here where applicable rather than introducing parallel names: Society/Authority Law (`web4-society-authority-law.md` §9), ACP (`acp-framework.md` §10), and metering (`web4-metering.md` §6) add codes following the `W4_ERR_*` convention defined here; MCP cross-society (`mcp-protocol.md` §7.6) currently uses lowercase `web4_*` identifiers for its cross-society failure modes. A consistent error format is essential for debugging, interoperability, and providing a good developer experience.
 
 ## 1. Error Format
 
@@ -138,11 +138,13 @@ Web4 defines a hierarchical error code taxonomy with the following categories:
 - **JSON**: `application/problem+json` (MUST support)
 - **CBOR**: `application/problem+cbor` (SHOULD support)
 
-## 5. HTTP Status Code Mapping
+## 5. Status Code Semantics
+
+Per §1, the `status` member is **transport-agnostic** — the reason phrases below are HTTP status codes used as the canonical *illustrative labels* for each semantic class, and the same semantic class applies over non-HTTP transports (e.g. CBOR over TLS/QUIC, BLE GATT, CAN Bus). Each entry names the semantic class the status conveys:
 
 - **400 Bad Request**: Malformed requests, invalid parameters
-- **401 Unauthorized**: Authentication or authorization failures
-- **403 Forbidden**: Operation not allowed for authenticated entity
+- **401 Unauthorized**: Authentication failure, or a credential that lacks the required capability (e.g. `W4_ERR_AUTHZ_DENIED`)
+- **403 Forbidden**: An authenticated entity lacking the additional scope or authorization required for the operation (e.g. `W4_ERR_AUTHZ_SCOPE`)
 - **408 Request Timeout**: Operation timed out
 - **409 Conflict**: Resource state conflicts
 - **410 Gone**: Resource no longer available


### PR DESCRIPTION
## C67 — errors.md remediation (alternation: audit→remediation)

Applies the **3 AUTONOMOUS** findings routed by the C66 delta re-audit (PR #345, merged `d55c0932`). DESIGN-Q and CROSS-TRACK findings deferred per routing.

### Findings applied (all in-file, `web4-standard/core-spec/errors.md`)

| ID | Sev | Fix |
|----|-----|-----|
| **B-3** | MED (priority) | §1 rescope over-claimed mcp §7.6 uses `W4_ERR_*`. Verified false (`grep -c W4_ERR mcp-protocol.md` = 0; §7.6 uses lowercase `web4_cross_society_*`). Now: `W4_ERR_*` scoped to SAL §9 / ACP §10 / metering §6; mcp §7.6 named separately as using lowercase `web4_*` — cross-reference preserved, actual convention described. |
| **B-6** | LOW | §5 retitled "HTTP Status Code Mapping" → "Status Code Semantics" + lead sentence framing HTTP reason phrases as illustrative labels, transport-agnostic per §1 L32's "per §2/§5" citation. No re-asserted HTTP normativity. |
| **B-7** | LOW | §5 401/403 prose sharpened to mirror §2's deliberate split (401 = authn + capability-denial → `AUTHZ_DENIED`; 403 = authenticated entity lacking scope → `AUTHZ_SCOPE`). **No status reassignment** — B-1's 401→403 DESIGN-Q untouched. |

### Out of scope (deferred per C66 routing)
- **B-1** (DESIGN-Q, operator): `AUTHZ_DENIED` 401→403 (needs coordinated change across §2.4 + pinned test-vector + SDK + initial-registries + handshake §10).
- **B-2/B-4/B-5/B-8/B-9** (CROSS-TRACK): land in `initial-registries.md` / SDK `errors.py` / `mcp-protocol.md` §7.6 / ACP §10 — not errors.md.

### Verification
- Diff: **+7/−5** (1 file). Below +58 threshold → focused self-check, not mini-audit.
- BC#5 corpus sweep: `grep -rn "HTTP Status Code Mapping"` → 0 hits; no anchor links broken.
- B-3 claim hand-verified against live `mcp-protocol.md` §7.6 (L500–505).
- Closes the 2 remediation-introduced imperfections the C56 token-by-token completeness method surfaced in C66. **errors.md C30→C66→C67 cycle COMPLETE.**

### Next
After merge, last never-delta'd core-spec = `security-framework.md` (prior C31) → next AUDIT turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)