### PR TITLE
spec(C71): remediate 6 autonomous C70 findings on registries/ — first delta cycle

### DIFF
--- a/web4-standard/registries/README.md
+++ b/web4-standard/registries/README.md
@@ -1,4 +1,5 @@
 # Web4 Registries
+Status: Draft • Last-Updated: 2026-06-18
 
 ## Overview
 
@@ -13,12 +14,19 @@ These registries define the IANA considerations for Web4 protocol parameters.
 
 ## Registration Process
 
-### Expert Review
-New registrations require expert review as per RFC 8126.
+Registration policies follow [RFC 8126](https://www.rfc-editor.org/rfc/rfc8126).
+Each registry selects a single policy; they are not all universal:
 
-### Specification Required
-Registrations must reference a stable specification.
+| Registry | Registration Policy (RFC 8126) |
+|----------|-------------------------------|
+| cipher-suites.md | Expert Review |
+| error-codes.md | Expert Review |
+| extensions.md | Specification Required |
+| initial-registries.md | N/A — initial seed values, not a registration target |
+
+- **Expert Review**: a designated expert reviews each request before assignment.
+- **Specification Required**: the request must reference a stable, publicly available specification (also implies Expert Review of that specification).
 
 ## Contact
 
-Registry questions: iana-web4@example.org
+Registry questions: TBD-before-IANA-submission

--- a/web4-standard/registries/cipher-suites.md
+++ b/web4-standard/registries/cipher-suites.md
@@ -1,4 +1,5 @@
 # Web4 Cipher Suite Registry
+Status: Draft / experimental — pre-IANA template • Last-Updated: 2026-06-18
 
 ## Registry Name
 Web4 Cipher Suites
@@ -7,7 +8,7 @@ Web4 Cipher Suites
 Expert Review (RFC 8126)
 
 ## Reference
-[Web4 Standard Section X.Y]
+[Web4 Standard, core-spec/core-protocol.md §1 (Cryptographic Suites)](../core-spec/core-protocol.md)
 
 ## Registry Contents
 

--- a/web4-standard/registries/error-codes.md
+++ b/web4-standard/registries/error-codes.md
@@ -1,4 +1,5 @@
 # Web4 Error Code Registry
+Status: Draft / experimental — pre-IANA template • Last-Updated: 2026-06-18
 
 ## Registry Name
 Web4 Error Codes
@@ -7,7 +8,7 @@ Web4 Error Codes
 Expert Review (RFC 8126)
 
 ## Reference
-[Web4 Standard Section X.Y]
+[Web4 Standard, core-spec/errors.md](../core-spec/errors.md)
 
 ## Registry Contents
 

--- a/web4-standard/registries/extensions.md
+++ b/web4-standard/registries/extensions.md
@@ -1,4 +1,5 @@
 # Web4 Extension Registry
+Status: Draft / experimental — pre-IANA template • Last-Updated: 2026-06-18
 
 ## Registry Name
 Web4 Protocol Extensions
@@ -7,7 +8,7 @@ Web4 Protocol Extensions
 Specification Required (RFC 8126)
 
 ## Reference
-[Web4 Standard Section X.Y]
+[Web4 Standard, protocols/web4-handshake.md §5 (Capability & Suite Negotiation)](../protocols/web4-handshake.md)
 
 ## Registry Contents
 

--- a/web4-standard/registries/initial-registries.md
+++ b/web4-standard/registries/initial-registries.md
@@ -2,8 +2,9 @@
 Status: Draft • Last-Updated: 2025-09-11T22:47:56.408268Z
 
 ## Suite IDs
-- W4-BASE-1 : X25519 / Ed25519 / ChaCha20-Poly1305 / SHA-256 (COSE)
-- W4-FIPS-1 : P-256 ECDH / ECDSA-P256 / AES-128-GCM / SHA-256 (JOSE)
+- W4-BASE-1 : X25519 / Ed25519 / ChaCha20-Poly1305 / SHA-256 / HKDF (COSE)
+- W4-FIPS-1 : P-256 ECDH / ECDSA-P256 / AES-128-GCM / SHA-256 / HKDF (JOSE)
+- W4-IOT-1 : X25519 / Ed25519 / AES-CCM / SHA-256 / HKDF (CBOR)
 
 ## Extension IDs (provisional)
 - w4_ext_sdjwt_vp@1


### PR DESCRIPTION
## C71 — Registries Cluster Remediation

Applies the **6 AUTONOMOUS findings** (B-A1..B-A6) from the C70 registries-cluster audit (PR #353, merged `88cb2c5d`). Registries-file-only; gives `web4-standard/registries/` its first full **audit→remediation delta cycle**.

**Held back (not in this PR):**
- **DESIGN-Q** → operator: B-D1 (flagship — registry SSOT inversion: directory ships two parallel disjoint registry systems, README points at the orphan numeric half; recommend Option A = string/named form canonical), B-D2 (numeric error-class scheme), B-D3 (extensions registers core MRH/T3_V3 it forbids).
- **CROSS-TRACK** → sibling-spec owners: B-C1 (errors.md missing live MUST-emit codes `W4_ERR_WITNESS_REQUIRED`/`PROTO_FORMAT`), B-C2/B-C3 (errors/metering), B-C4 (= C68 B-7 suite spelling → security-framework), B-C5/B-C6/B-C7.

### Changes (5 files, +22/−10)
| Finding | File | Change |
|---------|------|--------|
| B-A1 | initial-registries.md | add `W4-IOT-1 : X25519 / Ed25519 / AES-CCM / SHA-256 / HKDF (CBOR)` (verbatim from `core-protocol.md` §1 L20; suite was used-but-undefined in its home registry) |
| B-A2 | cipher-suites / error-codes / extensions | replace `[Web4 Standard Section X.Y]` placeholder References with real targets (→ core-protocol.md §1 / errors.md / web4-handshake.md §5) |
| B-A3 | README.md | contact `iana-web4@example.org` → `TBD-before-IANA-submission` |
| B-A4 | README.md | registration prose → per-registry RFC 8126 policy table |
| B-A5 | all 5 | uniform `Status / Last-Updated` line; numeric files = "Draft / experimental — pre-IANA template" (neutral on B-D1) |
| B-A6 | initial-registries.md | add `HKDF` KDF token to BASE-1/FIPS-1 |

### Deviation noted
B-A2 extensions target: audit routed → `web4-handshake.md §10`, but §10 is **Error Handling**. Extension negotiation is §5 **Capability & Suite Negotiation** — cited §5 rather than propagate the section-number slip.

### Verification
- All 5 relative link targets resolve (`../core-spec/core-protocol.md`, `../core-spec/errors.md`, `../protocols/web4-handshake.md`).
- Corpus sweep: zero `Section X.Y` placeholders remain in `web4-standard/`; only surviving `example.org` ref is the C70 audit doc quoting the finding.
- Scope: `git diff --stat` confirms all changes confined to `registries/`.

### Governance
v2 protocol followed: scope proposed → policy review **APPROVED** first-pass (verified B-A5 wording does not pre-decide B-D1; confirmed no item smuggles a design decision) → executed → documented. Session log: `private-context/autonomous-sessions/legion-web4-20260618-060047-session.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)