### PR TITLE
hub: public vault_tree base + protected-tier opened by M-of-N grant (H3)

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -102,6 +102,11 @@ pub struct RestState {
     pub unlock_verifier_cmd: Option<String>,
     /// Outstanding tier-2 unlock challenges (id → accumulating attestations).
     pub unlock_sessions: Arc<Mutex<std::collections::HashMap<Uuid, UnlockSession>>>,
+    /// The **protected tier**: a `vault_tree` enclosure holding data that opens only on a
+    /// granted M-of-N unlock (recursive-vault P2 / H3). `None` when the hub is locked (no
+    /// passphrase) — there's no master key to open it. Seeded with a demo Sealed item so a
+    /// granted quorum has something real to release.
+    pub protected: Option<Arc<Mutex<hub_lib::vault_tree::OpenVault>>>,
 }
 
 /// An in-flight tier-2 unlock: the minted challenge + the roster/threshold
@@ -262,6 +267,7 @@ impl RestState {
             unlock_gate: Arc::new(UnlockGate::default_policy()),
             unlock_verifier_cmd: std::env::var("HUB_UNLOCK_VERIFIER").ok().filter(|s| !s.is_empty()),
             unlock_sessions: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            protected: open_protected_store(&hub_dir),
         })
     }
 
@@ -628,6 +634,10 @@ pub struct AttestResp {
     rejected: usize,
     required: usize,
     reason: String,
+    /// On the first grant: the tier-2 protected payload the quorum released (H3 — proof the
+    /// M-of-N opened real encrypted data, not just a symbolic authorization).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    released: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -708,7 +718,9 @@ async fn unlock_attest(
     });
     let decision = run_unlock_verifier(&cmd, &vreq).await?;
 
-    // Witness the resolution exactly once, on the first grant.
+    // Witness the resolution exactly once, on the first grant — and actually OPEN the
+    // protected tier (H3): the quorum's authorization releases real Sealed data.
+    let mut released: Option<String> = None;
     if decision.granted && !already_granted {
         witness_event(
             &s,
@@ -725,9 +737,10 @@ async fn unlock_attest(
         if let Some(sess) = s.unlock_sessions.lock().await.get_mut(&req.challenge_id) {
             sess.granted = true;
         }
+        released = open_protected_tier(&s).await;
         tracing::warn!(
-            challenge = %req.challenge_id, tier = %challenge.tier,
-            "TIER-2 VAULT UNLOCK GRANTED by M-of-N quorum (witnessed)"
+            challenge = %req.challenge_id, tier = %challenge.tier, released = released.is_some(),
+            "TIER-2 VAULT UNLOCK GRANTED by M-of-N quorum (witnessed) — protected tier opened"
         );
     }
 
@@ -738,7 +751,25 @@ async fn unlock_attest(
         rejected: decision.rejected,
         required: decision.required,
         reason: decision.reason,
+        released,
     }))
+}
+
+/// On a granted quorum, open the protected-tier Sealed item: read its sealing credential
+/// (master tier, available since ignition) and decrypt the item into memory. This is the
+/// recognition model — the quorum *authorizes*; the hub holds the credential. Returns the
+/// released payload, or `None` if no protected store is configured / it can't be opened.
+async fn open_protected_tier(s: &RestState) -> Option<String> {
+    let store = s.protected.as_ref()?;
+    let v = store.lock().await;
+    let cred = match v.open_item(PROTECTED_NOTE_CRED, None) {
+        Ok(c) => String::from_utf8_lossy(&c).into_owned(),
+        Err(e) => { tracing::warn!("protected-tier: reading sealing credential failed: {e}"); return None; }
+    };
+    match v.open_item(PROTECTED_NOTE, Some(&cred)) {
+        Ok(bytes) => Some(String::from_utf8_lossy(&bytes).into_owned()),
+        Err(e) => { tracing::warn!("protected-tier: opening sealed item failed: {e}"); None }
+    }
 }
 
 /// Invoke the private verifier subprocess: pipe the request JSON to stdin, read
@@ -784,6 +815,44 @@ async fn run_unlock_verifier(
     serde_json::from_slice(&out.stdout).map_err(|e| {
         ApiError::internal(anyhow::anyhow!("unparseable verifier decision: {e}"))
     })
+}
+
+const PROTECTED_NOTE: &str = "protected-note";
+const PROTECTED_NOTE_CRED: &str = "protected-note.cred";
+
+/// Open (or create) the hub's **protected-tier** vault — the recursive-vault enclosure
+/// that holds data released only on a granted M-of-N unlock (H3). Keyed by the vault
+/// passphrase; `None` when the hub is locked (no passphrase → no master key). Seeds a demo
+/// Sealed item the first time, so a granted quorum has something real to open. Any failure
+/// is logged and yields `None` (degraded, not fatal — the rest of the hub still runs).
+fn open_protected_store(hub_dir: &std::path::Path) -> Option<Arc<Mutex<hub_lib::vault_tree::OpenVault>>> {
+    use hub_lib::vault_tree::{ItemKind, OpenVault};
+    let pass = hub_lib::identity::env_passphrase()?; // locked hub → no protected store
+    let path = hub_dir.join("protected.hvlt");
+    let mut v = match OpenVault::open_or_create(&path, &pass, "protected-tier") {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("protected-tier store unavailable ({}): {e}", path.display());
+            return None;
+        }
+    };
+    if !v.contains(PROTECTED_NOTE) {
+        // Sealing credential the hub holds at master tier (available after ignition); the
+        // tier-2 policy only *uses* it on a granted quorum.
+        let cred = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+        v.put_master(PROTECTED_NOTE_CRED, ItemKind::Credential, cred.as_bytes());
+        let payload = b"TIER-2 PROTECTED PAYLOAD - released only by a witnessed M-of-N quorum unlock.";
+        if let Err(e) = v.put_sealed(PROTECTED_NOTE, ItemKind::Document, payload, &cred) {
+            tracing::warn!("seeding protected-tier item failed: {e}");
+            return None;
+        }
+        if let Err(e) = v.save() {
+            tracing::warn!("persisting protected-tier store failed: {e}");
+            return None;
+        }
+        tracing::info!("protected-tier store initialized at {} (demo Sealed item seeded)", path.display());
+    }
+    Some(Arc::new(Mutex::new(v)))
 }
 
 pub fn router(state: RestState) -> Router {

--- a/hub/hub-lib/Cargo.toml
+++ b/hub/hub-lib/Cargo.toml
@@ -9,6 +9,7 @@ description = "Web4 Community Hub — society logic library (chapter state, ledg
 
 [dependencies]
 web4-core.workspace = true
+zeroize = "1"
 web4-trust-core.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/hub/hub-lib/src/lib.rs
+++ b/hub/hub-lib/src/lib.rs
@@ -41,6 +41,7 @@ pub mod signer;
 pub mod state;
 pub mod store;
 pub mod unlock_gate;
+pub mod vault_tree;
 
 /// Crate version, exposed for `hub --version`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/hub/hub-lib/src/vault_tree.rs
+++ b/hub/hub-lib/src/vault_tree.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Metalinxx Inc.
+
+//! `vault_tree` — a **recursive-item enclosure** (the generic base of the shared
+//! recursive-vault doctrine; see `web4/docs/best-practices/storage-and-key-management.md`).
+//!
+//! A vault is a tree whose outer unlock (master key) reveals only `config` + the **index**
+//! (what exists + how it's protected) — not every item's plaintext. Per-item
+//! [`Protection`]: `Master` (outer key) or `Sealed` (an independent credential). An item may
+//! itself be a `SubVault` (the recursion). Decryption is **memory-only** — [`open_item`] returns
+//! a zeroizing buffer; nothing decrypted touches disk; persistence always re-encrypts.
+//!
+//! This is the public, generic base. Presence/liveness-gated tiers (constellation-MFA, the
+//! novel mechanism) are a separate, private extension and are intentionally not here.
+//!
+//! Crypto is reused from [`web4_core::vault::crypto`] (Argon2id `derive_key` +
+//! ChaCha20-Poly1305 `seal`/`open`) — no new ciphers.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use web4_core::vault::crypto::{self, DerivedKey};
+use zeroize::Zeroizing;
+
+const MAGIC: &[u8; 4] = b"HVLT";
+const VERSION: u8 = 1;
+
+/// How an item is protected.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Protection {
+    /// Opened by the outer master key. The basics.
+    Master,
+    /// Encrypted under an INDEPENDENT credential; master unlock reveals it exists, not its
+    /// plaintext.
+    Sealed,
+}
+
+/// What an item is, for the index (no plaintext exposed).
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ItemKind {
+    Credential,
+    Document,
+    /// The item's plaintext is itself a serialized vault — the recursion.
+    SubVault,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct StoredItem {
+    kind: ItemKind,
+    protection: Protection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    inner_salt: Option<Vec<u8>>,
+    /// `Master`: plaintext (within the outer encryption). `Sealed`: inner AEAD blob.
+    payload: Vec<u8>,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct Meta {
+    schema: u32,
+    vault_id: String,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct VaultData {
+    meta: Meta,
+    config: serde_json::Value,
+    items: BTreeMap<String, StoredItem>,
+}
+
+/// A plaintext-free listing of a vault's contents (from the index).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ItemRef {
+    pub name: String,
+    pub kind: ItemKind,
+    pub protection: Protection,
+}
+
+/// An opened vault held **in memory**. Item plaintext is produced on demand by
+/// [`open_item`](Self::open_item) into a zeroizing buffer; never written to disk.
+pub struct OpenVault {
+    path: PathBuf,
+    master: DerivedKey,
+    salt: [u8; 16],
+    data: VaultData,
+}
+
+impl OpenVault {
+    /// Create a fresh empty vault at `path`, keyed by `master_passphrase`. Not yet persisted.
+    pub fn create(path: impl AsRef<Path>, master_passphrase: &str, vault_id: impl Into<String>) -> Result<Self> {
+        let salt = crypto::generate_salt();
+        let master = crypto::derive_key(master_passphrase, &salt).map_err(|e| anyhow::anyhow!("derive master: {e}"))?;
+        Ok(Self {
+            path: path.as_ref().to_path_buf(),
+            master,
+            salt,
+            data: VaultData { meta: Meta { schema: 1, vault_id: vault_id.into() }, ..Default::default() },
+        })
+    }
+
+    /// Open an existing vault file. Fails closed on a wrong key (AEAD) — no plaintext fallback.
+    pub fn open(path: impl AsRef<Path>, master_passphrase: &str) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let raw = std::fs::read(&path).with_context(|| format!("reading vault {}", path.display()))?;
+        if raw.len() < 21 || &raw[..4] != MAGIC {
+            bail!("{} is not a vault_tree file", path.display());
+        }
+        if raw[4] != VERSION {
+            bail!("vault_tree {} version {} unsupported", path.display(), raw[4]);
+        }
+        let mut salt = [0u8; 16];
+        salt.copy_from_slice(&raw[5..21]);
+        let master = crypto::derive_key(master_passphrase, &salt).map_err(|e| anyhow::anyhow!("derive master: {e}"))?;
+        let plain = crypto::open(&master, &raw[21..])
+            .map_err(|_| anyhow::anyhow!("vault {} did not open (wrong passphrase or corrupt)", path.display()))?;
+        let data: VaultData = serde_json::from_slice(&plain).context("parsing vault data")?;
+        Ok(Self { path, master, salt, data })
+    }
+
+    /// Open if present, else create. Convenience for daemon startup.
+    pub fn open_or_create(path: impl AsRef<Path>, master_passphrase: &str, vault_id: impl Into<String>) -> Result<Self> {
+        if path.as_ref().exists() {
+            Self::open(path, master_passphrase)
+        } else {
+            let v = Self::create(path, master_passphrase, vault_id)?;
+            v.save()?;
+            Ok(v)
+        }
+    }
+
+    /// Re-encrypt the whole tree and write it atomically (the only persistence path).
+    pub fn save(&self) -> Result<()> {
+        let plain = serde_json::to_vec(&self.data).context("serializing vault data")?;
+        let sealed = crypto::seal(&self.master, &plain).map_err(|e| anyhow::anyhow!("seal vault: {e}"))?;
+        let mut out = Vec::with_capacity(21 + sealed.len());
+        out.extend_from_slice(MAGIC);
+        out.push(VERSION);
+        out.extend_from_slice(&self.salt);
+        out.extend_from_slice(&sealed);
+        let tmp = self.path.with_extension("hvlt-tmp");
+        std::fs::write(&tmp, &out).with_context(|| format!("writing {}", tmp.display()))?;
+        std::fs::rename(&tmp, &self.path).with_context(|| format!("installing {}", self.path.display()))?;
+        Ok(())
+    }
+
+    /// The index: what exists and how it's protected — no plaintext.
+    pub fn list(&self) -> Vec<ItemRef> {
+        self.data.items.iter().map(|(name, it)| ItemRef {
+            name: name.clone(),
+            kind: it.kind,
+            protection: it.protection.clone(),
+        }).collect()
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.data.items.contains_key(name)
+    }
+
+    /// Add a `Master`-tier item (readable after the outer unlock).
+    pub fn put_master(&mut self, name: impl Into<String>, kind: ItemKind, bytes: &[u8]) {
+        self.data.items.insert(name.into(), StoredItem {
+            kind, protection: Protection::Master, inner_salt: None, payload: bytes.to_vec(),
+        });
+    }
+
+    /// Add a `Sealed` item, encrypted under an independent credential (not the master key).
+    pub fn put_sealed(&mut self, name: impl Into<String>, kind: ItemKind, bytes: &[u8], cred: &str) -> Result<()> {
+        let salt = crypto::generate_salt();
+        let key = crypto::derive_key(cred, &salt).map_err(|e| anyhow::anyhow!("derive sealed key: {e}"))?;
+        let blob = crypto::seal(&key, bytes).map_err(|e| anyhow::anyhow!("seal item: {e}"))?;
+        self.data.items.insert(name.into(), StoredItem {
+            kind, protection: Protection::Sealed, inner_salt: Some(salt.to_vec()), payload: blob,
+        });
+        Ok(())
+    }
+
+    /// Open an item, returning its plaintext in a **zeroizing** buffer. `Sealed` items
+    /// require the correct `cred`; a wrong/missing credential fails closed.
+    pub fn open_item(&self, name: &str, cred: Option<&str>) -> Result<Zeroizing<Vec<u8>>> {
+        let item = self.data.items.get(name).ok_or_else(|| anyhow::anyhow!("no such item: {name}"))?;
+        match item.protection {
+            Protection::Master => Ok(Zeroizing::new(item.payload.clone())),
+            Protection::Sealed => {
+                let cred = cred.ok_or_else(|| anyhow::anyhow!("item is sealed — a credential is required"))?;
+                let salt = item.inner_salt.as_ref().ok_or_else(|| anyhow::anyhow!("sealed item missing salt (corrupt)"))?;
+                let key = crypto::derive_key(cred, salt).map_err(|e| anyhow::anyhow!("derive sealed key: {e}"))?;
+                let plain = crypto::open(&key, &item.payload)
+                    .map_err(|_| anyhow::anyhow!("sealed item did not open (wrong credential)"))?;
+                Ok(Zeroizing::new(plain))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> (tempfile::TempDir, PathBuf) {
+        let d = tempfile::tempdir().unwrap();
+        let p = d.path().join("t.hvlt");
+        (d, p)
+    }
+
+    #[test]
+    fn master_round_trips_no_plaintext_on_disk() {
+        let (_d, p) = tmp();
+        {
+            let mut v = OpenVault::create(&p, "m", "v1").unwrap();
+            v.put_master("g", ItemKind::Document, b"SECRET_MARKER_XYZ");
+            v.save().unwrap();
+        }
+        let raw = std::fs::read(&p).unwrap();
+        assert_eq!(&raw[..4], b"HVLT");
+        assert!(!raw.windows(17).any(|w| w == b"SECRET_MARKER_XYZ"));
+        let v = OpenVault::open(&p, "m").unwrap();
+        assert_eq!(&v.open_item("g", None).unwrap()[..], b"SECRET_MARKER_XYZ");
+    }
+
+    #[test]
+    fn wrong_master_fails_closed() {
+        let (_d, p) = tmp();
+        OpenVault::create(&p, "right", "v").unwrap().save().unwrap();
+        assert!(OpenVault::open(&p, "wrong").is_err());
+    }
+
+    #[test]
+    fn sealed_needs_the_credential() {
+        let (_d, p) = tmp();
+        {
+            let mut v = OpenVault::create(&p, "m", "v").unwrap();
+            v.put_sealed("k", ItemKind::Credential, b"top-secret", "second-factor").unwrap();
+            v.save().unwrap();
+        }
+        let v = OpenVault::open(&p, "m").unwrap();
+        assert_eq!(v.list()[0].protection, Protection::Sealed);
+        assert!(v.open_item("k", None).is_err());            // master alone: no
+        assert!(v.open_item("k", Some("nope")).is_err());     // wrong cred: no
+        assert_eq!(&v.open_item("k", Some("second-factor")).unwrap()[..], b"top-secret");
+    }
+}


### PR DESCRIPTION
The generic recursive-item enclosure (`vault_tree`: Master/Sealed/Document/SubVault, memory-only zeroizing `open_item`) as a **public** hub-lib module — built on `web4_core::vault::crypto`, no new ciphers; the novel presence/liveness gating stays private. The daemon seeds a protected-tier vault at ignition; on a **granted M-of-N quorum** the `/unlock/attest` path now actually **opens** the Sealed item and returns the released payload (recognition model — quorum authorizes, hub holds the master-tier credential). This is the already-deployed H3 code.

3 vault_tree unit tests. Pairs with the private hub-vault crate (full Liveness) + unlock-core/verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)