### PR TITLE
spec(C87): remediate 8 autonomous C86 findings on core-spec/acp-framework.md (C18→C37→C86→C87)

### DIFF
--- a/web4-standard/core-spec/acp-framework.md
+++ b/web4-standard/core-spec/acp-framework.md
@@ -86,7 +86,8 @@ A declarative specification of what an agent intends to accomplish:
       "fallback": "deny"
     },
     "expiresAt": "2026-01-01T00:00:00Z"
-  }
+  },
+  "createdAt": "2025-09-15T15:30:00Z"
 }
 ```
 
@@ -158,14 +159,21 @@ Immutable record of action execution:
     "resourcesConsumed": {"atp": 2}
   },
   "t3v3Delta": {
-    "agent": {"t3": {"temperament": +0.01}},
-    "client": {"v3": {"valuation": +0.02}}
+    "agent": {"t3": {"temperament": 0.01}},
+    "client": {"v3": {"valuation": 0.02}}
   },
   "witnesses": ["lct:web4:witness:A"],
   "timestamp": "2025-09-15T15:30:10Z",
   "canonicalHash": "sha256:exec_hash_002"
 }
 ```
+
+> **ATP accounting.** `result.resourcesConsumed.atp` records the ATP **discharged**
+> by this execution in the sense of [`atp-adp-cycle.md`](./atp-adp-cycle.md) §2.3
+> (ATP→ADP transition) — it is the *same* quantity, not a separate ACP metering
+> unit. ACP records consumption against the plan's `resourceCaps.maxAtp` budget;
+> it does not mint, charge, or value ATP. The corresponding `atpConsumed` rollups
+> in §6.2 and §8.2 refer to this same discharge total.
 
 ## 3. ACP State Machine
 
@@ -223,7 +231,7 @@ Immutable record of action execution:
 | Failed | Retry | Idle | Reset state for retry |
 | Any active state¹ | Error / Timeout / Deny / Law-check fail | Failed | Log reason, rollback |
 
-¹ **"Any active state"** = the five in-flight states (Planning, Intent Created, Approval Gate, Executing, Recording). `Idle` and `Complete` are excluded: a terminal/idle plan does not transition straight to `Failed` (the SDK `VALID_TRANSITIONS` permits `→Failed` only from the five active states). The wildcard row therefore expands to **six** distinct `→Failed` edges (one per active state, plus the Intent-Created law-check-fail / Approval-Gate deny edges collapse into their source-state entry). Counting the six wildcard-expanded `→Failed` edges plus the seven explicit rows above yields the **13 transitions** asserted by conformance vector `acp-002` (`totalValidTransitions=13`). The `Deny` and `Law-check fail` events are normal governance outcomes routed to `Failed`, not transport errors.
+¹ **"Any active state"** = the five in-flight states (Planning, Intent Created, Approval Gate, Executing, Recording). `Idle` and `Complete` are excluded: a terminal/idle plan does not transition straight to `Failed` (the SDK `VALID_TRANSITIONS` permits `→Failed` only from the five active states). The wildcard row therefore expands to **five** distinct `→Failed` edges (one per active state); the Intent-Created law-check-fail and Approval-Gate deny events are additional triggers routed to `Failed` from states already counted, not new edges. Counting the five wildcard-expanded `→Failed` edges plus the **eight** explicit rows above yields the **13 transitions** asserted by conformance vector `acp-002` (`totalValidTransitions=13`). The `Deny` and `Law-check fail` events are normal governance outcomes routed to `Failed`, not transport errors.
 
 ## 4. ACP-AGY Integration
 
@@ -320,7 +328,7 @@ Critical actions require witness attestation:
 {
   "witness_requirement": {
     "level": 2,  // Number of witnesses required
-    "types": ["time", "audit"],  // Types of witnesses
+    "types": ["time", "audit-minimal"],  // Types of witnesses (Witness Role Registry roles)
     "quorum": {
       "model": "byzantine",
       "threshold": 0.67
@@ -373,8 +381,8 @@ Real-time visibility into agent operations:
     "successRate": 0.98,
     "atpConsumed": 523,
     "trustTrend": {
-      "agent": {"t3": +0.05, "period": "7d"},
-      "client": {"v3": +0.03, "period": "7d"}
+      "agent": {"t3": 0.05, "period": "7d"},
+      "client": {"v3": 0.03, "period": "7d"}
     },
     "alerts": [
       {
@@ -433,6 +441,11 @@ lct:intent acp:hasExecutionRecord lct:record .
 lct:record acp:executedBy lct:agent .
 lct:record acp:witnessedBy lct:witness .
 lct:record acp:recordedIn lct:ledger .
+lct:record acp:executedIntent lct:intent .   # inverse of acp:hasExecutionRecord
+
+# Execution-record result literals (from ExecutionRecord §2.4)
+lct:record acp:status "success" .            # result.status
+lct:record acp:atpConsumed 2 .               # result.resourcesConsumed.atp (§2.4 ATP accounting)
 ```
 
 ### 8.2 SPARQL Queries
@@ -440,22 +453,29 @@ lct:record acp:recordedIn lct:ledger .
 Query agent performance:
 
 ```sparql
-SELECT ?agent ?successRate ?avgATP WHERE {
-  ?plan acp:hasAgent ?agent .
+PREFIX acp: <https://web4.io/ontology/acp#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?agent
+       (COUNT(?record) AS ?total)
+       (SUM(IF(?status = "success", 1, 0)) AS ?successes)
+       (SUM(IF(?status = "success", xsd:double(1), xsd:double(0))) / COUNT(?record) AS ?successRate)
+       (AVG(?atp) AS ?avgATP)
+WHERE {
+  ?plan   acp:hasAgent ?agent .
   ?intent acp:derivedFrom ?plan .
   ?record acp:executedIntent ?intent ;
           acp:status ?status ;
           acp:atpConsumed ?atp .
-  
-  # Calculate metrics
-  BIND(COUNT(?record) AS ?total)
-  BIND(COUNT(IF(?status = "success", 1, 0)) AS ?successes)
-  BIND(?successes / ?total AS ?successRate)
-  BIND(AVG(?atp) AS ?avgATP)
 }
 GROUP BY ?agent
 ORDER BY DESC(?successRate)
 ```
+
+Aggregates appear only in `SELECT` projections (not `BIND`); the conditional
+success count uses `SUM(IF(...))` (a bare `COUNT(IF(...))` would count every
+solution because `IF` always returns a bound value); and `?agent` — the only
+non-aggregated projection — is grouped.
 
 ## 9. Implementation Requirements
 
@@ -575,6 +595,16 @@ def handle_acp_error(error, context):
 ```
 
 ## 11. Use Cases
+
+> **Note — illustrative, non-normative.** The YAML plans in this section are
+> conceptual sketches that communicate intent, not wire format. Their `guards:`
+> keys (e.g. `max_daily_amount`, `require_witness`, `auto_isolation`,
+> `false_positive_rate`) are domain shorthand and are **not** part of the
+> canonical guard model defined in §2.1
+> (`{lawHash, resourceCaps{maxAtp,maxExecutions,rateLimit}, witnessLevel, humanApproval, expiresAt}`).
+> A conformant plan MUST express its guards using the §2.1 fields; domain limits
+> like a daily-amount ceiling are enforced through `resourceCaps` and the
+> applicable society law, not through ad-hoc guard keys.
 
 ### 11.1 Invoice Processing
 


### PR DESCRIPTION
## C87 — ACP Framework Remediation

Applies the **8 AUTONOMOUS-routed findings** from the C86 second-delta audit (`docs/audits/C86-acp-framework-2nd-delta-2026-06-22.md`, Routing Summary) to a single spec file. DESIGN-Q and CROSS-TRACK findings are surfaced to operator/existing queues, **not** self-applied.

**Lineage:** C18 (internal-consistency) → C37 (1st delta, #283) → C86 (2nd delta, #377) → **C87** (this PR). Cycle COMPLETE.

### Fixes (all spec-local; authority in-file or in already-correct schema/SDK/registry)

| ID | Section | Fix |
|----|---------|-----|
| B1 | §2.4 / §6.2 | strip 4 leading-`+` numeric literals (invalid JSON grammar) |
| B2 | §3.2 footnote | fix #283-introduced miscount 6+7 → correct **5+8=13** (a [[feedback_remediation_introduced_regression]] instance) |
| B3 | §5.2 | witness type `"audit"` → `"audit-minimal"` (Witness Role Registry) |
| B4 | §8.1 | declare `executedIntent`/`status`/`atpConsumed` used by the §8.2 query |
| B5 | §8.2 | rewrite invalid SPARQL (aggregates-in-`BIND`, `IF`-as-counter, ungrouped projection) as a valid SPARQL 1.1 aggregate query |
| B6 | §11 | add illustrative/non-normative note (use-case YAML guards ≠ canonical §2.1 guard model) |
| B7 | §2.4 | cross-reference `atpConsumed` == atp-adp §2.3 discharge quantity |
| B10 | §2.1 | add `createdAt` to AgentPlan example (to_dict always emits it; §2.2 sibling shows it) |

### Verification
- All **7** `json` fences parse (`json.loads` after comment-strip); **0** leading-`+` literals remain.
- Rewritten §8.2 SPARQL validates **VALID** under `rdflib 7.6.0` `prepareQuery()`.
- B4: §8.2's 3 predicates now declared in §8.1.
- B2: footnote arithmetic 5 (wildcard `→Failed`) + 8 (explicit rows) = 13, matching vector `acp-002`.
- Diff: **+45/−15**, single file. No schema/SDK/other-spec edits.

### Out of scope (surfaced, not applied)
- **DESIGN-Q (operator)**: B-LEDGERPROOF/B9 (`ledgerProof` admit-vs-strip), B11 (subsystem `W4_ERR_*` → RFC 9457 envelope), B14 (ACP-critical-actions scope), B5-5/C37-8 (to_dict-vs-JSON-LD convention).
- **CROSS-TRACK**: B-AGENCY (proofOfAgency envelope → reputation/mcp bundle), B8 (R6 discharge), B12/B13 (SAL witness vocab / M7), B-M6 (`acp-ontology.ttl`), B15 (metering/D0).
- **Carries STILL-OPEN**: M3 (`resourceCaps` snake/camel), M7 (integer vs structured witness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)