### PR TITLE
spec(C79): remediate 5 autonomous C78 findings on core-spec/atp-adp-cycle.md

### DIFF
--- a/docs/audits/C78-atp-adp-cycle-delta-audit-2026-06-20.md
+++ b/docs/audits/C78-atp-adp-cycle-delta-audit-2026-06-20.md
@@ -122,6 +122,8 @@ The References block (L737-752) lists r6/r7, t3-v3, LCT, society-roles, SOCIETY_
 
 **Autonomous remediation set (next remediation turn, C79-candidate)**: B2a, B5, B6 (spec leg), B7, B8 — 5 spec-only AUTONOMOUS edits. B1/B2b/M2/ISP-B10 await operator; B3/B4/I2/B6-SDK ride the SDK track.
 
+> **REMEDIATED in C79** (PR pending, `worker/web4-20260620-180009`): all 5 autonomous findings applied to `atp-adp-cycle.md` (+42/−2). **B2a** — §3.3 R6-scoping note (demurrage is a time-triggered, non-R6 carve-out from MUST #5). **B5** — `mint_adp` harmonized to §3.1 nested form (`state_distribution.ADP` + `allocations.circulating`), preserving both pool invariants. **B6-spec** — §3.1 metric `charge_rate`→`charged_fraction` (full-file sweep; §2.2/§6 conversion-multiplier sites deliberately left). **B7** — ISP + mcp added to §5 inline pointer + References. **B8** — §4.3 role-vocabulary note aligning cascade levels to §2.3 and seating the primary_beneficiary outside the contribution cascade (no % / tensor-delta changes). atp-adp C34→#277→C78→C79 cycle COMPLETE for the autonomous set.
+
 ---
 
 ## §D — Lessons / Method Notes

--- a/web4-standard/core-spec/atp-adp-cycle.md
+++ b/web4-standard/core-spec/atp-adp-cycle.md
@@ -237,7 +237,7 @@ Each society maintains token pools:
     },
     "metrics": {
       "velocity": 4.2,  // Cycles per period
-      "charge_rate": 0.15,  // ATP/(ATP+ADP): fraction of supply charged
+      "charged_fraction": 0.15,  // ATP/(ATP+ADP): fraction of supply currently charged (state ratio; distinct from the §2.2/§6 conversion-multiplier `charge_rate`)
       "decay_rate": 0.001,  // Per period
       "efficiency": 0.91  // Value preserved
     }
@@ -261,7 +261,11 @@ class SocietyTokenPool:
         if not self.law.permits_minting(authority, amount):
             raise UnauthorizedMinting()
         
-        self.pools['ADP'] += amount
+        # Pool keys follow the §3.1 nested architecture: minted ADP enters the
+        # discharged state distribution and the circulating allocation, keeping
+        # `total_supply` == sum(allocations) and == sum(state_distribution).
+        self.pools['state_distribution']['ADP'] += amount
+        self.pools['allocations']['circulating'] += amount
         self.pools['total_supply'] += amount
         
         return MintingReceipt(amount, justification)
@@ -315,6 +319,16 @@ def apply_demurrage_decay(entity_stakes):
                 t3_delta={"temperament": -0.01}
             )
 ```
+
+> **R6 scoping.** Demurrage performs the ATP→ADP discharge of §2.3, but it is
+> **time-triggered and not an R6 transaction** — it fires automatically once a
+> stake passes the demurrage threshold, with no R6 Request/Result. It is
+> therefore a carve-out from §7.1 MUST #5 ("Discharging MUST occur through R6
+> transactions"), in the same way slashing (§2.4) is a carve-out from the
+> transfer-conservation invariant: MUST #5 scopes *value-spending* discharge,
+> while demurrage is a *maintenance* discharge enforcing anti-hoarding. The
+> hoarding-penalty tensor delta above is the only T3/V3 effect; demurrage
+> creates no V3 value and so does not engage MUST #6.
 
 ## 4. Value Creation and Tracking
 
@@ -401,7 +415,28 @@ The percentages shown are **illustrative defaults**, not protocol constants.
 Societies SHOULD define attribution rates in their economic laws (see §6.2 on
 economic laws). Implementations MUST NOT hard-code these values.
 
+> **Role vocabulary (aligns with §2.3).** The cascade levels use these roles:
+> *Direct executor* (Level 1) is the entity that performs the work — the §2.3
+> `executor` (the acting agent). *Agent/delegator* (Level 2) is an intermediary
+> that appears **only in a delegation chain**; in the simple §2.3 example the
+> executor acts directly for the client, so Level 2 is empty. The **primary
+> beneficiary** (§2.3 `primary_beneficiary`, the client) is the value
+> *recipient*, not a contributor, and therefore sits **outside** this
+> contribution-attribution cascade: its tensor delta — the largest in the
+> example (§4.2, `valuation +0.05`) — is a *value-receipt* update on the
+> consumer of the work, distinct from the contribution shares the cascade
+> distributes. Keeping the beneficiary out of the cascade is why the attribution
+> percentages sum over contributors only and are unaffected by it.
+
 ## 5. Inter-Society Currency Exchange
+
+> **Inter-society homes.** Cross-society settlement is also governed by
+> `inter-society-protocol.md` (which declares `Extends: atp-adp-cycle.md` for the
+> ATP form) and `mcp-protocol.md` (the inter-society protocol; §7.7 covers
+> cross-society exchange-rate negotiation). The exchange mechanisms in §5.2/§5.3
+> describe society-level currency-pair bookkeeping; how rates are *grounded* and
+> negotiated across societies is owned by those specs and is being reconciled
+> with them (see References).
 
 ### 5.1 Society Membership and Currency
 
@@ -749,5 +784,10 @@ This specification cross-references the following Web4 core specs:
   identifiers used throughout (societies, entities, witnesses).
 - **Societies and roles** — `society-roles.md` and `SOCIETY_SPECIFICATION.md`
   for pool governance, monetary authority, and role-scoped economic law.
+- **Inter-society settlement** — `inter-society-protocol.md` (declares
+  `Extends: atp-adp-cycle.md` for the ATP form; §4 covers unit-of-account
+  semantics and ADP minting) and `mcp-protocol.md` (the inter-society protocol;
+  §7.7 covers referent-grounded cross-society exchange-rate negotiation) for the
+  cross-society exchange described in §5.
 
 *"In Web4, value flows like energy through living systems—constantly cycling, never hoarded, always creating."*


### PR DESCRIPTION
## C79 — atp-adp-cycle remediation

Remediation turn applying the **5 spec-only AUTONOMOUS findings** the C78 delta re-audit ([PR #367](https://github.com/dp-web4/web4/pull/367), merged `3e3883f0`) routed here. Single file edit, +42/−2. Completes the **atp-adp C34 → #277 → C78 → C79** cycle for the autonomous set.

### Applied (per C78 §C routing table)
| ID | Finding | Edit |
|----|---------|------|
| **B2a** | demurrage (§3.3) discharges ATP→ADP outside R6, conflicting §7.1 MUST #5 | Added R6-scoping note: demurrage is a time-triggered, non-R6 *maintenance* discharge — a carve-out from MUST #5 (parallel to the §2.4 slashing note). |
| **B5** | §3.2 `mint_adp` uses flat keys vs §3.1 nested `state_distribution.ADP` | Harmonized to nested form; also credits `allocations.circulating` so both pool invariants (Σstate == total_supply, Σalloc == total_supply) hold post-mint. |
| **B6** | `charge_rate` denotes ≥2 quantities (state ratio vs conversion multiplier) | Renamed the §3.1 **state-ratio** metric → `charged_fraction`. Full-file sweep: §2.2/§6 conversion-multiplier sites (`set_charge_rates`) deliberately **left** as `charge_rate`. |
| **B7** | References/§5 omit the inter-society homes despite ISP `Extends: atp-adp-cycle.md` | Added `inter-society-protocol.md` + `mcp-protocol.md` to a §5 inline pointer and the References block. |
| **B8** | executor role taxonomy collides §2.3↔§4.3; cascade has no beneficiary slot | Added a §4.3 role-vocabulary note aligning cascade levels to §2.3 and seating `primary_beneficiary` **outside** the contribution cascade (value-recipient ≠ contributor). No %/tensor-delta changes. |

### Out of scope (correctly deferred)
- **Operator DESIGN-Q**: B1 (FLAGSHIP — §5 abstract-FX vs mcp §7.7.1 normative referent-grounding reframe), B2b (exchange exempt from value-create MUSTs?), M2 (slashing authority cap binding), ISP-B10.
- **SDK track**: B3 (`atp.py:4` "canonical impl" overclaim), B4 (`recharge` ungated), I2 ("three sub-pools" wording), B6-SDK (`energy_ratio` alias note).

### Policy review
Subagent reviewer **APPROVED** first-pass with two non-blocking method conditions, both honored: (1) deliberate full-file `charge_rate` disambiguation (only the §3.1 metric renamed); (2) B8 leaves all §4.2/§4.3 tensor/cascade math untouched.

### Verification
Markdown spec edits (no tests). `charge_rate` sweep confirmed disambiguation; §3.1 pool-invariant arithmetic re-derived by hand (example: Σstate=100M=total, Σalloc=100M=total; mint adds `amount` to all three → invariants preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)