### PR TITLE
DRAFT: ReferencedAct + hub→citizen notifications (Phase-0 Gap A)

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -691,7 +691,8 @@ fn event_summary(event: &HubEvent) -> String {
                 ActAddress::Society { lct_id } => format!("society {}", short(lct_id)),
             };
             format!(
-                "✉️ act <span class=\"muted\">from</span> {} → {} <span class=\"muted\">[{}]</span>",
+                "✉️ act <code>{}</code> <span class=\"muted\">from</span> {} → {} <span class=\"muted\">[{}]</span>",
+                html_escape(&act.kind),
                 short(&act.actor_lct),
                 dst,
                 html_escape(&act.substance.uri),

--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -681,18 +681,20 @@ fn event_summary(event: &HubEvent) -> String {
                 short(challenge_id),
             )
         }
-        HubEvent::ReferencedAct { to, act_kind, pointer_uri, .. } => {
-            let dst = match to {
-                hub_lib::events::ActAddress::FutureSelf { entity } => format!("future-self {}", short(entity)),
-                hub_lib::events::ActAddress::Peer { lct_id } => format!("peer {}", short(lct_id)),
-                hub_lib::events::ActAddress::Citizen { lct_id } => format!("citizen {}", short(lct_id)),
-                hub_lib::events::ActAddress::Role { role } => format!("role {}", html_escape(role)),
+        HubEvent::ReferencedAct { act } => {
+            use web4_core::act::ActAddress;
+            let dst = match &act.address {
+                ActAddress::FutureSelf { entity } => format!("future-self {}", short(entity)),
+                ActAddress::Peer { lct_id } => format!("peer {}", short(lct_id)),
+                ActAddress::Citizen { lct_id } => format!("citizen {}", short(lct_id)),
+                ActAddress::Role { role } => format!("role {}", html_escape(role)),
+                ActAddress::Society { lct_id } => format!("society {}", short(lct_id)),
             };
             format!(
-                "✉️ act <code>{}</code> → {} <span class=\"muted\">[{}]</span>",
-                html_escape(act_kind),
+                "✉️ act <span class=\"muted\">from</span> {} → {} <span class=\"muted\">[{}]</span>",
+                short(&act.actor_lct),
                 dst,
-                html_escape(pointer_uri),
+                html_escape(&act.substance.uri),
             )
         }
     }

--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -681,6 +681,20 @@ fn event_summary(event: &HubEvent) -> String {
                 short(challenge_id),
             )
         }
+        HubEvent::ReferencedAct { to, act_kind, pointer_uri, .. } => {
+            let dst = match to {
+                hub_lib::events::ActAddress::FutureSelf { entity } => format!("future-self {}", short(entity)),
+                hub_lib::events::ActAddress::Peer { lct_id } => format!("peer {}", short(lct_id)),
+                hub_lib::events::ActAddress::Citizen { lct_id } => format!("citizen {}", short(lct_id)),
+                hub_lib::events::ActAddress::Role { role } => format!("role {}", html_escape(role)),
+            };
+            format!(
+                "✉️ act <code>{}</code> → {} <span class=\"muted\">[{}]</span>",
+                html_escape(act_kind),
+                dst,
+                html_escape(pointer_uri),
+            )
+        }
     }
 }
 

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -153,11 +153,14 @@ pub struct RestState {
 /// One sealed notice queued for a citizen. `sealed` is ciphertext sealed to the
 /// citizen's pinned pubkey — only that LCT can open it (`channel_open` with the hub
 /// pubkey + `pair_id`).
+/// The hestia notify wire (`forum/hub-to-hestia-witness-notify-wire-confirmed`):
+/// `pair_id` + cleartext `kind` + sealed body. These are *delivery* concerns —
+/// they ride the mailbox envelope, never the witnessed `Act` on the ledger.
 #[derive(Clone, Serialize)]
 pub struct SealedNotice {
     pub pair_id: Uuid,
     pub sealed: String,
-    pub act_kind: String,
+    pub kind: String,
     pub pointer_uri: String,
     pub queued_at: chrono::DateTime<Utc>,
 }
@@ -670,7 +673,7 @@ async fn witness_event(s: &RestState, event: HubEvent) -> Result<u64, ApiError> 
 /// sealed notice in the citizen's mailbox (the poll floor). `body` is sealed to the
 /// citizen's pinned pubkey — only that LCT can open it. Best-effort: missing pubkey / seal
 /// failure logs and drops (the witnessed act still records that a notice was intended).
-async fn notify_citizen(s: &RestState, recipient: Uuid, act_kind: &str, pointer_uri: &str, body: &[u8]) {
+async fn notify_citizen(s: &RestState, recipient: Uuid, kind: &str, pointer_uri: &str, body: &[u8]) {
     let pubkey_hex = {
         let ledger = s.ledger.lock().await;
         HubState::project(&ledger).member_pubkeys.get(&recipient).cloned()
@@ -692,23 +695,26 @@ async fn notify_citizen(s: &RestState, recipient: Uuid, act_kind: &str, pointer_
         Ok(c) => c,
         Err(e) => { tracing::warn!("notify_citizen: seal failed: {e}"); return; }
     };
-    let _ = witness_event(
-        s,
-        HubEvent::ReferencedAct {
-            from_lct: s.sovereign_lct_id,
-            to: hub_lib::events::ActAddress::Citizen { lct_id: recipient },
-            act_kind: act_kind.to_string(),
-            pointer_uri: pointer_uri.to_string(),
-            consequence_class: hub_lib::events::ConsequenceClass::Informational,
-            sealed_body: None, // body delivered via the mailbox, not on the thin ledger
-            acted_at: Utc::now(),
-        },
-    )
-    .await;
+    // Witness a thin act — a `web4_core::act::Act` verbatim (the convergence's
+    // "both sides witness the same bytes"). `content_hash` binds the witnessed
+    // pointer to this exact notice body so it can't drift; medium = Message (a
+    // direct sealed notice); consequence defaults to Reversible (a notification
+    // is freely undoable). The sealed body rides the mailbox below, NOT the ledger.
+    let act = web4_core::act::Act::addressed(
+        s.sovereign_lct_id,
+        web4_core::act::ActAddress::Citizen { lct_id: recipient },
+        web4_core::act::SubstanceRef::new(
+            pointer_uri,
+            web4_core::sha256_hex(body),
+            web4_core::act::SubstanceMedium::Message,
+        ),
+        Utc::now(),
+    );
+    let _ = witness_event(s, HubEvent::ReferencedAct { act }).await;
     s.notifications.lock().await.entry(recipient).or_default().push(SealedNotice {
         pair_id,
         sealed,
-        act_kind: act_kind.to_string(),
+        kind: kind.to_string(),
         pointer_uri: pointer_uri.to_string(),
         queued_at: Utc::now(),
     });
@@ -2176,28 +2182,34 @@ async fn dispatch_channel(
             Ok(serde_json::json!({ "total": notices.len(), "notifications": notices }))
         }
         "referenced_act" => {
-            // A caller submits a generic referenced act (cbp's handoff/sweep/memo). from =
-            // the authenticated caller; the hub witnesses it. Substance lives at pointer_uri.
-            let to: hub_lib::events::ActAddress = inner.args.get("to")
+            // A caller submits a generic referenced act (cbp's handoff/sweep/memo). The act's
+            // `actor_lct` is the authenticated caller; the hub witnesses it as a verbatim
+            // `web4_core::act::Act`. `to` is a core `ActAddress` (Peer/Citizen/Role/Society/
+            // FutureSelf); the substance pointer carries a `content_hash` so the witnessed
+            // record binds to a specific version and can't silently drift.
+            let address: web4_core::act::ActAddress = inner.args.get("to")
                 .cloned()
                 .and_then(|v| serde_json::from_value(v).ok())
                 .ok_or_else(|| ApiError::bad_request("referenced_act requires 'to' (ActAddress)".to_string()))?;
-            let act_kind = inner.args.get("kind").and_then(|v| v.as_str())
-                .ok_or_else(|| ApiError::bad_request("referenced_act requires 'kind'".to_string()))?.to_string();
-            let pointer_uri = inner.args.get("pointer_uri").and_then(|v| v.as_str())
+            let uri = inner.args.get("pointer_uri").and_then(|v| v.as_str())
                 .ok_or_else(|| ApiError::bad_request("referenced_act requires 'pointer_uri'".to_string()))?.to_string();
-            let consequence_class = inner.args.get("consequence_class")
+            let content_hash = inner.args.get("content_hash").and_then(|v| v.as_str())
+                .unwrap_or("").to_string();
+            let medium: web4_core::act::SubstanceMedium = inner.args.get("medium")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
-                .unwrap_or(hub_lib::events::ConsequenceClass::Routine);
-            let index = witness_event(s, HubEvent::ReferencedAct {
-                from_lct: caller_lct_id,
-                to,
-                act_kind,
-                pointer_uri,
-                consequence_class,
-                sealed_body: None,
-                acted_at: Utc::now(),
-            }).await?;
+                .unwrap_or(web4_core::act::SubstanceMedium::Other);
+            // Reversibility is the canonical, actor-assessable property; the council gate
+            // (`Irreversible ⇒ proposal_ref`) is derived from it. Defaults to Reversible.
+            let consequence: web4_core::act::ConsequenceClass = inner.args.get("consequence")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            let act = web4_core::act::Act::addressed(
+                caller_lct_id,
+                address,
+                web4_core::act::SubstanceRef::new(uri, content_hash, medium),
+                Utc::now(),
+            ).with_consequence(consequence);
+            let index = witness_event(s, HubEvent::ReferencedAct { act }).await?;
             Ok(serde_json::json!({ "recorded": true, "entry_index": index }))
         }
         // ---- constellation attestation (challenge-response MFA, assurance tiers) ----
@@ -4336,7 +4348,7 @@ norms:
             let mb = state.notifications.lock().await;
             let notices = mb.get(&citizen).expect("a notice was queued");
             assert_eq!(notices.len(), 1);
-            assert_eq!(notices[0].act_kind, "notify:test");
+            assert_eq!(notices[0].kind, "notify:test");
             assert_eq!(notices[0].pointer_uri, "ptr/1");
             assert!(!notices[0].sealed.is_empty(), "the body is sealed to the citizen");
         }

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -143,6 +143,23 @@ pub struct RestState {
     /// environment on every runtime store re-open. `None` while locked. Set once
     /// at ignition; shared with `McpState`.
     pub store_key: Arc<tokio::sync::RwLock<Option<zeroize::Zeroizing<[u8; 32]>>>>,
+    /// Per-citizen pending-notifications mailbox (DRAFT — the hub→citizen delivery
+    /// floor). A `ReferencedAct{to: Citizen}` queues a `SealedNotice` here; the citizen
+    /// drains it via the `notifications` channel tool (poll floor). Push to a registered
+    /// LCT-MCP endpoint is the future optimization on the same queue.
+    pub notifications: Arc<Mutex<std::collections::HashMap<Uuid, Vec<SealedNotice>>>>,
+}
+
+/// One sealed notice queued for a citizen. `sealed` is ciphertext sealed to the
+/// citizen's pinned pubkey — only that LCT can open it (`channel_open` with the hub
+/// pubkey + `pair_id`).
+#[derive(Clone, Serialize)]
+pub struct SealedNotice {
+    pub pair_id: Uuid,
+    pub sealed: String,
+    pub act_kind: String,
+    pub pointer_uri: String,
+    pub queued_at: chrono::DateTime<Utc>,
 }
 
 /// An in-flight tier-2 unlock: the minted challenge + the roster/threshold
@@ -317,6 +334,7 @@ impl RestState {
                     None => None,
                 },
             )),
+            notifications: Arc::new(Mutex::new(std::collections::HashMap::new())),
         })
     }
 
@@ -367,6 +385,7 @@ impl RestState {
             unlock_sessions: Arc::new(Mutex::new(std::collections::HashMap::new())),
             protected: Arc::new(Mutex::new(None)),
             store_key: Arc::new(tokio::sync::RwLock::new(None)),
+            notifications: Arc::new(Mutex::new(std::collections::HashMap::new())),
         })
     }
 
@@ -645,6 +664,54 @@ async fn witness_event(s: &RestState, event: HubEvent) -> Result<u64, ApiError> 
         .await
         .map_err(ApiError::internal)?;
     Ok(entry.index)
+}
+
+/// Hub→citizen notification (DRAFT): witness a `ReferencedAct{to: Citizen}` and queue a
+/// sealed notice in the citizen's mailbox (the poll floor). `body` is sealed to the
+/// citizen's pinned pubkey — only that LCT can open it. Best-effort: missing pubkey / seal
+/// failure logs and drops (the witnessed act still records that a notice was intended).
+async fn notify_citizen(s: &RestState, recipient: Uuid, act_kind: &str, pointer_uri: &str, body: &[u8]) {
+    let pubkey_hex = {
+        let ledger = s.ledger.lock().await;
+        HubState::project(&ledger).member_pubkeys.get(&recipient).cloned()
+    };
+    let Some(pubkey_hex) = pubkey_hex else {
+        tracing::warn!("notify_citizen: no pinned pubkey for {recipient}; notice dropped");
+        return;
+    };
+    let pubkey = match hex::decode(&pubkey_hex)
+        .ok()
+        .and_then(|b| <[u8; 32]>::try_from(b).ok())
+        .and_then(|a| web4_core::crypto::PublicKey::from_bytes(&a).ok())
+    {
+        Some(pk) => pk,
+        None => { tracing::warn!("notify_citizen: bad pubkey for {recipient}"); return; }
+    };
+    let pair_id = Uuid::new_v4();
+    let sealed = match s.signer.channel_seal(&pubkey, pair_id, body) {
+        Ok(c) => c,
+        Err(e) => { tracing::warn!("notify_citizen: seal failed: {e}"); return; }
+    };
+    let _ = witness_event(
+        s,
+        HubEvent::ReferencedAct {
+            from_lct: s.sovereign_lct_id,
+            to: hub_lib::events::ActAddress::Citizen { lct_id: recipient },
+            act_kind: act_kind.to_string(),
+            pointer_uri: pointer_uri.to_string(),
+            consequence_class: hub_lib::events::ConsequenceClass::Informational,
+            sealed_body: None, // body delivered via the mailbox, not on the thin ledger
+            acted_at: Utc::now(),
+        },
+    )
+    .await;
+    s.notifications.lock().await.entry(recipient).or_default().push(SealedNotice {
+        pair_id,
+        sealed,
+        act_kind: act_kind.to_string(),
+        pointer_uri: pointer_uri.to_string(),
+        queued_at: Utc::now(),
+    });
 }
 
 #[derive(Deserialize)]
@@ -2089,8 +2156,49 @@ async fn dispatch_channel(
             if accept {
                 out["peer_lct"] = serde_json::json!(from);
                 out["peer_pubkey_hex"] = serde_json::json!(state.member_pubkeys.get(&from));
+                // Hub→citizen push (DRAFT): notify the original requester their intro was
+                // accepted — they'd otherwise only learn by polling list_intros.
+                let notice = serde_json::json!({
+                    "event": "intro_accepted",
+                    "intro_id": intro_id,
+                    "peer_lct": caller_lct_id,
+                    "peer_pubkey_hex": state.member_pubkeys.get(&caller_lct_id),
+                }).to_string();
+                notify_citizen(s, from, "notify:intro_accepted", &format!("intro/{intro_id}"), notice.as_bytes()).await;
             }
             Ok(out)
+        }
+        // ---- DRAFT: referenced acts + the hub→citizen notification poll floor ----
+        "notifications" => {
+            // A citizen drains their pending sealed notices (the delivery floor; push to a
+            // registered LCT-MCP endpoint is the future optimization on the same queue).
+            let notices = s.notifications.lock().await.remove(&caller_lct_id).unwrap_or_default();
+            Ok(serde_json::json!({ "total": notices.len(), "notifications": notices }))
+        }
+        "referenced_act" => {
+            // A caller submits a generic referenced act (cbp's handoff/sweep/memo). from =
+            // the authenticated caller; the hub witnesses it. Substance lives at pointer_uri.
+            let to: hub_lib::events::ActAddress = inner.args.get("to")
+                .cloned()
+                .and_then(|v| serde_json::from_value(v).ok())
+                .ok_or_else(|| ApiError::bad_request("referenced_act requires 'to' (ActAddress)".to_string()))?;
+            let act_kind = inner.args.get("kind").and_then(|v| v.as_str())
+                .ok_or_else(|| ApiError::bad_request("referenced_act requires 'kind'".to_string()))?.to_string();
+            let pointer_uri = inner.args.get("pointer_uri").and_then(|v| v.as_str())
+                .ok_or_else(|| ApiError::bad_request("referenced_act requires 'pointer_uri'".to_string()))?.to_string();
+            let consequence_class = inner.args.get("consequence_class")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or(hub_lib::events::ConsequenceClass::Routine);
+            let index = witness_event(s, HubEvent::ReferencedAct {
+                from_lct: caller_lct_id,
+                to,
+                act_kind,
+                pointer_uri,
+                consequence_class,
+                sealed_body: None,
+                acted_at: Utc::now(),
+            }).await?;
+            Ok(serde_json::json!({ "recorded": true, "entry_index": index }))
         }
         // ---- constellation attestation (challenge-response MFA, assurance tiers) ----
         // Wire contract: forum/legion-constellation-attestation-wire-shape-2026-06-11.md.
@@ -4205,6 +4313,41 @@ norms:
         assert_eq!(hits[0]["score"], serde_json::json!(0.91));
         // Unknown LCT: left as index-only (no fabricated name).
         assert!(hits[1].get("name").is_none());
+    }
+
+    #[tokio::test]
+    async fn notify_citizen_witnesses_a_referenced_act_and_queues_a_sealed_notice() {
+        let (_tmp, state) = fresh_rest_state(None).await;
+        // Enroll a citizen with a pinned channel pubkey.
+        let kp = KeyPair::generate();
+        let citizen = Uuid::new_v4();
+        witness_event(&state, HubEvent::MemberAdded {
+            member_lct_id: citizen,
+            added_by: state.sovereign_lct_id,
+            member_name: Some("Cit".into()),
+            member_pubkey_hex: Some(kp.verifying_key().to_hex()),
+        }).await.unwrap();
+
+        // Hub pushes a notification to the citizen.
+        notify_citizen(&state, citizen, "notify:test", "ptr/1", b"hello-citizen").await;
+
+        // Queued for delivery (the poll floor) — sealed, addressed, with the act kind + pointer.
+        {
+            let mb = state.notifications.lock().await;
+            let notices = mb.get(&citizen).expect("a notice was queued");
+            assert_eq!(notices.len(), 1);
+            assert_eq!(notices[0].act_kind, "notify:test");
+            assert_eq!(notices[0].pointer_uri, "ptr/1");
+            assert!(!notices[0].sealed.is_empty(), "the body is sealed to the citizen");
+        }
+        // And witnessed on the ledger as a thin referenced_act (no body on the ledger).
+        let ledger = state.ledger.lock().await;
+        let kinds: Vec<String> = ledger.entries().iter().map(|e| e.event.kind().to_string()).collect();
+        assert!(kinds.contains(&"referenced_act".to_string()));
+        // A notice for an unknown (un-pinned) recipient is dropped, not queued.
+        drop(ledger);
+        notify_citizen(&state, Uuid::new_v4(), "notify:test", "ptr/2", b"x").await;
+        assert_eq!(state.notifications.lock().await.len(), 1, "no pinned pubkey → dropped");
     }
 
     #[tokio::test]

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -696,13 +696,15 @@ async fn notify_citizen(s: &RestState, recipient: Uuid, kind: &str, pointer_uri:
         Err(e) => { tracing::warn!("notify_citizen: seal failed: {e}"); return; }
     };
     // Witness a thin act — a `web4_core::act::Act` verbatim (the convergence's
-    // "both sides witness the same bytes"). `content_hash` binds the witnessed
+    // "both sides witness the same bytes"). `kind` is the `notify:<event>` label
+    // (HUB owns the `notify:*` sub-vocabulary); `content_hash` binds the witnessed
     // pointer to this exact notice body so it can't drift; medium = Message (a
     // direct sealed notice); consequence defaults to Reversible (a notification
     // is freely undoable). The sealed body rides the mailbox below, NOT the ledger.
     let act = web4_core::act::Act::addressed(
         s.sovereign_lct_id,
         web4_core::act::ActAddress::Citizen { lct_id: recipient },
+        kind,
         web4_core::act::SubstanceRef::new(
             pointer_uri,
             web4_core::sha256_hex(body),
@@ -2191,6 +2193,10 @@ async fn dispatch_channel(
                 .cloned()
                 .and_then(|v| serde_json::from_value(v).ok())
                 .ok_or_else(|| ApiError::bad_request("referenced_act requires 'to' (ActAddress)".to_string()))?;
+            // The act's routing label — bare `<verb>` for fleet/peer acts
+            // ("handoff"/"sweep"/"memo"/"forum"), `notify:<event>` for hub→citizen.
+            let kind = inner.args.get("kind").and_then(|v| v.as_str())
+                .ok_or_else(|| ApiError::bad_request("referenced_act requires 'kind'".to_string()))?.to_string();
             let uri = inner.args.get("pointer_uri").and_then(|v| v.as_str())
                 .ok_or_else(|| ApiError::bad_request("referenced_act requires 'pointer_uri'".to_string()))?.to_string();
             let content_hash = inner.args.get("content_hash").and_then(|v| v.as_str())
@@ -2206,6 +2212,7 @@ async fn dispatch_channel(
             let act = web4_core::act::Act::addressed(
                 caller_lct_id,
                 address,
+                kind,
                 web4_core::act::SubstanceRef::new(uri, content_hash, medium),
                 Utc::now(),
             ).with_consequence(consequence);
@@ -4356,6 +4363,15 @@ norms:
         let ledger = state.ledger.lock().await;
         let kinds: Vec<String> = ledger.entries().iter().map(|e| e.event.kind().to_string()).collect();
         assert!(kinds.contains(&"referenced_act".to_string()));
+        // The witnessed act is a verbatim core Act carrying the notify kind, addressed to the
+        // citizen, content-bound to the exact body (sha256), with no ciphertext on the ledger.
+        let witnessed = ledger.entries().iter().find_map(|e| match &e.event {
+            HubEvent::ReferencedAct { act } => Some(act.clone()),
+            _ => None,
+        }).expect("a referenced_act was witnessed");
+        assert_eq!(witnessed.kind, "notify:test");
+        assert_eq!(witnessed.address, web4_core::act::ActAddress::Citizen { lct_id: citizen });
+        assert_eq!(witnessed.substance.content_hash, web4_core::sha256_hex(b"hello-citizen"));
         // A notice for an unknown (un-pinned) recipient is dropped, not queued.
         drop(ledger);
         notify_citizen(&state, Uuid::new_v4(), "notify:test", "ptr/2", b"x").await;

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -325,12 +325,13 @@ pub enum HubEvent {
     ///
     /// Authorship is `act.actor_lct` (the *from*): the hub signs every ledger
     /// entry as the Sovereign (it is the witness), so the actor rides in the
-    /// payload, exactly as `IntroRequested.from_lct`. The cleartext routing
-    /// `kind` and any recipient-sealed body are *delivery* concerns carried on
-    /// the mailbox envelope (the daemon's `SealedNotice`), never duplicated onto
-    /// this witnessed record. A fine-grained act `kind` field is being added to
-    /// core `act::Act` (Legion hosts the registry); until it lands, the coarse
-    /// kind is read from `act.address`.
+    /// payload, exactly as `IntroRequested.from_lct`. The act's routing label
+    /// `act.kind` is bare `<verb>` for fleet/peer acts (`handoff`/`memo`/`sweep`/
+    /// `forum`) or `notify:<event>` for the hub→citizen act-reversed case (Legion
+    /// hosts the registry; HUB owns the `notify:*` sub-vocabulary). Any
+    /// recipient-sealed body is a *delivery* concern carried on the mailbox
+    /// envelope (the daemon's `SealedNotice`), never duplicated onto this
+    /// witnessed record — its integrity is bound instead by `content_hash`.
     ReferencedAct { act: Act },
 }
 
@@ -414,5 +415,45 @@ mod tests {
         };
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains("\"role\":\"treasurer\""));
+    }
+
+    /// The convergence guarantee: a `ReferencedAct`'s payload is a `web4_core::act::Act`
+    /// *verbatim*, so the fleet's first real Act
+    /// (`shared-context/acts/legion-2026-06-24-session-handoff.act.json`) replays onto the
+    /// hub ledger with zero reshaping, and the inner act bytes are identical to what the
+    /// originating cell witnessed ("both sides witness the same bytes").
+    #[tokio::test]
+    async fn legions_first_real_act_round_trips_as_a_referenced_act_payload() {
+        // The artifact, verbatim (kept in-crate so the test is hermetic).
+        let act_json = r#"{
+  "act_id": "7dea2b7a-e0b2-43b5-adb3-6d1c9ed353e3",
+  "actor_lct": "881f13b0-6ca4-445b-b36a-655018174ba5",
+  "address": { "to": "future_self", "entity": "881f13b0-6ca4-445b-b36a-655018174ba5" },
+  "kind": "handoff",
+  "consequence": "reversible",
+  "substance": {
+    "uri": "shared-context/acts/legion-2026-06-24-session-handoff.md",
+    "content_hash": "c903bf541d68a6dd461e56ae2056c761e399b628ce0ef2f1f054b015cd8d282a",
+    "medium": "doc"
+  },
+  "witnesses": [{
+    "lct": "881f13b0-6ca4-445b-b36a-655018174ba5",
+    "attestation": "authored",
+    "signature": "906aa168fe8431391d5a34317a1c16fb83be3e53cc6a077b33d6a4610873a3e3c960ed4416af041593df6a9c586a0e561d5a22eb4e03f3357321e0fcc415ef0a",
+    "timestamp": "2026-06-24T23:11:44.811783264Z"
+  }],
+  "at": "2026-06-24T23:11:44.811510269Z"
+}"#;
+        // It deserializes into the core Act with no hub-side reshaping...
+        let act: Act = serde_json::from_str(act_json).expect("Legion's act parses as a core Act");
+        assert_eq!(act.kind, "handoff");
+        assert!(matches!(act.address, web4_core::act::ActAddress::FutureSelf { .. }));
+
+        // ...and the inner act bytes survive the wrap/unwrap unchanged (verbatim payload).
+        let value_before: serde_json::Value = serde_json::from_str(act_json).unwrap();
+        let event = HubEvent::ReferencedAct { act };
+        assert_eq!(event.kind(), "referenced_act");
+        let HubEvent::ReferencedAct { act: unwrapped } = &event else { unreachable!() };
+        assert_eq!(serde_json::to_value(unwrapped).unwrap(), value_before);
     }
 }

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -20,6 +20,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use web4_core::act::Act;
 use web4_core::role::SocietyRole;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -306,58 +307,31 @@ pub enum HubEvent {
         resolved_at: DateTime<Utc>,
     },
 
-    /// A **referenced act** — the generic thin governance record (DRAFT, pending
-    /// Phase-0 convergence: forum/hub-to-cbp-web4-referenced-act-and-notifications).
-    /// One shape for both fleet lateral/temporal acts (cbp's handoffs/sweeps/memos)
-    /// AND hub→citizen notifications (a notification = this act with `to = Citizen`).
-    /// `from` is the envelope's `actor_lct_id`. The substance lives at `pointer_uri`;
-    /// the ledger only witnesses the act. `High` consequence acts carry a
-    /// `proposal_ref` (M-of-N council gate, already built).
-    ReferencedAct {
-        /// The originator (the act's `from`). The hub signs every ledger entry as
-        /// the Sovereign (it is the witness), so authorship is carried here as a
-        /// field — `from_lct` is the submitting peer (handoff) or the hub itself
-        /// (notification), exactly as `IntroRequested.from_lct` works.
-        from_lct: Uuid,
-        /// Recipient + relevance horizon (MRH-as-addressing).
-        to: ActAddress,
-        /// Act kind — conventioned free-form: "handoff", "sweep", "memo",
-        /// "notify:intro_accepted", "notify:pair_message", "notify:role_assigned", …
-        act_kind: String,
-        /// Pointer to the substance (forum URL, git commit, snarc id, /pairs/:id, …).
-        pointer_uri: String,
-        consequence_class: ConsequenceClass,
-        /// Optional recipient-only body: ciphertext sealed to the recipient's pinned
-        /// pubkey. Usually carried in the delivery mailbox (kept off the thin ledger);
-        /// present here only when the body should itself be witnessed.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        sealed_body: Option<String>,
-        acted_at: DateTime<Utc>,
-    },
-}
-
-/// Who a [`HubEvent::ReferencedAct`] is addressed to — the MRH scope IS the addressing.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "scope", rename_all = "snake_case")]
-pub enum ActAddress {
-    /// Another instance of the plural self (next wake / post-compaction). MRH = temporal.
-    FutureSelf { entity: Uuid },
-    /// A peer cell (machine/track LCT). MRH = lateral.
-    Peer { lct_id: Uuid },
-    /// A specific citizen of this society (the notification case).
-    Citizen { lct_id: Uuid },
-    /// A role — fan-out to current holders.
-    Role { role: String },
-}
-
-/// Consequence tier of a referenced act. `High` requires an M-of-N `proposal_ref`
-/// (enforced later; recorded now).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ConsequenceClass {
-    Informational,
-    Routine,
-    High,
+    /// A **referenced act** — a thin, witnessed governance record of an entity
+    /// externalizing work: the one primitive behind fleet handoffs
+    /// (`to = Peer`), hub→citizen notifications (`to = Citizen` — a notification
+    /// is just this act *reversed*), forum posts (`to = Society`), and memory
+    /// writes (`to = FutureSelf`). The payload is a [`web4_core::act::Act`]
+    /// **verbatim**, so the originating cell and every witness serialize
+    /// byte-identical records (convergence:
+    /// `forum/legion-to-hub-referenced-act-shape-converged-2026-06-20`).
+    ///
+    /// The act binds to a *specific version* of its substance via
+    /// `act.substance.content_hash` (a witnessed pointer that can't silently
+    /// drift from the fat thing it attests), and its reversibility
+    /// (`act.consequence`) drives the council gate —
+    /// `ConsequenceClass::Irreversible ⇒ proposal_ref`, via
+    /// [`web4_core::act::ConsequenceClass::requires_council`].
+    ///
+    /// Authorship is `act.actor_lct` (the *from*): the hub signs every ledger
+    /// entry as the Sovereign (it is the witness), so the actor rides in the
+    /// payload, exactly as `IntroRequested.from_lct`. The cleartext routing
+    /// `kind` and any recipient-sealed body are *delivery* concerns carried on
+    /// the mailbox envelope (the daemon's `SealedNotice`), never duplicated onto
+    /// this witnessed record. A fine-grained act `kind` field is being added to
+    /// core `act::Act` (Legion hosts the registry); until it lands, the coarse
+    /// kind is read from `act.address`.
+    ReferencedAct { act: Act },
 }
 
 /// Why a pair ended. Captures audit-relevant intent so V3 trust

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -305,6 +305,59 @@ pub enum HubEvent {
         declines: Vec<Uuid>,
         resolved_at: DateTime<Utc>,
     },
+
+    /// A **referenced act** — the generic thin governance record (DRAFT, pending
+    /// Phase-0 convergence: forum/hub-to-cbp-web4-referenced-act-and-notifications).
+    /// One shape for both fleet lateral/temporal acts (cbp's handoffs/sweeps/memos)
+    /// AND hub→citizen notifications (a notification = this act with `to = Citizen`).
+    /// `from` is the envelope's `actor_lct_id`. The substance lives at `pointer_uri`;
+    /// the ledger only witnesses the act. `High` consequence acts carry a
+    /// `proposal_ref` (M-of-N council gate, already built).
+    ReferencedAct {
+        /// The originator (the act's `from`). The hub signs every ledger entry as
+        /// the Sovereign (it is the witness), so authorship is carried here as a
+        /// field — `from_lct` is the submitting peer (handoff) or the hub itself
+        /// (notification), exactly as `IntroRequested.from_lct` works.
+        from_lct: Uuid,
+        /// Recipient + relevance horizon (MRH-as-addressing).
+        to: ActAddress,
+        /// Act kind — conventioned free-form: "handoff", "sweep", "memo",
+        /// "notify:intro_accepted", "notify:pair_message", "notify:role_assigned", …
+        act_kind: String,
+        /// Pointer to the substance (forum URL, git commit, snarc id, /pairs/:id, …).
+        pointer_uri: String,
+        consequence_class: ConsequenceClass,
+        /// Optional recipient-only body: ciphertext sealed to the recipient's pinned
+        /// pubkey. Usually carried in the delivery mailbox (kept off the thin ledger);
+        /// present here only when the body should itself be witnessed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sealed_body: Option<String>,
+        acted_at: DateTime<Utc>,
+    },
+}
+
+/// Who a [`HubEvent::ReferencedAct`] is addressed to — the MRH scope IS the addressing.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "scope", rename_all = "snake_case")]
+pub enum ActAddress {
+    /// Another instance of the plural self (next wake / post-compaction). MRH = temporal.
+    FutureSelf { entity: Uuid },
+    /// A peer cell (machine/track LCT). MRH = lateral.
+    Peer { lct_id: Uuid },
+    /// A specific citizen of this society (the notification case).
+    Citizen { lct_id: Uuid },
+    /// A role — fan-out to current holders.
+    Role { role: String },
+}
+
+/// Consequence tier of a referenced act. `High` requires an M-of-N `proposal_ref`
+/// (enforced later; recorded now).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsequenceClass {
+    Informational,
+    Routine,
+    High,
 }
 
 /// Why a pair ended. Captures audit-relevant intent so V3 trust
@@ -354,6 +407,7 @@ impl HubEvent {
             Self::VaultUnlockRequested { .. } => "vault_unlock_requested",
             Self::VaultUnlockAttested { .. } => "vault_unlock_attested",
             Self::VaultUnlockResolved { .. } => "vault_unlock_resolved",
+            Self::ReferencedAct { .. } => "referenced_act",
         }
     }
 }

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -290,7 +290,10 @@ impl HubState {
             // tier-2 M-of-N decision. They don't change member/role/pair state.
             | HubEvent::VaultUnlockRequested { .. }
             | HubEvent::VaultUnlockAttested { .. }
-            | HubEvent::VaultUnlockResolved { .. } => {
+            | HubEvent::VaultUnlockResolved { .. }
+            // Referenced acts are thin witnessed records; the substance lives at
+            // pointer_uri, not in HubState.
+            | HubEvent::ReferencedAct { .. } => {
                 // Not projected into HubState yet — these affect society.json /
                 // charter.json / hub-law.yaml instead. Future sprints surface
                 // them here too.


### PR DESCRIPTION
**Draft — pending Phase-0 convergence** on the act field set (forum: hub-to-cbp-web4-referenced-act-and-notifications). The concrete impl alongside the spec, so it's deploy-ready the moment the shape is agreed.

One `HubEvent::ReferencedAct` covers both cbp's fleet handoffs and hub→citizen push (a notification = the act with `to: Citizen`). `notify_citizen` seals to the pinned pubkey + witnesses a thin act + queues a `SealedNotice`; the `notifications` channel tool is the poll floor; `respond_intro` accept now notifies the requester. Push-to-LCT-MCP-endpoint + endpoint registration are the follow-on. 20 daemon + 154 lib tests.

Not for merge until web4/cbp/hestia sign off on the field set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)