### PR TITLE
spec(C81): remediate 7 autonomous C80 findings on core-spec/multi-device-lct-binding.md

### DIFF
--- a/docs/audits/C81-multi-device-lct-binding-remediation-2026-06-21.md
+++ b/docs/audits/C81-multi-device-lct-binding-remediation-2026-06-21.md
@@ -1,0 +1,52 @@
+# `multi-device-lct-binding.md` — C80 Remediation (C81)
+
+**Remediated file**: `web4-standard/core-spec/multi-device-lct-binding.md`
+**Date**: 2026-06-21
+**Series**: C-series, C81 (remediation). Chain: **C19** (first-pass) → #246 → **C36** (first delta) → #281 → **C80** (second delta, PR #371) → **C81** (this).
+**Source audit**: `docs/audits/C80-multi-device-lct-binding-delta-audit-2026-06-21.md` ("Implementation-track flag" table).
+**Scope**: apply ONLY C80's **Autonomous**-routed findings. Design-Q / operator / deferred items are explicitly held (see "Not applied" below).
+**Authority aligned to** (canonical precedence: SDK + shipped vectors > spec text): `implementation/sdk/web4/binding.py`, `test-vectors/binding/binding-vectors.json`.
+
+---
+
+## Findings applied (7)
+
+| C80 | Sev | Site(s) | Change |
+|-----|-----|---------|--------|
+| **§A flagship** | HIGH | §3.2 enrollment, L490 | `cross_witness(existing_device, new_device)` → `cross_witness(root_lct.device_constellation, existing_device, new_device)`. #281 changed `cross_witness` from 2→3 params and swept §3.6 (L840) but missed this call site → a spec-faithful enrollment `TypeError`s. Now matches the §3.3 signature + §3.6 caller. |
+| **N3** | MED | §2.4 example, §3.3 comment, §3.4 algo, §7.1 summary | Renamed `cross_device_witnesses` → `cross_witnesses` at **all 4 sites** and reshaped the §2.4 example from object entries (keyed `device_lct_id` + `last_witness`/`witness_count`) to a **bare device-LCT-ID string list**. §3.4 `compute_cross_witness_density` now iterates `for w_id in d.cross_witnesses` over strings. Matches SDK `DeviceRecord.cross_witnesses: List[str]` (binding.py:184) and the shipped `constellation_trust_multi_device` vector (`["dev1","dev2"]`). Before: spec-faithful `compute_cross_witness_density` evaluated `"dev1"["device_lct_id"]` → crash on the canonical vector. |
+| **N4** | MED | §2.4 example, §3.4 comment | Removed the orphaned `device_trust` block (`anchor_strength`/`attestation_freshness`/`cross_witness_score`) — read by no algorithm, no SDK counterpart. Updated the §3.4 comment that pointed at it (now: "not also contained in a separate pre-aggregated trust block"). |
+| **N5** | MED | §2.3 / §2.4 boundary | Added a **"Constellation entry → resolved device record"** note: the §2.3 entries are the membership index; the trust algorithms operate over the resolved record (entry joined with the §2.4 Device LCT) = the single flat SDK `DeviceRecord` shape, which additionally exposes `cross_witnesses` (bare strings) + optional `latest_attestation`. Documents the projection so the §3.4 reads (`cross_witnesses`, `latest_attestation`) have a declared home. Root cause of N3/N4 — applied together. |
+| **N6** | LOW | §2.4 lifecycle bullet | Scope-note: the 4 user-initiated reasons (`lost`/`sold`/`compromised`/`upgrade`) are set via §3.5 and are the only values the SDK `remove_device` guard accepts; `recovery_revoked` is **set only by the §3.6 recovery path**, never a `remove_device` reason — so the §3.5/SDK 4-value guard is correct by construction. **SDK left unchanged** (see decision note). |
+| **N7** | LOW | §3.5 L747 | Signature-collection loop iterates `authorizing_active` (the quorum-filtered set) instead of raw `authorizing_devices`, consistent with the quorum check the same function enforces (C36-N8 fix). Added a one-line rationale comment. |
+| **N8** | LOW | §5.2 docstring + comment | "true majority: ceil(device_count/2)" → "at least half the devices: ceil(device_count/2)" with an explicit even-n note (n=6→3 is exactly half, not strict majority); comment `# ceil(n/2) = majority` → `# ceil(n/2): at least half`. Numbers were already correct (vectors n=5→3, n=6→3, n=10→5 unchanged); only the word was imprecise. |
+
+**N3 four-site sweep (the flagship's own lesson, honored):** `cross_device_witnesses` grep → **0** post-edit; `cross_witnesses` present at §2.3 note, §2.4 example + note, §3.3 comment, §3.4 algo, §7.1 summary. An incomplete rename here would have reproduced exactly the incomplete-sweep regression that *was* C80's flagship.
+
+## Decision note — N6 (spec-note only, SDK guard unchanged)
+
+C80 flagged N6 as "Autonomous (spec note) + SDK-track (add `recovery_revoked` to `valid_reasons`)" with the resolution offering an explicit **"or"**: loosen the SDK guard, **or** scope `recovery_revoked` in §2.4 so the 4-value guard is correct by construction. I took the **scope-note arm only** and deliberately left the SDK guard at 4 values, because `recovery_revoked` is a **recovery side-effect** (§3.6 sets `device.revocation_reason` directly), not a user-initiated removal reason — loosening `remove_device`'s guard would mis-model it (it would let a caller "remove" a device citing a reason that only the recovery path may set). The conservative arm preserves the guard's tightness. The policy reviewer confirmed this is within the auditor's explicit either-or, not under-delivery. Result: **no SDK change**; the 95 `test_binding*.py` tests stay green and remain the canonical authority the spec now matches.
+
+## Not applied (held — out of C81 scope)
+
+| C80 | Type | Why held |
+|-----|------|----------|
+| **N1** (T3 flat 8-dim vs canonical 3-root) | Design-Q / cross-spec | Requires coordinated t3-v3 + ontology edits (closes deferred C19-M5); not unilaterally applicable to multi-device alone. |
+| **N2** (T3 no entity-role binding) | Design-Q / cross-spec | Same edit site as N1; couples the role-context invariant in `t3-v3-tensors.md`. |
+| **C36-N9** (Society reciprocity; birth-cert authority now SAL) | Operator / cross-track | Couples carry-C23-H1; canonical owner is `web4-society-authority-law.md §3.4`. |
+| **C36-N11** (entity-segmented LCT IDs) | Design-Q | Feeds carry-C33 B-H1 (`lct:web4:` surface form). |
+| **C19-M3** (3 exception classes vs `errors.md`) | Deferred | `NoHardwareAnchorError` is the true gap; quorum reuse path (`W4_ERR_WITNESS_QUORUM`) intact. Fold into carry-C30. |
+| **C19-M4** (LCT-core does not acknowledge §7.1 extension) | Deferred | Cross-spec LCT-reciprocity. |
+| **C19-M5** (8 T3 sub-dims absent from ontology) | Deferred / Design-Q | Couples N1 — resolve together. |
+| **C19-M7** (§7.3 ATP costs vs `atp-adp-cycle.md`) | Deferred | Cross-spec design-Q; no atp-adp counterpart exists. |
+
+These remain in the standing carry ledger for an operator / cross-track turn. With C81, the **autonomous** remainder of the multi-device C19→C36→C80 chain is closed; only the cross-spec/design-Q/operator carries persist.
+
+## Verification
+
+- `cross_device_witnesses` grep = 0; `cross_witnesses` at all intended sites; `device_trust` block gone (only the local `device_trust`/`device_trusts` variables remain in `compute_constellation_trust`, correct); §3.2 call now 3-arg; §3.5 loop iterates `authorizing_active`; §5.2 wording fixed at both sites.
+- `binding.py` parses; `tests/test_binding.py` + `tests/test_binding_attestation.py` → **95 passed**. SDK + vectors unchanged (the spec was aligned to them, not vice-versa).
+
+---
+
+*"An arity change is a rename of the call contract — sweep every call site. A field rename is the same — sweep every site, then grep to zero."*

--- a/web4-standard/core-spec/multi-device-lct-binding.md
+++ b/web4-standard/core-spec/multi-device-lct-binding.md
@@ -231,6 +231,8 @@ The Root LCT extends the base LCT with device constellation management:
 }
 ```
 
+> **Constellation entry → resolved device record.** The `device_constellation.devices[]` entries above are the *membership index* — they carry `device_lct_id`, `anchor_type`, `enrolled_at`, `last_witnessed`, and `status`. The trust algorithms (§3.4 `compute_constellation_trust` / `compute_cross_witness_density`, §4.3) operate over the **resolved device record**: each entry joined with its standalone Device LCT (§2.4) to yield the single flat shape the SDK `DeviceRecord` (`implementation/sdk/web4/binding.py`) computes over. Beyond the index fields, that resolved record additionally exposes `cross_witnesses` (list of bare device-LCT-ID strings, §2.4) and an optional `latest_attestation` (an `AttestationEnvelope`, used for attestation freshness; defaults to no-penalty 1.0 when absent). Implementations MAY denormalize these onto the constellation entry directly; the algorithms read them by name off the per-device record regardless of storage layout.
+
 ### 2.4 Device LCT Structure
 
 Each device has its own LCT that binds to the root:
@@ -271,29 +273,21 @@ Each device has its own LCT that binds to the root:
     "last_root_sync": "2026-01-13T12:00:00Z"
   },
 
-  "cross_device_witnesses": [
-    {
-      "device_lct_id": "lct:web4:device:laptop:...",
-      "last_witness": "2026-01-13T11:00:00Z",
-      "witness_count": 42
-    }
+  "cross_witnesses": [
+    "lct:web4:device:laptop:..."
   ],
-
-  "device_trust": {
-    "anchor_strength": 0.95,
-    "attestation_freshness": 0.98,
-    "cross_witness_score": 0.88
-  },
 
   "status": "active"
 }
 ```
 
+> **`cross_witnesses` shape (canonical).** Each entry is a **bare device-LCT-ID string** — the set of devices that have cross-witnessed this one. This matches the SDK `DeviceRecord.cross_witnesses: List[str]` (`implementation/sdk/web4/binding.py`) and the shipped `constellation_trust_multi_device` test vector (`test-vectors/binding/binding-vectors.json`), and is the shape the §3.4 cross-witness-density algorithm iterates. (Earlier drafts carried object entries keyed `device_lct_id` with `last_witness`/`witness_count`; those richer per-witness records are not part of the trust-computation wire surface and were removed to keep one shape corpus-wide.)
+
 **Device lifecycle states**: A device record's `status` field is one of three values:
 
 - `"active"` — Device participates in trust computation, cross-witnessing, and may authorize removal/recovery.
 - `"suspended"` — Device is temporarily excluded from trust computation and cross-witnessing without being permanently revoked. Re-activation by quorum is a future extension; this spec does not define entry/exit transitions for `suspended`. Implementations that do not require suspension semantics MAY treat `suspended` as equivalent to `revoked` for trust-computation purposes.
-- `"revoked"` — Device is permanently removed from the constellation (see §3.5 Device Removal). A revoked device's keys MUST NOT authorize any further operations. A revoked device record additionally carries `revoked_at` (ISO 8601 timestamp) and `revocation_reason` (one of `lost` | `sold` | `compromised` | `upgrade` | `recovery_revoked`); both are absent on `active`/`suspended` records.
+- `"revoked"` — Device is permanently removed from the constellation (see §3.5 Device Removal). A revoked device's keys MUST NOT authorize any further operations. A revoked device record additionally carries `revoked_at` (ISO 8601 timestamp) and `revocation_reason` (one of `lost` | `sold` | `compromised` | `upgrade` | `recovery_revoked`); both are absent on `active`/`suspended` records. The first four reasons are **user-initiated removals** set via §3.5 Device Removal (and are the only values the SDK `remove_device` guard accepts). `recovery_revoked` is **set only by the §3.6 recovery path** when a quorum recovery supersedes lost devices — it is never a valid `remove_device` reason, so the §3.5/SDK 4-value removal guard is correct by construction.
 
 ## 3. Protocols
 
@@ -487,7 +481,7 @@ def enroll_additional_device(root_lct, existing_device, new_device, society):
     root_lct.add_device(new_device_lct)
 
     # 9. Perform initial cross-device witnessing
-    cross_witness(existing_device, new_device)
+    cross_witness(root_lct.device_constellation, existing_device, new_device)
 
     return new_device_lct
 ```
@@ -532,7 +526,7 @@ def cross_witness(constellation, device_a, device_b):
         "sig_b": sig_b_for_a
     }
 
-    # 5. Update cross_device_witnesses in both device LCTs.
+    # 5. Update cross_witnesses in both device LCTs.
     # record_cross_witness (canonical definition in the Web4 SDK,
     # implementation/sdk/web4/binding.py) adds each device to the other's
     # cross-witness list and refreshes last_witnessed; it is idempotent.
@@ -571,7 +565,7 @@ def compute_constellation_trust(root_lct):
 
     # Individual device trust: anchor × witness freshness × attestation freshness.
     # Anchor strength is incorporated via anchor_weight ONLY (it is not also
-    # contained in a separate `composite` aggregate — see §2.4 device_trust).
+    # contained in a separate pre-aggregated trust block on the device record).
     device_trusts = []
     for device in active:
         anchor_weight = ANCHOR_TRUST_WEIGHT[device.anchor_type]
@@ -697,11 +691,12 @@ def compute_cross_witness_density(devices):
     possible_pairs = len(devices) * (len(devices) - 1) / 2
     device_ids = set(d.device_lct_id for d in devices)
 
-    # Count unique mutual witness pairs (in-constellation only)
+    # Count unique mutual witness pairs (in-constellation only).
+    # d.cross_witnesses is a list of bare device-LCT-ID strings (see §2.4 and
+    # the SDK DeviceRecord.cross_witnesses); iterate the ids directly.
     witness_pairs = set()
     for d in devices:
-        for w in d.cross_device_witnesses:
-            w_id = w["device_lct_id"]
+        for w_id in d.cross_witnesses:
             if w_id in device_ids:
                 witness_pairs.add(tuple(sorted([d.device_lct_id, w_id])))
 
@@ -743,8 +738,12 @@ def remove_device(root_lct, device_to_remove, reason, authorizing_devices):
         "requested_at": utc_now()
     }
 
+    # Collect signatures only from the quorum-filtered set (authorizing_active),
+    # not the raw authorizing_devices argument — a device that is not in the
+    # remaining-active set (e.g. the device being removed) must not contribute a
+    # removal signature, consistent with the quorum check just enforced.
     signatures = []
-    for device in authorizing_devices:
+    for device in authorizing_active:
         sig = device.sign_removal_request(removal_request)
         signatures.append(sig)
 
@@ -981,7 +980,8 @@ def default_recovery_quorum(device_count):
     Minimum devices needed for recovery.
 
     Balances security vs. recoverability. For device_count > 4, the quorum
-    is a true majority: ceil(device_count / 2). Test vectors in
+    is at least half the devices: ceil(device_count / 2). (For even n this is
+    exactly n/2, not a strict majority — e.g. n=6 → 3.) Test vectors in
     `web4-standard/test-vectors/binding/binding-vectors.json` (group
     `recovery_quorum_calculation`) are normative for the expected values
     (n=5 → 3, n=6 → 3, n=10 → 5).
@@ -991,7 +991,7 @@ def default_recovery_quorum(device_count):
     elif device_count <= 4:
         return 2
     else:
-        return max(2, (device_count + 1) // 2)  # ceil(n/2) = majority
+        return max(2, (device_count + 1) // 2)  # ceil(n/2): at least half
 ```
 
 ### 5.3 Compromise Response
@@ -1087,7 +1087,7 @@ const credential = await navigator.credentials.create({
 
 This protocol extends [`LCT-linked-context-token.md`](LCT-linked-context-token.md):
 - Adds `device_constellation` to root LCT structure
-- Adds `root_attestation` and `cross_device_witnesses` to device LCT
+- Adds `root_attestation` and `cross_witnesses` to device LCT
 - Extends T3 tensor with `hardware_binding_strength` and `constellation_coherence`
 
 ### 7.2 Society Specification


### PR DESCRIPTION
## C81 — multi-device-lct-binding remediation

Applies the **7 Autonomous-routed findings** from the **C80** second delta re-audit (PR #371, `docs/audits/C80-...md` "Implementation-track flag" table). Chain: C19 → #246 → C36 → #281 → C80 → **C81 (this)**.

Design-Q / operator / deferred carries are **held** (N1/N2 T3 3-root structure, C36-N9 SAL birth-cert authority, C36-N11 id scheme, C19-M3/M4/M5/M7) — they need cross-spec/ontology coordination or an operator turn.

### Findings applied
| C80 | Sev | Change |
|-----|-----|--------|
| **§A flagship** | HIGH | §3.2 `cross_witness()` call left at old 2-arg arity by #281's 2→3 param signature change (swept §3.6, missed §3.2) → un-callable enrollment. Now 3-arg, mirroring §3.6. |
| **N3** | MED | Rename `cross_device_witnesses`→`cross_witnesses` at **all 4 sites** + reshape to bare device-LCT-ID strings; §3.4 iterates strings. Matches SDK `DeviceRecord.cross_witnesses` + `constellation_trust_multi_device` vector (spec-faithful impl previously crashed on the canonical vector). |
| **N4** | MED | Drop orphan §2.4 `device_trust` block (read by no algorithm, no SDK counterpart). |
| **N5** | MED | Add constellation-entry → resolved-device-record projection note (aligned to SDK `DeviceRecord`) so §3.4 reads have a schema home. |
| **N6** | LOW | Scope-note `recovery_revoked` as §3.6-recovery-only; SDK 4-value `remove_device` guard left correct-by-construction (no loosening — see decision note in C81 doc). |
| **N7** | LOW | §3.5 signature loop iterates quorum-filtered `authorizing_active`. |
| **N8** | LOW | §5.2 "true majority" → "at least half (ceil n/2)" + even-n note. |

### Verification
- `cross_device_witnesses` grep → **0** (4-site sweep complete — the flagship's own incomplete-sweep lesson honored); `device_trust` block gone; §3.2 3-arg; §3.5 iterates `authorizing_active`; §5.2 fixed both sites.
- SDK + vectors **unchanged** (the spec was aligned to them); `test_binding.py` + `test_binding_attestation.py` → **95 passed**.
- Net diff: 1 spec file +23/−23; 1 new remediation doc.

multi-device C19→C36→C80→C81 **autonomous chain closed**; cross-spec/design-Q/operator carries persist in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)