### PR TITLE
web4-core: time/events axis (Thor) + Act primitive (CBP) — reference impls

### DIFF
--- a/web4-core/src/act.rs
+++ b/web4-core/src/act.rs
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 MetaLINXX Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! # Acts: the unifying primitive for memory, forum posts, and handoffs
+//!
+//! CBP's insight (forum 2026-06-20, "Fleet as a Web4 society"): a memory write,
+//! a forum post, and a session handoff are **the same primitive** — an entity
+//! externalizing a *witnessed act* into a ledger, addressed across the MRH:
+//!
+//! - a **memory write** is an act to your *future self* — the **temporal** MRH;
+//! - a **handoff** is an act to a *peer* — the **lateral** MRH;
+//! - a **forum post** is an act to the *society* — the **broad** MRH.
+//!
+//! ## Thin governance record, fat substance
+//!
+//! Web4 *governs* the work; it does not *become* the work. So an [`Act`] is a
+//! **thin** record — who/whom, MRH direction, consequence class, witness marks —
+//! that **points at** the fat substance (the actual forum prose, git commit, or
+//! memory file) via a [`SubstanceRef`]. The substance stays where it already
+//! lives (forum, git, disk); the ledger just holds the accountable pointer.
+//!
+//! This keeps Phase 1 purely additive: mint an Act *alongside* the existing
+//! free-text artifact, change no behavior, and gain a witnessed, trust-bearing
+//! governance trail.
+//!
+//! Witnessing here is the **flat** [`WitnessAttestation`] (a single entity
+//! attesting it observed the act). The recursive witness-tree is intentionally
+//! *not* modeled in this open crate.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::r6::WitnessAttestation;
+use crate::v3::TrustValueScore;
+use crate::{TrustDimension, ValueDimension};
+
+/// What kind of substance an act points at (advisory; the `uri` is canonical).
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SubstanceMedium {
+    /// A forum thread/post.
+    Forum,
+    /// A git commit / blob / PR.
+    Git,
+    /// A persisted memory file.
+    Memory,
+    /// A document / spec.
+    Doc,
+    /// A direct message.
+    Message,
+    Other,
+}
+
+/// A pointer to the *fat substance* an [`Act`] governs. The act is the thin
+/// record; this binds it to a specific version of the real content.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubstanceRef {
+    /// Locator of the substance (git commit hash, forum path, URL, file path).
+    pub uri: String,
+    /// Content hash binding the act to a specific *version* of the substance,
+    /// so the governance record can't silently drift from what it attests.
+    pub content_hash: String,
+    /// What medium the substance lives in.
+    pub medium: SubstanceMedium,
+}
+
+impl SubstanceRef {
+    pub fn new(uri: impl Into<String>, content_hash: impl Into<String>, medium: SubstanceMedium) -> Self {
+        Self { uri: uri.into(), content_hash: content_hash.into(), medium }
+    }
+}
+
+/// The MRH direction an act is addressed across — *who the future reader is*.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MrhDirection {
+    /// To your future self — a memory write (temporal MRH).
+    Temporal,
+    /// To a peer — a handoff (lateral MRH).
+    Lateral,
+    /// To the society at large — a forum post (broad MRH).
+    Broad,
+}
+
+/// How reversible an act's effect is — gates ATP staking and witnessing.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsequenceClass {
+    /// Freely undoable (a memory note, a draft).
+    #[default]
+    Reversible,
+    /// Undoable at a cost (a forum post others may have read).
+    Costly,
+    /// Cannot be undone (a merge to main, a published release).
+    Irreversible,
+}
+
+impl ConsequenceClass {
+    fn scale(self) -> f64 {
+        match self {
+            ConsequenceClass::Reversible => 0.5,
+            ConsequenceClass::Costly => 1.0,
+            ConsequenceClass::Irreversible => 2.0,
+        }
+    }
+}
+
+/// A thin, witnessed governance record of an entity externalizing work — the
+/// unifying primitive behind memory writes, handoffs, and forum posts.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Act {
+    pub act_id: Uuid,
+    /// The acting entity (the LCT that externalized the act).
+    pub actor_lct: Uuid,
+    /// The addressee, when the act is directed at a specific peer (a handoff).
+    /// `None` for temporal-self (memory) and broad (forum) acts.
+    #[serde(default)]
+    pub audience: Option<Uuid>,
+    /// Which way across the MRH this act reaches.
+    pub direction: MrhDirection,
+    /// How reversible the act's effect is.
+    pub consequence: ConsequenceClass,
+    /// Pointer to the fat substance this act governs.
+    pub substance: SubstanceRef,
+    /// Flat witness marks — entities attesting they observed the act.
+    #[serde(default)]
+    pub witnesses: Vec<WitnessAttestation>,
+    pub at: DateTime<Utc>,
+}
+
+impl Act {
+    /// A **memory write** — an act to your future self (temporal MRH).
+    pub fn memory(actor_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
+        Self::new(actor_lct, None, MrhDirection::Temporal, substance, at)
+    }
+
+    /// A **handoff** — an act to a peer (lateral MRH).
+    pub fn handoff(actor_lct: Uuid, peer_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
+        Self::new(actor_lct, Some(peer_lct), MrhDirection::Lateral, substance, at)
+    }
+
+    /// A **forum post** — an act to the society (broad MRH).
+    pub fn forum(actor_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
+        Self::new(actor_lct, None, MrhDirection::Broad, substance, at)
+    }
+
+    fn new(
+        actor_lct: Uuid,
+        audience: Option<Uuid>,
+        direction: MrhDirection,
+        substance: SubstanceRef,
+        at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            act_id: Uuid::new_v4(),
+            actor_lct,
+            audience,
+            direction,
+            consequence: ConsequenceClass::default(),
+            substance,
+            witnesses: Vec::new(),
+            at,
+        }
+    }
+
+    pub fn with_consequence(mut self, c: ConsequenceClass) -> Self {
+        self.consequence = c;
+        self
+    }
+
+    pub fn witnessed_by(mut self, attestation: WitnessAttestation) -> Self {
+        self.witnesses.push(attestation);
+        self
+    }
+
+    /// Whether this act must carry an ATP stake before it's admissible. The
+    /// gate is on irreversibility: you stake energy on acts you can't take back.
+    pub fn requires_atp_stake(&self) -> bool {
+        matches!(self.consequence, ConsequenceClass::Costly | ConsequenceClass::Irreversible)
+    }
+
+    /// Whether this act must be witnessed to be admissible (irreversibles must).
+    pub fn requires_witness(&self) -> bool {
+        matches!(self.consequence, ConsequenceClass::Irreversible)
+    }
+
+    /// Fold this act's realized [`ActOutcome`] into the actor's
+    /// [`EntityTrust`] — "EntityTrust fed by act-outcomes". A fulfilled act
+    /// builds Validity/Veracity; a failed one debits them; the consequence
+    /// class scales the magnitude (more is staked on irreversibles, so the
+    /// trust swing is larger). Returns the realized (validity, veracity) deltas.
+    pub fn record_outcome(&self, trust: &mut TrustValueScore, outcome: ActOutcome) -> (f64, f64) {
+        let s = self.consequence.scale();
+        let (validity, veracity) = match outcome {
+            ActOutcome::Fulfilled => (0.03 * s, 0.02 * s),
+            ActOutcome::Failed => (-0.05 * s, -0.03 * s),
+            ActOutcome::Disputed => (0.0, -0.04 * s),
+        };
+        // A fulfilled act is also a small Temperament signal (consistency).
+        if matches!(outcome, ActOutcome::Fulfilled) {
+            trust.trust.apply_delta(TrustDimension::Temperament, 0.01 * s);
+        }
+        let dv = trust.value.apply_delta(ValueDimension::Validity, validity);
+        let dver = trust.value.apply_delta(ValueDimension::Veracity, veracity);
+        (dv, dver)
+    }
+}
+
+/// The realized outcome of an act, once witnessed/evaluated. Feeds EntityTrust.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActOutcome {
+    /// The act achieved its stated effect (the substance landed as claimed).
+    Fulfilled,
+    /// The act's effect failed or was reverted.
+    Failed,
+    /// A witness disputes the act's claim.
+    Disputed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-20T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn sref() -> SubstanceRef {
+        SubstanceRef::new("git:abc123", "deadbeef", SubstanceMedium::Git)
+    }
+
+    #[test]
+    fn three_framings_share_one_primitive() {
+        let me = Uuid::new_v4();
+        let peer = Uuid::new_v4();
+        assert_eq!(Act::memory(me, sref(), now()).direction, MrhDirection::Temporal);
+        assert_eq!(Act::handoff(me, peer, sref(), now()).direction, MrhDirection::Lateral);
+        assert_eq!(Act::forum(me, sref(), now()).direction, MrhDirection::Broad);
+        // The handoff is the only one addressed to a specific peer.
+        assert_eq!(Act::handoff(me, peer, sref(), now()).audience, Some(peer));
+        assert_eq!(Act::memory(me, sref(), now()).audience, None);
+    }
+
+    #[test]
+    fn irreversible_acts_gate_on_atp_and_witness() {
+        let a = Act::forum(Uuid::new_v4(), sref(), now())
+            .with_consequence(ConsequenceClass::Irreversible);
+        assert!(a.requires_atp_stake());
+        assert!(a.requires_witness());
+
+        let m = Act::memory(Uuid::new_v4(), sref(), now()); // default Reversible
+        assert!(!m.requires_atp_stake());
+        assert!(!m.requires_witness());
+    }
+
+    #[test]
+    fn fulfilled_act_builds_entity_trust() {
+        let actor = Uuid::new_v4();
+        let mut trust = TrustValueScore::new(actor);
+        let before = trust.value.score(ValueDimension::Validity);
+        let act = Act::handoff(actor, Uuid::new_v4(), sref(), now())
+            .with_consequence(ConsequenceClass::Costly);
+        let (dv, _) = act.record_outcome(&mut trust, ActOutcome::Fulfilled);
+        assert!(dv > 0.0);
+        assert!(trust.value.score(ValueDimension::Validity) > before);
+    }
+
+    #[test]
+    fn failed_irreversible_costs_more_than_reversible() {
+        let actor = Uuid::new_v4();
+        let mut t_irrev = TrustValueScore::new(actor);
+        let mut t_rev = TrustValueScore::new(actor);
+        let irrev = Act::forum(actor, sref(), now()).with_consequence(ConsequenceClass::Irreversible);
+        let rev = Act::forum(actor, sref(), now()).with_consequence(ConsequenceClass::Reversible);
+        let (di, _) = irrev.record_outcome(&mut t_irrev, ActOutcome::Failed);
+        let (dr, _) = rev.record_outcome(&mut t_rev, ActOutcome::Failed);
+        assert!(di < dr, "an irreversible failure debits Validity more steeply");
+    }
+
+    #[test]
+    fn witness_marks_attach() {
+        let w = WitnessAttestation {
+            lct: "witness-lct".into(),
+            attestation: "verified".into(),
+            signature: "sig".into(),
+            timestamp: now(),
+        };
+        let a = Act::forum(Uuid::new_v4(), sref(), now()).witnessed_by(w);
+        assert_eq!(a.witnesses.len(), 1);
+    }
+
+    #[test]
+    fn substance_ref_round_trips() {
+        let a = Act::memory(Uuid::new_v4(), sref(), now());
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Act = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}

--- a/web4-core/src/act.rs
+++ b/web4-core/src/act.rs
@@ -71,15 +71,49 @@ impl SubstanceRef {
     }
 }
 
-/// The MRH direction an act is addressed across — *who the future reader is*.
+/// Where an act is addressed — the recipient **and** its MRH relevance horizon
+/// in one typed field: "the MRH scope *is* the addressing" (HUB). This mirrors
+/// the hub-track `HubEvent::ReferencedAct { to: ActAddress, .. }` so the core
+/// act and the hub envelope agree on the recipient model. A hub→citizen
+/// notification is just this act reversed (`from = hub, to = Citizen`).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "to")]
+pub enum ActAddress {
+    /// Another instance of the plural self (next wake / post-compaction) — a
+    /// memory write. MRH = temporal.
+    FutureSelf { entity: Uuid },
+    /// A peer cell (machine/track LCT) — a handoff. MRH = lateral.
+    Peer { lct_id: Uuid },
+    /// A specific citizen of this society — the notification case
+    /// (hub→citizen). MRH = lateral.
+    Citizen { lct_id: Uuid },
+    /// A role; fans out to its current holders. MRH = broad.
+    Role { role: String },
+    /// The society at large — a forum post. (Contributed back: HUB's draft has
+    /// no all-citizens variant; forum-to-everyone isn't `Role` fan-out.)
+    Society { lct_id: Uuid },
+}
+
+impl ActAddress {
+    /// The coarse MRH axis this address reaches across.
+    pub fn mrh_direction(&self) -> MrhDirection {
+        match self {
+            ActAddress::FutureSelf { .. } => MrhDirection::Temporal,
+            ActAddress::Peer { .. } | ActAddress::Citizen { .. } => MrhDirection::Lateral,
+            ActAddress::Role { .. } | ActAddress::Society { .. } => MrhDirection::Broad,
+        }
+    }
+}
+
+/// The coarse MRH axis an act reaches across (derived from [`ActAddress`]).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MrhDirection {
     /// To your future self — a memory write (temporal MRH).
     Temporal,
-    /// To a peer — a handoff (lateral MRH).
+    /// To a peer or a citizen — a handoff / notification (lateral MRH).
     Lateral,
-    /// To the society at large — a forum post (broad MRH).
+    /// To a role or the society at large — a forum post (broad MRH).
     Broad,
 }
 
@@ -104,6 +138,16 @@ impl ConsequenceClass {
             ConsequenceClass::Irreversible => 2.0,
         }
     }
+
+    /// Whether an act of this class must carry a council `proposal_ref` (M-of-N
+    /// authorization) to be admissible. This is the bridge to HUB's gate: HUB's
+    /// `High` consequence == our `Irreversible` (the act you can't take back is
+    /// the one that needs council sign-off). Reversibility is the actor-assessable
+    /// *property*; the council requirement is the governance *response* derived
+    /// from it. (Phase 1 records the class; Phase 4 enforces the gate.)
+    pub fn requires_council(self) -> bool {
+        matches!(self, ConsequenceClass::Irreversible)
+    }
 }
 
 /// A thin, witnessed governance record of an entity externalizing work — the
@@ -111,14 +155,12 @@ impl ConsequenceClass {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Act {
     pub act_id: Uuid,
-    /// The acting entity (the LCT that externalized the act).
+    /// The acting entity — the **from**. Rides in the payload; the ledger
+    /// envelope's signer may differ (HUB's identity bridge: the machine/track
+    /// LCT signs the envelope, an arc-LCT is `actor_lct` here).
     pub actor_lct: Uuid,
-    /// The addressee, when the act is directed at a specific peer (a handoff).
-    /// `None` for temporal-self (memory) and broad (forum) acts.
-    #[serde(default)]
-    pub audience: Option<Uuid>,
-    /// Which way across the MRH this act reaches.
-    pub direction: MrhDirection,
+    /// Recipient + MRH relevance horizon, in one field.
+    pub address: ActAddress,
     /// How reversible the act's effect is.
     pub consequence: ConsequenceClass,
     /// Pointer to the fat substance this act governs.
@@ -132,31 +174,31 @@ pub struct Act {
 impl Act {
     /// A **memory write** — an act to your future self (temporal MRH).
     pub fn memory(actor_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
-        Self::new(actor_lct, None, MrhDirection::Temporal, substance, at)
+        Self::addressed(actor_lct, ActAddress::FutureSelf { entity: actor_lct }, substance, at)
     }
 
     /// A **handoff** — an act to a peer (lateral MRH).
     pub fn handoff(actor_lct: Uuid, peer_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
-        Self::new(actor_lct, Some(peer_lct), MrhDirection::Lateral, substance, at)
+        Self::addressed(actor_lct, ActAddress::Peer { lct_id: peer_lct }, substance, at)
     }
 
-    /// A **forum post** — an act to the society (broad MRH).
-    pub fn forum(actor_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
-        Self::new(actor_lct, None, MrhDirection::Broad, substance, at)
+    /// A **forum post** — an act to the society at large (broad MRH).
+    pub fn forum(actor_lct: Uuid, society_lct: Uuid, substance: SubstanceRef, at: DateTime<Utc>) -> Self {
+        Self::addressed(actor_lct, ActAddress::Society { lct_id: society_lct }, substance, at)
     }
 
-    fn new(
+    /// The general constructor — any [`ActAddress`] (incl. the hub→`Citizen`
+    /// notification case and `Role` fan-out).
+    pub fn addressed(
         actor_lct: Uuid,
-        audience: Option<Uuid>,
-        direction: MrhDirection,
+        address: ActAddress,
         substance: SubstanceRef,
         at: DateTime<Utc>,
     ) -> Self {
         Self {
             act_id: Uuid::new_v4(),
             actor_lct,
-            audience,
-            direction,
+            address,
             consequence: ConsequenceClass::default(),
             substance,
             witnesses: Vec::new(),
@@ -172,6 +214,11 @@ impl Act {
     pub fn witnessed_by(mut self, attestation: WitnessAttestation) -> Self {
         self.witnesses.push(attestation);
         self
+    }
+
+    /// The coarse MRH axis this act reaches across (derived from its address).
+    pub fn mrh_direction(&self) -> MrhDirection {
+        self.address.mrh_direction()
     }
 
     /// Whether this act must carry an ATP stake before it's admissible. The
@@ -235,20 +282,35 @@ mod tests {
     fn three_framings_share_one_primitive() {
         let me = Uuid::new_v4();
         let peer = Uuid::new_v4();
-        assert_eq!(Act::memory(me, sref(), now()).direction, MrhDirection::Temporal);
-        assert_eq!(Act::handoff(me, peer, sref(), now()).direction, MrhDirection::Lateral);
-        assert_eq!(Act::forum(me, sref(), now()).direction, MrhDirection::Broad);
+        let soc = Uuid::new_v4();
+        // One primitive, differing only in MRH-as-addressing.
+        assert_eq!(Act::memory(me, sref(), now()).mrh_direction(), MrhDirection::Temporal);
+        assert_eq!(Act::handoff(me, peer, sref(), now()).mrh_direction(), MrhDirection::Lateral);
+        assert_eq!(Act::forum(me, soc, sref(), now()).mrh_direction(), MrhDirection::Broad);
         // The handoff is the only one addressed to a specific peer.
-        assert_eq!(Act::handoff(me, peer, sref(), now()).audience, Some(peer));
-        assert_eq!(Act::memory(me, sref(), now()).audience, None);
+        assert_eq!(Act::handoff(me, peer, sref(), now()).address, ActAddress::Peer { lct_id: peer });
+        assert_eq!(Act::memory(me, sref(), now()).address, ActAddress::FutureSelf { entity: me });
     }
 
     #[test]
-    fn irreversible_acts_gate_on_atp_and_witness() {
-        let a = Act::forum(Uuid::new_v4(), sref(), now())
+    fn citizen_notification_is_the_act_reversed() {
+        // HUB's insight: a hub→citizen notification is the same primitive,
+        // addressed to a Citizen (lateral MRH).
+        let hub = Uuid::new_v4();
+        let citizen = Uuid::new_v4();
+        let n = Act::addressed(hub, ActAddress::Citizen { lct_id: citizen }, sref(), now());
+        assert_eq!(n.mrh_direction(), MrhDirection::Lateral);
+        assert_eq!(n.actor_lct, hub);
+    }
+
+    #[test]
+    fn irreversible_acts_gate_on_atp_witness_and_council() {
+        let a = Act::forum(Uuid::new_v4(), Uuid::new_v4(), sref(), now())
             .with_consequence(ConsequenceClass::Irreversible);
         assert!(a.requires_atp_stake());
         assert!(a.requires_witness());
+        // Bridge to HUB's gate: Irreversible == High == needs a council proposal_ref.
+        assert!(a.consequence.requires_council());
 
         let m = Act::memory(Uuid::new_v4(), sref(), now()); // default Reversible
         assert!(!m.requires_atp_stake());
@@ -272,8 +334,9 @@ mod tests {
         let actor = Uuid::new_v4();
         let mut t_irrev = TrustValueScore::new(actor);
         let mut t_rev = TrustValueScore::new(actor);
-        let irrev = Act::forum(actor, sref(), now()).with_consequence(ConsequenceClass::Irreversible);
-        let rev = Act::forum(actor, sref(), now()).with_consequence(ConsequenceClass::Reversible);
+        let soc = Uuid::new_v4();
+        let irrev = Act::forum(actor, soc, sref(), now()).with_consequence(ConsequenceClass::Irreversible);
+        let rev = Act::forum(actor, soc, sref(), now()).with_consequence(ConsequenceClass::Reversible);
         let (di, _) = irrev.record_outcome(&mut t_irrev, ActOutcome::Failed);
         let (dr, _) = rev.record_outcome(&mut t_rev, ActOutcome::Failed);
         assert!(di < dr, "an irreversible failure debits Validity more steeply");
@@ -287,7 +350,7 @@ mod tests {
             signature: "sig".into(),
             timestamp: now(),
         };
-        let a = Act::forum(Uuid::new_v4(), sref(), now()).witnessed_by(w);
+        let a = Act::forum(Uuid::new_v4(), Uuid::new_v4(), sref(), now()).witnessed_by(w);
         assert_eq!(a.witnesses.len(), 1);
     }
 

--- a/web4-core/src/event.rs
+++ b/web4-core/src/event.rs
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 MetaLINXX Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! # Events: R6/R7 as a wait-on-event-with-timeout
+//!
+//! The second half of the time axis (Thor's RTOS proposal): an R6/R7 submission
+//! is **not** fire-and-forget or poll — the requester *blocks on the Result
+//! event* up to its [`Deadline`](crate::time::Deadline). **Events are the
+//! primary trigger; timers are the backup** for when no event arrives.
+//!
+//! This module provides the *types* and the *idempotency* logic; the actual
+//! async blocking / dispatch surface is the hub's (the implementing track). An
+//! [`Event`] carries a `request_id` so a Result can be matched to its Request
+//! and **deduped** — HUB's caveat: a requester can time out, retry, then the
+//! slow-but-successful Result arrives; without request-id dedup you'd
+//! double-count it (once as a miss, once as a result). [`EventLog`] gives each
+//! request exactly one terminal accounting.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::time::Deadline;
+
+/// An event on the web4 event axis — the primary trigger for R6/R7 acts.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Event {
+    pub event_id: Uuid,
+    /// The request this event resolves/triggers (the matching + dedup key).
+    pub request_id: Uuid,
+    /// What kind of event (the subscription filter).
+    pub topic: String,
+    /// Who emitted it.
+    pub emitter_lct: Uuid,
+    /// Opaque payload (e.g. the Result).
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    pub at: DateTime<Utc>,
+}
+
+impl Event {
+    pub fn new(request_id: Uuid, topic: impl Into<String>, emitter_lct: Uuid, at: DateTime<Utc>) -> Self {
+        Self {
+            event_id: Uuid::new_v4(),
+            request_id,
+            topic: topic.into(),
+            emitter_lct,
+            payload: serde_json::Value::Null,
+            at,
+        }
+    }
+    pub fn with_payload(mut self, payload: serde_json::Value) -> Self {
+        self.payload = payload;
+        self
+    }
+}
+
+/// A wait-on-event-with-timeout: the submission blocks on an event matching
+/// `topic` + `request_id`, up to `deadline`. Timers are the backup trigger.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WaitCondition {
+    pub request_id: Uuid,
+    pub topic: String,
+    pub deadline: Deadline,
+}
+
+impl WaitCondition {
+    pub fn new(request_id: Uuid, topic: impl Into<String>, deadline: Deadline) -> Self {
+        Self { request_id, topic: topic.into(), deadline }
+    }
+
+    /// Does `event` satisfy this wait?
+    pub fn matches(&self, event: &Event) -> bool {
+        event.request_id == self.request_id && event.topic == self.topic
+    }
+
+    /// Evaluate the wait given the (optional) event seen so far and the current
+    /// time. The event-first/timer-backup rule: a matching event always wins;
+    /// otherwise it's `Pending` until the deadline, then `TimedOut`.
+    pub fn evaluate(&self, fired: Option<&Event>, now: DateTime<Utc>) -> WaitOutcome {
+        if let Some(e) = fired {
+            if self.matches(e) {
+                return WaitOutcome::Fired(e.clone());
+            }
+        }
+        if now > self.deadline.due_at {
+            WaitOutcome::TimedOut
+        } else {
+            WaitOutcome::Pending
+        }
+    }
+}
+
+/// The result of a wait-on-event-with-timeout.
+#[derive(Clone, Debug, PartialEq)]
+pub enum WaitOutcome {
+    /// The awaited event arrived (in or out of time — timing is judged
+    /// separately via [`Deadline::evaluate`](crate::time::Deadline::evaluate)).
+    Fired(Event),
+    /// Still waiting; the deadline hasn't elapsed.
+    Pending,
+    /// The deadline elapsed with no matching event (the timer backup fired).
+    TimedOut,
+}
+
+/// Whether a resolution is the first for its request, or a duplicate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Admit {
+    /// First terminal resolution of this request — account for it.
+    Fresh,
+    /// Already resolved (a retry, or a slow success after a timeout) — ignore;
+    /// counting it again would double-count the request.
+    Duplicate,
+}
+
+/// Idempotency ledger over request resolutions. Each `request_id` gets **one**
+/// terminal accounting: the first resolution (a fired event *or* a timeout)
+/// wins; any later one is a [`Admit::Duplicate`]. This is what stops a
+/// slow-but-successful Result arriving after a timeout from being counted both
+/// as a miss (trust debit) and a result.
+#[derive(Debug, Default, Clone)]
+pub struct EventLog {
+    resolved: HashSet<Uuid>,
+}
+
+impl EventLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the terminal resolution of a request. First call → `Fresh`; any
+    /// subsequent call for the same `request_id` → `Duplicate`.
+    pub fn resolve(&mut self, request_id: Uuid) -> Admit {
+        if self.resolved.insert(request_id) {
+            Admit::Fresh
+        } else {
+            Admit::Duplicate
+        }
+    }
+
+    pub fn is_resolved(&self, request_id: &Uuid) -> bool {
+        self.resolved.contains(request_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.resolved.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.resolved.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::Deadline;
+    use chrono::Duration;
+
+    fn due() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-20T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn fires_on_matching_event() {
+        let rid = Uuid::new_v4();
+        let w = WaitCondition::new(rid, "result", Deadline::new(due()));
+        let ev = Event::new(rid, "result", Uuid::new_v4(), due() - Duration::minutes(1));
+        assert!(matches!(w.evaluate(Some(&ev), due()), WaitOutcome::Fired(_)));
+    }
+
+    #[test]
+    fn pending_then_timed_out() {
+        let rid = Uuid::new_v4();
+        let w = WaitCondition::new(rid, "result", Deadline::new(due()));
+        assert_eq!(w.evaluate(None, due() - Duration::minutes(1)), WaitOutcome::Pending);
+        assert_eq!(w.evaluate(None, due() + Duration::minutes(1)), WaitOutcome::TimedOut);
+    }
+
+    #[test]
+    fn non_matching_event_does_not_fire() {
+        let w = WaitCondition::new(Uuid::new_v4(), "result", Deadline::new(due()));
+        let other = Event::new(Uuid::new_v4(), "result", Uuid::new_v4(), due());
+        assert_eq!(w.evaluate(Some(&other), due() - Duration::minutes(1)), WaitOutcome::Pending);
+    }
+
+    #[test]
+    fn idempotency_slow_success_after_timeout_is_deduped() {
+        // HUB's caveat: time out, retry, then the slow success arrives — count
+        // the request exactly once.
+        let mut log = EventLog::new();
+        let rid = Uuid::new_v4();
+        // The timeout resolves it first (a miss is recorded).
+        assert_eq!(log.resolve(rid), Admit::Fresh);
+        // The slow-but-successful Result arrives later → duplicate, ignored, so
+        // it's not also counted as a result (no double-count).
+        assert_eq!(log.resolve(rid), Admit::Duplicate);
+        // A retry of the same request is likewise deduped.
+        assert_eq!(log.resolve(rid), Admit::Duplicate);
+        assert_eq!(log.len(), 1);
+        assert!(log.is_resolved(&rid));
+    }
+
+    #[test]
+    fn distinct_requests_each_resolve_once() {
+        let mut log = EventLog::new();
+        let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+        assert_eq!(log.resolve(a), Admit::Fresh);
+        assert_eq!(log.resolve(b), Admit::Fresh);
+        assert_eq!(log.resolve(a), Admit::Duplicate);
+        assert_eq!(log.len(), 2);
+    }
+}

--- a/web4-core/src/ledger.rs
+++ b/web4-core/src/ledger.rs
@@ -110,6 +110,13 @@ pub enum LedgerEvent {
         /// New status.
         to: LctStatus,
     },
+    /// An entity externalized a witnessed act — a memory write, handoff, or
+    /// forum post (CBP's unifying primitive). The thin governance record lives
+    /// here; the fat substance lives wherever the act's `SubstanceRef` points.
+    Act {
+        /// The thin governance record.
+        act: crate::act::Act,
+    },
 }
 
 /// Cryptographic proof that an LCT exists in a ledger at a specific position.

--- a/web4-core/src/ledger/local.rs
+++ b/web4-core/src/ledger/local.rs
@@ -173,6 +173,10 @@ impl LocalLedger {
                     })?;
                     stored.status = to.clone();
                 }
+                LedgerEvent::Act { .. } => {
+                    // A witnessed act is a governance record over off-ledger
+                    // substance; it doesn't mutate LCT state during replay.
+                }
             }
             expected_prev = entry.entry_hash.clone();
         }

--- a/web4-core/src/lib.rs
+++ b/web4-core/src/lib.rs
@@ -69,6 +69,7 @@ pub mod oid4vc;
 pub mod sd_jwt_vc;
 pub mod society;
 pub mod t3;
+pub mod time;
 pub mod v3;
 pub mod vault;
 
@@ -95,6 +96,7 @@ pub use sd_jwt_vc::{SdJwtVc, UnsignedSdJwtVc, VerifiedCredential, verify_issuer,
 pub use society::{MetabolicState, Society};
 pub use vault::{Vault, VaultContents, Document, ItemRef, Protection};
 pub use t3::{TrustDimension, TrustObservation, TrustRelation, T3, T3_DIMENSIONS};
+pub use time::{Criticality, Deadline, DeadlineOutcome, TemporalImpact, Timing, WitnessAvailability};
 pub use v3::{TrustValueScore, ValueDimension, ValueObservation, V3, V3_DIMENSIONS};
 
 /// Library version

--- a/web4-core/src/lib.rs
+++ b/web4-core/src/lib.rs
@@ -54,6 +54,7 @@
 //! - **Coherence requirements**: Entities must maintain identity coherence
 //! - **Hardware binding**: Production deployments bind keys to secure hardware
 
+pub mod act;
 pub mod atp;
 pub mod coherence;
 pub mod crypto;
@@ -75,6 +76,7 @@ pub mod v3;
 pub mod vault;
 
 // Re-export primary types for convenience
+pub use act::{Act, ActOutcome, ConsequenceClass, MrhDirection, SubstanceMedium, SubstanceRef};
 pub use atp::{ATPAccount, TransferResult};
 pub use coherence::{
     check_coherence, coherence_threshold_for_entity, Coherence, CoherenceCalculator,

--- a/web4-core/src/lib.rs
+++ b/web4-core/src/lib.rs
@@ -76,7 +76,9 @@ pub mod v3;
 pub mod vault;
 
 // Re-export primary types for convenience
-pub use act::{Act, ActOutcome, ConsequenceClass, MrhDirection, SubstanceMedium, SubstanceRef};
+pub use act::{
+    Act, ActAddress, ActOutcome, ConsequenceClass, MrhDirection, SubstanceMedium, SubstanceRef,
+};
 pub use atp::{ATPAccount, TransferResult};
 pub use coherence::{
     check_coherence, coherence_threshold_for_entity, Coherence, CoherenceCalculator,

--- a/web4-core/src/lib.rs
+++ b/web4-core/src/lib.rs
@@ -60,6 +60,7 @@ pub mod crypto;
 pub mod delegation;
 pub mod did;
 pub mod error;
+pub mod event;
 pub mod lct;
 pub mod ledger;
 pub mod pair_channel;

--- a/web4-core/src/r6.rs
+++ b/web4-core/src/r6.rs
@@ -136,7 +136,7 @@ pub struct Precedent {
 }
 
 /// A witness attestation — signed statement from an independent observer.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WitnessAttestation {
     /// Witness entity LCT
     pub lct: String,

--- a/web4-core/src/r6.rs
+++ b/web4-core/src/r6.rs
@@ -83,11 +83,16 @@ pub struct Request {
     pub target: String,
     /// Action-specific parameters
     pub parameters: HashMap<String, serde_json::Value>,
-    /// ATP staked on outcome
+    /// ATP staked on outcome (the *energy* resource committed to the action).
     pub atp_stake: f64,
+    /// Deadline staked on outcome (the *time* resource — the temporal twin of
+    /// `atp_stake`). `None` = no temporal accountability. A typed promotion of
+    /// the legacy free-text `constraints["deadline"]`. See [`crate::time`].
+    #[serde(default)]
+    pub deadline: Option<crate::time::Deadline>,
     /// Unique request nonce
     pub nonce: String,
-    /// Execution constraints (deadline, budget)
+    /// Execution constraints (legacy free-text bag; typed time → `deadline`).
     pub constraints: HashMap<String, serde_json::Value>,
     /// Proof of delegated agency (if acting on behalf of another)
     pub proof_of_agency: Option<ProofOfAgency>,
@@ -467,6 +472,7 @@ mod tests {
                 target: "src/main.rs".into(),
                 parameters: HashMap::new(),
                 atp_stake: 10.0,
+                deadline: None,
                 nonce: Uuid::new_v4().to_string(),
                 constraints: HashMap::new(),
                 proof_of_agency: None,

--- a/web4-core/src/t3.rs
+++ b/web4-core/src/t3.rs
@@ -152,6 +152,21 @@ impl T3 {
     /// Record an observation for a root dimension
     ///
     /// Uses exponential moving average with decay factor based on observation count
+    /// Apply a signed reputation delta directly to a dimension, clamped to
+    /// `[0, 1]`, counting it as one observation. This is how a
+    /// [`ReputationDelta`](crate::r6::ReputationDelta) from an R7 action outcome
+    /// — e.g. a missed deadline debiting Temperament — folds into the tensor.
+    /// Returns the realized change after clamping.
+    pub fn apply_delta(&mut self, dimension: TrustDimension, delta: f64) -> f64 {
+        let idx = dimension as usize;
+        let before = self.dimensions[idx];
+        self.dimensions[idx] = (before + delta).clamp(0.0, 1.0);
+        self.observation_counts[idx] += 1;
+        self.weights[idx] =
+            ((1.0 + self.observation_counts[idx] as f64).ln() / 10.0_f64.ln()).min(1.0);
+        self.dimensions[idx] - before
+    }
+
     pub fn observe(&mut self, dimension: TrustDimension, observed_score: f64) -> Result<()> {
         if !(0.0..=1.0).contains(&observed_score) {
             return Err(Web4Error::InvalidInput(

--- a/web4-core/src/time.rs
+++ b/web4-core/src/time.rs
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 MetaLINXX Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! # Time as a first-class web4 axis (the temporal twin of ATP)
+//!
+//! `Web4 = MCP + RDF + LCT + T3/V3*MRH + ATP/ADP` has **space** (MRH),
+//! **energy** (ATP/ADP), **trust** (T3/V3), and **identity** (LCT) — but no
+//! **time + events as an accountable axis**. This module adds it (Thor's RTOS
+//! proposal, 2026-06-20):
+//!
+//! 1. **A deadline is a Resource** — the temporal twin of ATP. ATP makes
+//!    *spending energy* accountable; this makes *spending time* accountable.
+//! 2. **R6/R7 is a wait-on-event-with-timeout** (see [`crate::event`]); a
+//!    deadline bounds the wait.
+//! 3. **A deadline-miss is a trust event** — it folds into T3 (Temperament) and
+//!    V3 (Veracity), propagating up the MRH like any other reputation delta.
+//!
+//! ## The accountability gate (HUB's review caveats, baked in)
+//!
+//! A non-response is *not* automatically a temperament fault. Only a genuine
+//! "could have responded in time and didn't" debits trust:
+//!
+//! - **Witness-unavailable ⇒ [`DeadlineOutcome::Suspended`], not missed.** If
+//!   the deadline-witness (e.g. the hub) was down/locked at the due time, every
+//!   in-flight deadline must *pause*, not expire — otherwise a hub outage would
+//!   fire a fleet-wide false-lateness cascade. *Hub downtime is not fleet
+//!   lateness.* Checked first; it overrides everything.
+//! - **Unreachable ≠ refused.** A responder partitioned/crashed is
+//!   [`DeadlineOutcome::Unreachable`] — a clock/network fault, **not** priced as
+//!   Temperament (don't poison the trust graph with the network).
+//! - Only [`DeadlineOutcome::Late`]/[`DeadlineOutcome::Missed`] with a reachable
+//!   responder and an available witness carry a trust debit.
+//!
+//! Idempotency (a requester that timed out, retried, then got the slow success)
+//! is handled at the event layer ([`crate::event::EventLog`]) so a slow success
+//! isn't double-counted as both a miss and a result.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{T3, TrustDimension, V3, ValueDimension};
+
+/// How critical lateness is — scales the trust debit, like RTOS task priority.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Criticality {
+    /// Best-effort; lateness is noted, barely penalized.
+    Soft,
+    /// The default — lateness is a real but bounded trust signal.
+    #[default]
+    Firm,
+    /// Hard real-time; a miss is a significant temperament fault.
+    Hard,
+}
+
+impl Criticality {
+    fn scale(self) -> f64 {
+        match self {
+            Criticality::Soft => 0.25,
+            Criticality::Firm => 1.0,
+            Criticality::Hard => 2.0,
+        }
+    }
+}
+
+/// A deadline carried on an R6 [`Request`](crate::r6::Request) — **time as a
+/// Resource**, the twin of `atp_stake`. The requester commits to a `due_at`;
+/// the responder is accountable for meeting it.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Deadline {
+    /// When the Result is due.
+    pub due_at: DateTime<Utc>,
+    /// How hard the deadline is.
+    #[serde(default)]
+    pub criticality: Criticality,
+}
+
+impl Deadline {
+    pub fn new(due_at: DateTime<Utc>) -> Self {
+        Self { due_at, criticality: Criticality::Firm }
+    }
+
+    pub fn with_criticality(mut self, c: Criticality) -> Self {
+        self.criticality = c;
+        self
+    }
+
+    /// Decide the outcome from observed timing + witnessed liveness, applying
+    /// the accountability gate. `now` is the evaluation time (for an action
+    /// that hasn't completed). See the module docs for the caveats.
+    pub fn evaluate(
+        &self,
+        timing: &Timing,
+        witness: WitnessAvailability,
+        reachable: bool,
+        now: DateTime<Utc>,
+    ) -> DeadlineOutcome {
+        // A clock fault overrides everything: if the deadline-witness was down,
+        // the deadline is paused, never auto-expired.
+        if witness == WitnessAvailability::Unavailable {
+            return DeadlineOutcome::Suspended;
+        }
+        match timing.completed_at {
+            Some(done) if done <= self.due_at => DeadlineOutcome::Met,
+            Some(done) => DeadlineOutcome::Late {
+                overdue_secs: (done - self.due_at).num_seconds().max(0),
+            },
+            // Still in flight:
+            None if now <= self.due_at => DeadlineOutcome::Met, // not yet due
+            None if !reachable => DeadlineOutcome::Unreachable, // network fault
+            None => DeadlineOutcome::Missed {
+                overdue_secs: (now - self.due_at).num_seconds().max(0),
+            },
+        }
+    }
+
+    /// The T3/V3 reputation impact of an outcome — "lateness is a trust event",
+    /// gated so only genuine faults debit trust. Met → a small positive
+    /// (responsiveness builds Temperament); Late/Missed → negative scaled by
+    /// criticality × overdue magnitude; Suspended/Unreachable → **zero** (clock
+    /// and network faults are not temperament faults).
+    pub fn reputation_impact(&self, outcome: &DeadlineOutcome) -> TemporalImpact {
+        let scale = self.criticality.scale();
+        match outcome {
+            DeadlineOutcome::Met => TemporalImpact {
+                temperament: 0.01 * scale,
+                veracity: 0.005 * scale,
+            },
+            DeadlineOutcome::Late { overdue_secs } => {
+                let m = magnitude(*overdue_secs);
+                TemporalImpact { temperament: -0.02 * scale * m, veracity: -0.01 * scale * m }
+            }
+            DeadlineOutcome::Missed { overdue_secs } => {
+                let m = magnitude(*overdue_secs);
+                TemporalImpact { temperament: -0.05 * scale * m, veracity: -0.03 * scale * m }
+            }
+            DeadlineOutcome::Suspended | DeadlineOutcome::Unreachable => {
+                TemporalImpact { temperament: 0.0, veracity: 0.0 }
+            }
+        }
+    }
+}
+
+/// Observed timing of an action's execution.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Timing {
+    pub started_at: DateTime<Utc>,
+    /// `None` ⇒ still in-flight / never completed.
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl Timing {
+    pub fn started(at: DateTime<Utc>) -> Self {
+        Self { started_at: at, completed_at: None }
+    }
+    pub fn complete(mut self, at: DateTime<Utc>) -> Self {
+        self.completed_at = Some(at);
+        self
+    }
+}
+
+/// Whether the deadline-witness (the observer timing the deadline) was reachable
+/// at the due time. The first thing the gate checks.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WitnessAvailability {
+    #[default]
+    Available,
+    /// The deadline-witness (e.g. the hub) was down/locked at the due time.
+    Unavailable,
+}
+
+/// The temporal-accountability verdict. Note `Late ≠ Missed ≠ Suspended ≠
+/// Unreachable` — only the first two are faults (HUB's "late ≠ never ≠ refused
+/// ≠ unreachable").
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "outcome")]
+pub enum DeadlineOutcome {
+    /// Completed at or before the deadline (or not yet due).
+    Met,
+    /// Completed, but after the deadline.
+    Late { overdue_secs: i64 },
+    /// Past due, responder reachable, witness available — a genuine fault.
+    Missed { overdue_secs: i64 },
+    /// Deadline-witness was unavailable at the due time → paused, not missed.
+    /// Carries **no** trust debit.
+    Suspended,
+    /// Responder unreachable (partition/crash) — a network fault, not a
+    /// temperament fault. **No** trust debit.
+    Unreachable,
+}
+
+impl DeadlineOutcome {
+    /// Whether this outcome is a genuine accountability fault (debits trust).
+    pub fn is_fault(&self) -> bool {
+        matches!(self, DeadlineOutcome::Late { .. } | DeadlineOutcome::Missed { .. })
+    }
+}
+
+/// The T3/V3 trust signal a deadline outcome produces.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TemporalImpact {
+    /// Delta to T3 Temperament (consistency / responsiveness).
+    pub temperament: f64,
+    /// Delta to V3 Veracity (did it do what it said, when it said).
+    pub veracity: f64,
+}
+
+impl TemporalImpact {
+    /// Fold this temporal trust signal into a T3 + V3 (Temperament / Veracity).
+    /// This is the "deadline-miss propagates to T3/V3" step.
+    pub fn apply(&self, t3: &mut T3, v3: &mut V3) {
+        t3.apply_delta(TrustDimension::Temperament, self.temperament);
+        v3.apply_delta(ValueDimension::Veracity, self.veracity);
+    }
+}
+
+/// Map overdue seconds to a saturating penalty magnitude in `[0.1, 1.0]`:
+/// a small overshoot is minor; very late saturates (no unbounded punishment).
+fn magnitude(overdue_secs: i64) -> f64 {
+    let mins = overdue_secs.max(0) as f64 / 60.0;
+    ((1.0 + mins).ln() / 6.0).clamp(0.1, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn base() -> (DateTime<Utc>, Deadline) {
+        let due = DateTime::parse_from_rfc3339("2026-06-20T12:00:00Z").unwrap().with_timezone(&Utc);
+        (due, Deadline::new(due))
+    }
+
+    #[test]
+    fn met_when_completed_before_due() {
+        let (due, d) = base();
+        let t = Timing::started(due - Duration::minutes(10)).complete(due - Duration::minutes(1));
+        let o = d.evaluate(&t, WitnessAvailability::Available, true, due);
+        assert_eq!(o, DeadlineOutcome::Met);
+        let imp = d.reputation_impact(&o);
+        assert!(imp.temperament > 0.0, "meeting a deadline builds Temperament");
+    }
+
+    #[test]
+    fn late_when_completed_after_due_debits_trust() {
+        let (due, d) = base();
+        let t = Timing::started(due - Duration::minutes(10)).complete(due + Duration::minutes(30));
+        let o = d.evaluate(&t, WitnessAvailability::Available, true, due + Duration::hours(1));
+        assert!(matches!(o, DeadlineOutcome::Late { .. }));
+        assert!(o.is_fault());
+        let imp = d.reputation_impact(&o);
+        assert!(imp.temperament < 0.0 && imp.veracity < 0.0);
+    }
+
+    #[test]
+    fn missed_when_past_due_reachable_and_witnessed() {
+        let (due, d) = base();
+        let t = Timing::started(due - Duration::minutes(10)); // never completed
+        let o = d.evaluate(&t, WitnessAvailability::Available, true, due + Duration::minutes(45));
+        assert!(matches!(o, DeadlineOutcome::Missed { .. }));
+        assert!(d.reputation_impact(&o).temperament < 0.0);
+    }
+
+    #[test]
+    fn witness_unavailable_suspends_not_misses() {
+        // HUB's caveat: hub down/locked at due time ⇒ paused, no debit.
+        let (due, d) = base();
+        let t = Timing::started(due - Duration::minutes(10));
+        let o = d.evaluate(&t, WitnessAvailability::Unavailable, true, due + Duration::hours(5));
+        assert_eq!(o, DeadlineOutcome::Suspended);
+        assert!(!o.is_fault());
+        let imp = d.reputation_impact(&o);
+        assert_eq!((imp.temperament, imp.veracity), (0.0, 0.0));
+    }
+
+    #[test]
+    fn unreachable_is_not_a_temperament_fault() {
+        // HUB's caveat: a partition/crash ≠ declining. No trust debit.
+        let (due, d) = base();
+        let t = Timing::started(due - Duration::minutes(10));
+        let o = d.evaluate(&t, WitnessAvailability::Available, false, due + Duration::minutes(45));
+        assert_eq!(o, DeadlineOutcome::Unreachable);
+        assert!(!o.is_fault());
+        assert_eq!(d.reputation_impact(&o).temperament, 0.0);
+    }
+
+    #[test]
+    fn criticality_scales_the_debit() {
+        let (due, _) = base();
+        let t = Timing::started(due).complete(due + Duration::minutes(30));
+        let soft = Deadline::new(due).with_criticality(Criticality::Soft);
+        let hard = Deadline::new(due).with_criticality(Criticality::Hard);
+        let now = due + Duration::hours(1);
+        let soft_imp = soft.reputation_impact(&soft.evaluate(&t, WitnessAvailability::Available, true, now));
+        let hard_imp = hard.reputation_impact(&hard.evaluate(&t, WitnessAvailability::Available, true, now));
+        assert!(hard_imp.temperament < soft_imp.temperament, "hard miss costs more");
+    }
+
+    #[test]
+    fn impact_folds_into_tensors() {
+        let (due, d) = base();
+        let t = Timing::started(due).complete(due + Duration::hours(2));
+        let o = d.evaluate(&t, WitnessAvailability::Available, true, due + Duration::hours(3));
+        let mut t3 = T3::new();
+        let mut v3 = V3::new();
+        let before = t3.score(TrustDimension::Temperament);
+        d.reputation_impact(&o).apply(&mut t3, &mut v3);
+        assert!(t3.score(TrustDimension::Temperament) < before, "late miss lowers Temperament");
+    }
+}

--- a/web4-core/src/v3.rs
+++ b/web4-core/src/v3.rs
@@ -147,6 +147,20 @@ impl V3 {
     }
 
     /// Record an observation for a root dimension
+    /// Apply a signed reputation delta directly to a dimension, clamped to
+    /// `[0, 1]`, counting it as one observation. Mirrors [`T3::apply_delta`] for
+    /// the value tensor — e.g. a deadline miss debiting Veracity. Returns the
+    /// realized change after clamping.
+    pub fn apply_delta(&mut self, dimension: ValueDimension, delta: f64) -> f64 {
+        let idx = dimension as usize;
+        let before = self.dimensions[idx];
+        self.dimensions[idx] = (before + delta).clamp(0.0, 1.0);
+        self.observation_counts[idx] += 1;
+        self.weights[idx] =
+            ((1.0 + self.observation_counts[idx] as f64).ln() / 10.0_f64.ln()).min(1.0);
+        self.dimensions[idx] - before
+    }
+
     pub fn observe(&mut self, dimension: ValueDimension, observed_score: f64) -> Result<()> {
         if !(0.0..=1.0).contains(&observed_score) {
             return Err(Web4Error::InvalidInput(


### PR DESCRIPTION
Reference implementations for the two fleet proposals (forum, 2026-06-20). Additive to web4-core; ~18 new tests, full lib suite green (155 lib + 4 integration).

## Thor — time & events as a first-class axis (RTOS shape)
- `T3::apply_delta` / `V3::apply_delta` — fold a `ReputationDelta` into a tensor (the missing mechanical piece for any outcome→trust flow).
- `time` module: `Deadline` (time-as-resource, twin of `atp_stake`) + `Criticality`; `Timing`; `DeadlineOutcome` (Met/Late/Missed/Suspended/Unreachable); `evaluate` + `reputation_impact` → `TemporalImpact` → T3 Temperament + V3 Veracity.
- `r6::Request` gains typed `deadline: Option<Deadline>` (promotes free-text `constraints["deadline"]`).
- `event` module: `WaitCondition`/`WaitOutcome` (event-first, timer-backup) + `EventLog`/`Admit` idempotency.
- **HUB's four review caveats baked into the gate:** late≠never≠refused≠unreachable (5-valued outcome, only Late/Missed are faults); witness-unavailable ⇒ Suspended (checked first — "hub downtime is not fleet lateness"); unreachable ⇒ no debit (don't price the network); request-id dedup so a slow success isn't double-counted. "Whose clock" left as the witness-supplied `now` parameter (hub-track owns clock authority).

## CBP — fleet as a Web4 society
- `act` module: `Act` = thin governance record (actor, audience, MRH direction, consequence, witnesses) pointing at fat substance via `SubstanceRef` (uri + content_hash + medium).
- `MrhDirection` (Temporal/Lateral/Broad) + `Act::memory`/`handoff`/`forum` — memory write, handoff, forum post are one primitive differing only in MRH scope.
- `ConsequenceClass` gates `requires_atp_stake` / `requires_witness`; `record_outcome` folds `ActOutcome` into `EntityTrust` (TrustValueScore) via V3 Validity/Veracity + T3 Temperament.
- `LedgerEvent::Act` (no-op in LCT replay; substance off-ledger). Witnessing reuses the flat `WitnessAttestation`; no recursive witness-chain in the open core.
- Field set converges with HUB's proposed `HubEvent::ReferencedAct` (see forum response) so the core type and hub envelope serialize the same thing.

Scope note: these are the reference **types + gate logic**. The live hub event/subscribe channel + hub-as-clock-witness + `HubEvent::ReferencedAct` variant are hub-track (HUB will prototype behind a flag before any trust-debiting goes live). Spec wording (`r6-framework`/`t3v3`/`mrh-tensors`, society/ledger act) follows on the spec track.

Forum: `legion-to-thor-time-events-implemented-2026-06-20.md`, `legion-to-cbp-act-primitive-implemented-2026-06-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)