### PR TITLE
hub: de-env runtime store opens + McpState shares swappable signer (2-3/8)

### DIFF
--- a/hub/hub-daemon/Cargo.toml
+++ b/hub/hub-daemon/Cargo.toml
@@ -12,6 +12,7 @@ name = "hub"
 path = "src/main.rs"
 
 [dependencies]
+zeroize = "1"
 hub-lib = { path = "../hub-lib" }
 web4-core.workspace = true
 anyhow.workspace = true

--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -352,7 +352,7 @@ async fn council(State(s): State<RestState>) -> Result<Html<String>, AdminError>
     let projected = HubState::project(&*ledger);
     drop(ledger);
     let proposals = {
-        let store = hub_lib::store::open_hub_store(&s.paths.root)
+        let store = s.open_store().await
             .map_err(|e| AdminError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         store.list_proposals().await
             .map_err(|e| AdminError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
@@ -483,8 +483,7 @@ async fn pairs(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
 }
 
 async fn law(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
-    use hub_lib::store::open_hub_store;
-    let store = open_hub_store(&s.paths.root)?;
+        let store = s.open_store().await?;
     let yaml = store.read_law().await?;
 
     let mut body = String::from("<h2>Chapter law</h2>");

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -942,11 +942,21 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
             hub_lib::ledger::HubLedger::open(store).await?,
         ))
     };
-    let mcp_state =
-        McpState::open_with_law_and_ledger(hub_dir.clone(), shared_law.clone(), shared_ledger.clone())
-            .await?;
+    // RestState first — it owns the swappable signer, sovereign id, and derived
+    // store key; McpState shares those (so a single runtime ignition lights up
+    // both surfaces, and McpState constructs even in a locked shell).
     let rest_state =
-        RestState::open_with_law_and_ledger(hub_dir.clone(), shared_law, shared_ledger).await?;
+        RestState::open_with_law_and_ledger(hub_dir.clone(), shared_law.clone(), shared_ledger.clone())
+            .await?;
+    let mcp_state = McpState::open_with_law_and_ledger(
+        hub_dir.clone(),
+        shared_law,
+        shared_ledger,
+        rest_state.signer.clone(),
+        rest_state.sovereign_lct_id,
+        rest_state.store_key.clone(),
+    )
+    .await?;
     // Admin UI reuses RestState (read-only; shares ledger + law snapshot).
     let admin_state = rest_state.clone();
     let app = mcp_router(mcp_state)

--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -39,13 +39,12 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 use web4_core::role::SocietyRole;
 
-use hub_lib::hub::{HubPaths, SovereignMode};
+use hub_lib::hub::HubPaths;
 use hub_lib::events::HubEvent;
-use hub_lib::identity::IdentityFile;
 use hub_lib::init::load_society;
 use hub_lib::law::{Decision, Law, R6Request};
 use hub_lib::ledger::HubLedger;
-use hub_lib::signer::{HestiaCallbackSigner, LocalKeypairSigner, RemoteSigner, SignIntent};
+use hub_lib::signer::{RemoteSigner, SignIntent, SwappableSigner};
 use hub_lib::state::HubState;
 
 #[derive(Clone)]
@@ -54,10 +53,11 @@ pub struct McpState {
     pub hub_id: Uuid,
     pub hub_name: String,
     pub sovereign_lct_id: Uuid,
-    /// Signer abstraction — LocalKeypairSigner for MVP-compat chapters,
-    /// HestiaCallbackSigner for Hestia-mode. MCP handlers route ledger
-    /// signing through this trait, same shape as REST.
-    pub signer: Arc<dyn RemoteSigner>,
+    /// Shared swappable signer (the SAME `Arc<SwappableSigner>` RestState holds).
+    /// MCP handlers route ledger signing through it; runtime ignition swaps the
+    /// LockedSigner → real one once, visible to both surfaces. Also lets McpState
+    /// construct in a locked shell (no `load_auto` of an encrypted identity).
+    pub signer: Arc<SwappableSigner>,
     pub ledger: Arc<Mutex<HubLedger>>,
     /// Chapter law snapshot (loaded at open). PolicyEntity gate runs
     /// before each act-recording tool commits to the ledger.
@@ -66,6 +66,8 @@ pub struct McpState {
     /// any subsequent MCP tool-call picks up the swapped-in law on its
     /// next .read() lock.
     pub law: Arc<tokio::sync::RwLock<Option<Law>>>,
+    /// Shared derived store key (same Arc as RestState) — de-env'd runtime opens.
+    pub store_key: Arc<tokio::sync::RwLock<Option<zeroize::Zeroizing<[u8; 32]>>>>,
 }
 
 impl McpState {
@@ -76,26 +78,21 @@ impl McpState {
     /// this, each surface held its own ledger loaded at startup and only
     /// reconverged on daemon restart — live writes (e.g. a member declaring a
     /// skill via MCP) were invisible to the admin dashboard until then.
+    /// `hub serve` builds RestState first, then constructs McpState sharing
+    /// RestState's `signer`, `sovereign_lct_id`, and `store_key`. McpState no
+    /// longer loads the identity itself — so it constructs cleanly in a locked
+    /// shell, and a single runtime ignition (the signer swap) lights up both
+    /// surfaces.
     pub async fn open_with_law_and_ledger(
         hub_dir: PathBuf,
         law: Arc<tokio::sync::RwLock<Option<Law>>>,
         ledger: Arc<Mutex<HubLedger>>,
+        signer: Arc<SwappableSigner>,
+        sovereign_lct_id: Uuid,
+        store_key: Arc<tokio::sync::RwLock<Option<zeroize::Zeroizing<[u8; 32]>>>>,
     ) -> Result<Self> {
         let paths = HubPaths::new(hub_dir.clone());
-        let config = hub_lib::hub::HubConfig::load(paths.config())?;
         let society = load_society(&hub_dir).await?;
-        let (sovereign_lct_id, signer): (Uuid, Arc<dyn RemoteSigner>) = match config.sovereign.mode()? {
-            SovereignMode::Local { lct_path } => {
-                let sovereign = IdentityFile::load_auto(&lct_path)?;
-                let kp = sovereign.keypair()?;
-                let signer = Arc::new(LocalKeypairSigner::new(sovereign.lct.id, kp));
-                (sovereign.lct.id, signer)
-            }
-            SovereignMode::Hestia { callback_url, lct_id, .. } => {
-                let signer = Arc::new(HestiaCallbackSigner::new(lct_id, callback_url)?);
-                (lct_id, signer)
-            }
-        };
         Ok(Self {
             paths,
             hub_id: society.lct_id,
@@ -104,7 +101,14 @@ impl McpState {
             signer,
             ledger,
             law,
+            store_key,
         })
+    }
+
+    /// De-env'd runtime store open (mirrors `RestState::open_store`).
+    pub async fn open_store(&self) -> Result<Box<dyn hub_lib::store::HubStore>> {
+        let key = self.store_key.read().await.as_ref().map(|z| **z);
+        hub_lib::store::open_hub_store_with_key(&self.paths.root, key)
     }
 }
 
@@ -293,7 +297,7 @@ async fn assign_role(
     // Update the persisted society role-fill (web4-core enforces authority and
     // owns the role LCT), then witness the act in the ledger with that LCT.
     // Without the society update the assignment never showed as filled.
-    let mut store = hub_lib::store::open_hub_store(&s.paths.root)
+    let mut store = s.open_store().await
         .map_err(ApiError::internal)?;
     let mut society = store.read_society().await
         .map_err(ApiError::internal)?

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -107,6 +107,11 @@ pub struct RestState {
     /// passphrase) — there's no master key to open it. Seeded with a demo Sealed item so a
     /// granted quorum has something real to release.
     pub protected: Option<Arc<Mutex<hub_lib::vault_tree::OpenVault>>>,
+    /// The derived SQLCipher key for the state store, held in memory (zeroized on
+    /// drop) — the de-env'd replacement for reading `HUB_PASSPHRASE` from the
+    /// environment on every runtime store re-open. `None` while locked. Set once
+    /// at ignition; shared with `McpState`.
+    pub store_key: Arc<tokio::sync::RwLock<Option<zeroize::Zeroizing<[u8; 32]>>>>,
 }
 
 /// An in-flight tier-2 unlock: the minted challenge + the roster/threshold
@@ -268,7 +273,26 @@ impl RestState {
             unlock_verifier_cmd: std::env::var("HUB_UNLOCK_VERIFIER").ok().filter(|s| !s.is_empty()),
             unlock_sessions: Arc::new(Mutex::new(std::collections::HashMap::new())),
             protected: open_protected_store(&hub_dir),
+            // Derive + hold the store key in memory (env-fed at construction for now;
+            // ignition will set it from a transient passphrase — increment 6). Never
+            // re-read from env at runtime.
+            store_key: Arc::new(tokio::sync::RwLock::new(
+                match hub_lib::identity::env_passphrase() {
+                    Some(p) => hub_lib::store::derive_store_key(&hub_dir, &p)
+                        .ok()
+                        .map(zeroize::Zeroizing::new),
+                    None => None,
+                },
+            )),
         })
+    }
+
+    /// Open the state store using the in-memory derived key (de-env'd). Used for
+    /// every runtime store re-open instead of reading `HUB_PASSPHRASE` from the
+    /// environment.
+    pub async fn open_store(&self) -> anyhow::Result<Box<dyn hub_lib::store::HubStore>> {
+        let key = self.store_key.read().await.as_ref().map(|z| **z);
+        hub_lib::store::open_hub_store_with_key(&self.paths.root, key)
     }
 
     /// Re-read the chapter law from storage and swap it into the
@@ -278,7 +302,7 @@ impl RestState {
     /// restarting hub serve.
     pub async fn reload_law(&self) -> anyhow::Result<String> {
         use anyhow::Context;
-        let store = hub_lib::store::open_hub_store(&self.paths.root)
+        let store = self.open_store().await
             .context("opening store for law reload")?;
         let new_law: Option<Law> = match store.read_law().await? {
             Some(ref yaml) => Some(Law::parse_and_validate(yaml)
@@ -2604,21 +2628,21 @@ async fn get_proposal(
 // awaits here.
 
 async fn persist_proposal(s: &RestState, proposal: &CouncilProposal) -> Result<(), ApiError> {
-    let mut store = hub_lib::store::open_hub_store(&s.paths.root)
+    let mut store = s.open_store().await
         .map_err(ApiError::internal)?;
     store.write_proposal(proposal).await
         .map_err(ApiError::internal)
 }
 
 async fn read_proposal(s: &RestState, id: Uuid) -> Result<Option<CouncilProposal>, ApiError> {
-    let store = hub_lib::store::open_hub_store(&s.paths.root)
+    let store = s.open_store().await
         .map_err(ApiError::internal)?;
     store.read_proposal(id).await
         .map_err(ApiError::internal)
 }
 
 async fn read_all_proposals(s: &RestState) -> Result<Vec<CouncilProposal>, ApiError> {
-    let store = hub_lib::store::open_hub_store(&s.paths.root)
+    let store = s.open_store().await
         .map_err(ApiError::internal)?;
     store.list_proposals().await
         .map_err(ApiError::internal)
@@ -3192,7 +3216,7 @@ async fn post_pair_message(
         ephemeral_pub_hex: None,
     };
     {
-        let mut store = hub_lib::store::open_hub_store(&s.paths.root)
+        let mut store = s.open_store().await
             .map_err(ApiError::internal)?;
         store.append_pair_message(&msg).await
             .map_err(ApiError::internal)?;
@@ -3251,7 +3275,7 @@ async fn get_pair_messages(
             return Err(ApiError::not_found(format!("pair {} not found", pair_id)));
         }
     }
-    let store = hub_lib::store::open_hub_store(&s.paths.root)
+    let store = s.open_store().await
         .map_err(ApiError::internal)?;
     let messages = store.list_pair_messages(pair_id, q.since).await
         .map_err(ApiError::internal)?;


### PR DESCRIPTION
Increments 2-3 of the locked-shell ignition build. RestState holds the derived store key in memory (de-env'd runtime opens via open_store); McpState shares RestState's swappable signer + key + sovereign id and drops its own load_auto so it constructs in a locked shell. No behavior change yet (env-fed at construction). 19 daemon tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)