### PR TITLE
spec(C69): remediate 6 autonomous C68 findings on security-framework.md

### DIFF
--- a/web4-standard/core-spec/security-framework.md
+++ b/web4-standard/core-spec/security-framework.md
@@ -11,10 +11,10 @@ Web4 defines standardized cryptographic suites to ensure interoperability and se
 
 ### 1.1. Suite Definitions
 
-| Suite ID          | KEM       | Sig        | AEAD                | Hash    | Profile | Status |
-|-------------------|-----------|------------|---------------------|---------|---------|--------|
-| W4-BASE-1         | X25519    | Ed25519    | ChaCha20-Poly1305   | SHA-256 | COSE    | MUST   |
-| W4-FIPS-1         | ECDH-P256 | ECDSA-P256 | AES-128-GCM         | SHA-256 | JOSE    | SHOULD |
+| Suite ID          | KEM       | Sig        | AEAD                | Hash    | KDF         | Encoding | Status |
+|-------------------|-----------|------------|---------------------|---------|-------------|----------|--------|
+| W4-BASE-1         | X25519    | Ed25519    | ChaCha20-Poly1305   | SHA-256 | HKDF-SHA256 | COSE     | MUST   |
+| W4-FIPS-1         | ECDH-P256 | ECDSA-P256 | AES-128-GCM         | SHA-256 | HKDF-SHA256 | JOSE     | SHOULD |
 
 **Implementation Requirements:**
 - Implementations MUST support W4-BASE-1
@@ -29,7 +29,7 @@ Web4 defines standardized cryptographic suites to ensure interoperability and se
 - **AEAD**: ChaCha20-Poly1305 (RFC 8439)
 - **Hash**: SHA-256 (FIPS 180-4)
 - **KDF**: HKDF-SHA256 (RFC 5869)
-- **Encoding**: COSE (RFC 8152)
+- **Encoding**: COSE (RFC 9052/9053, obsoletes RFC 8152)
 
 #### W4-FIPS-1 (FIPS Compliance)
 - **Key Exchange**: ECDH-P256 (ECDH with P-256, FIPS 186-4)
@@ -45,7 +45,7 @@ All Web4 signed payloads **MUST** implement COSE/CBOR (Ed25519/EdDSA) as mandato
 
 #### COSE/CBOR (MUST)
 - Deterministic CBOR encoding per CTAP2
-- Ed25519 with `crv: Ed25519` and `alg: EdDSA` 
+- Ed25519 with `crv = 6` (COSE curve label) and `alg = -8` (EdDSA)
 - Payload is the canonical CBOR map
 - See web4-handshake.md Section 6.0.3 for complete profile
 
@@ -75,7 +75,7 @@ Private keys MUST be stored securely to prevent unauthorized access. Recommended
 
 ### 2.3. Key Rotation
 
-To mitigate the risk of key compromise, Web4 entities SHOULD rotate their keys periodically. The key rotation process involves generating a new key pair and updating the entity's Web4 Identifier to use the new public key. See `LCT-linked-context-token.md` Section 7.3 for the normative rotation lifecycle (new LCT issuance, `lineage` to the parent, and the dual-validity overlap window before the parent is retired as `superseded`).
+To mitigate the risk of key compromise, Web4 entities SHOULD rotate their keys periodically. The key rotation process involves generating a new key pair and issuing a new LCT bound to the new public key. See `LCT-linked-context-token.md` Section 7.3 for the normative rotation lifecycle (new LCT issuance, `lineage` to the parent, and the dual-validity overlap window before the parent is retired as `superseded`).
 
 
 
@@ -86,7 +86,7 @@ Authentication and authorization are essential for controlling access to Web4 re
 
 ### 3.1. Authentication
 
-Authentication in Web4 is based on digital signatures. An entity authenticates itself by signing a challenge with its private key. The signature can then be verified by the other party using the entity's public key.
+Authentication in Web4 is based on digital signatures. An entity authenticates itself by signing a challenge with its private key. The signature can then be verified by the other party using the entity's public key. See `web4-handshake.md` Section 6.0.5 for the normative session-binding, freshness, nonce-uniqueness, and replay-protection requirements that a conformant challenge-response MUST satisfy.
 
 ### 3.2. Authorization
 


### PR DESCRIPTION
## C69 — security-framework.md remediation (closes C31→C68→C69 cycle)

Applies the **6 AUTONOMOUS** findings from the C68 first-delta re-audit (`docs/audits/C68-security-framework-delta-audit-2026-06-17.md`, merged #348). Intra-file consistency only, **+8/−8**.

| ID | § | Change |
|----|---|--------|
| **B-1** | 1.3 | COSE `crv`/`alg` JOSE-string (`crv: Ed25519`/`alg: EdDSA`) → COSE-numeric (`crv = 6` curve label / `alg = -8` EdDSA), mirroring the handshake §6.0.3 profile this section explicitly anchors to (handshake L136/L140 verified) |
| **B-2** | 3.1 | add deference to `web4-handshake.md §6.0.5` for normative session-binding / freshness / nonce-uniqueness / replay (handshake L150/L210 verified) |
| **B-4** | 1.1 | rename table column `Profile` → `Encoding` (matches §1.2 prose / SDK serialized key / vector key) |
| **B-5** | 1.1 | add `KDF` column (`HKDF-SHA256`) the table omitted while §1.2/SDK/vector all carry it |
| **B-6** | 1.2 | COSE cite `RFC 8152` → `RFC 9052/9053` (8152 obsoleted) |
| **B-9 interim** | 2.3 | reword first clause `updating the entity's Web4 Identifier to use the new public key` → `issuing a new LCT bound to the new public key` so the sentence stops contradicting the LCT §7.3 model it already cites. **Does NOT pre-empt the B-M2 rotation-semantics DESIGN-Q.** |

### Routed, NOT touched this turn
- **DESIGN-Q** (operator): B-3 (VC-vs-SAL authz basis), B-9/B-M2 (rotation mutate-vs-stable-DID semantics), C-M1 (canonical crypto-suite registry — now ≥5 files / 4 FIPS-KEM spellings), B-H2/B-11 (W4-IOT-1 + AES-CCM in SDK/vectors).
- **CROSS-TRACK**: B-7 (normalize 4 sibling FIPS-KEM spellings → `ECDH-P256`), B-8 (SDK `security.py:146` docstring quotes deleted A-L2 text), B-10 (`cose:ES256`→`cose:EdDSA` in LCT/lct-cap/multi-device), B-L6/B-L7.

### Verification
- All cross-refs hand-verified against `protocols/web4-handshake.md` (BC#5 discipline).
- `8152` swept → single occurrence in target.
- Markdown table integrity preserved (8-col header/separator/2 rows).
- No new canonical token introduced → no corpus ripple.

**With this, `security-framework.md` has a complete delta cycle → ALL core-spec files now have ≥1 audit→remediation delta cycle.**

Session: legion-web4-20260617-180047, v2 protocol, LEAD voice. Policy review: APPROVED first-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)