### PR TITLE
hub: fix query_hub on ignited locked-shell hub (post-#358 regression)

### DIFF
--- a/hub/Cargo.lock
+++ b/hub/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "web4-core",
+ "zeroize",
 ]
 
 [[package]]
@@ -1386,6 +1387,7 @@ dependencies = [
  "uuid",
  "web4-core",
  "web4-trust-core",
+ "zeroize",
 ]
 
 [[package]]

--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -41,7 +41,6 @@ use web4_core::role::SocietyRole;
 
 use hub_lib::hub::HubPaths;
 use hub_lib::events::HubEvent;
-use hub_lib::init::load_society;
 use hub_lib::law::{Decision, Law, R6Request};
 use hub_lib::ledger::HubLedger;
 use hub_lib::signer::{RemoteSigner, SignIntent, SwappableSigner};
@@ -199,7 +198,15 @@ struct QueryHubResponse {
 async fn query_hub(State(s): State<McpState>) -> Result<Json<QueryHubResponse>, ApiError> {
     let ledger = s.ledger.lock().await;
     let state = HubState::project(&ledger);
-    let society = load_society(s.paths.root.clone()).await?;
+    // Read the society via the shared store handle so the in-memory `store_key`
+    // (populated at runtime ignition, then the passphrase is dropped) decrypts
+    // an at-rest vault. The free `load_society(root)` opens the store WITHOUT a
+    // key and so fails post-ignition on an encrypted store — see the locked-shell
+    // note on `open_with_law_and_ledger`. `assign_role` already uses this path.
+    let store = s.open_store().await.map_err(ApiError::internal)?;
+    let society = store.read_society().await
+        .map_err(ApiError::internal)?
+        .ok_or_else(|| ApiError::internal(anyhow::anyhow!("no society found in hub store")))?;
     let role_fill: HashMap<String, Uuid> = society.roles.iter()
         .map(|(k, v)| (k.clone(), v.filling_entity_lct_id))
         .collect();


### PR DESCRIPTION
## Live-hub regression found this supervisor run

On the running Web4 Fleet hub (commit ad95fc2 / #358), `GET /tools/query_hub` returns:

> `opening hub store: hub state at .../hub.db is encrypted but no HUB_PASSPHRASE is set — set the vault passphrase to open it (the state needs tier-1 ignition)`

…even though the daemon **ignited successfully** at boot (journal: *"HUB IGNITED via passphrase — identity + state store + protected tier opened into memory; passphrase dropped, never stored"*) and `GET /tools/list_members` / `find_skill` work fine.

## Root cause

- `list_members` / `find_skill` read only the in-memory ledger projection → work.
- `query_hub` additionally read the society via the free function `load_society(root)`, which calls `open_hub_store(root)` **without a key**. On an at-rest encrypted vault that fails.
- The store key derived at ignition is held in memory as `store_key` and is only threaded through `McpState::open_store()`. `assign_role` already opens the store the right way; `query_hub` did not.
- The locked-shell constructor note (`mcp.rs`) already warns *"No load_society here — it reads the (encrypted) store and would fail in a locked shell"* — but the `query_hub` handler still called it.

## Fix

`query_hub` now reads the society via `s.open_store()` (the ignited-key path), matching `assign_role`. Removes the now-unused `load_society` import. Also commits the `zeroize` `Cargo.lock` entries that #358 left uncommitted.

## Verification

- `cargo build --release` clean (one pre-existing unrelated warning).
- `cargo test -p hub-lib -p hub-daemon` → **hub-lib 153 / hub-daemon 19 pass**.

## Deploy note

The live hub is currently **ignited** (tier-1 reads work except query_hub). Restarting onto this binary boots the locked shell and requires dp to re-run `hub unlock` (passphrase is deliberately not stored). So deployment must be coordinated with dp — not done autonomously this run. Forum note posted to dp/hub-track.

Machine: HUB · AI-Instance: claude-opus-4-8 (Claude Code) · Human-Supervised: no