### PR TITLE
spec(C89): remediate 4 autonomous C88 findings on core-spec/presence-protocol.md (C5→C38→C88→C89)

### DIFF
--- a/web4-standard/core-spec/presence-protocol.md
+++ b/web4-standard/core-spec/presence-protocol.md
@@ -84,10 +84,11 @@ This protocol is versioned with a single integer `protocolVersion`.
   change to error code semantics, requires a version bump.**
   Exception: **optional additive fields** (new keys that older readers
   can safely ignore) are back-compatible and do NOT trigger a bump.
-  `status`/`nextPollMs` (output, v1 back-compat addition) and
-  `synthetic` (input, v1 back-compat addition) were both added under
-  this exception. Removals, renames, type changes, or new required
-  fields always bump.
+  `status`/`nextPollMs` (output, v1 back-compat addition — fully
+  conformed: schema + vector P1-004 + CHANGELOG) and `synthetic`
+  (input, v1 back-compat addition — spec-documented but not yet
+  artifact-conformed; see §8) were both added under this exception.
+  Removals, renames, type changes, or new required fields always bump.
 
 The daemon advertises its `protocolVersion` in the
 [`hestia_connect`](#31-hestia_connect) response. SDKs MUST expose a
@@ -333,19 +334,23 @@ the credential's allow-list.
   "approvalToken": null
 }
 ```
-`approvalToken` is reserved for v1+ flows that require user
-interactive approval; in v0 it's always `null`.
+`approvalToken` is reserved for v2+ flows that require user
+interactive approval; in v0 and v1 it's always `null` (interactive
+vault approval is deferred to v2+ — see §6.1 and §8).
 
 **Errors:**
 - `hestia.vault_not_found` — credential not in vault
 - `hestia.vault_scope_mismatch` — caller is not in `allowed_consumers` or scope doesn't match
-- `hestia.vault_denied` — interactive approval refused (reserved for v1+)
+- `hestia.vault_denied` — interactive approval refused (reserved for v2+;
+  interactive vault approval not yet shipped — v0 and v1 daemons MAY emit
+  `hestia.internal_error` instead, see §6.1)
 - `hestia.internal_error`
 
 ### 3.6 `hestia_vault_set`
 
 Store or upsert a credential. v0 has no interactive approval —
-the caller can write without prompt. v1+ MAY add approval flow.
+the caller can write without prompt. v2+ MAY add an interactive
+approval flow (deferred, same as `vault_get` — see §6.1 and §8).
 
 **Input:**
 ```json
@@ -618,7 +623,7 @@ inside the envelope. This is **Mechanism A** from ADR-0005.
 | `hestia.not_connected` | SDK | Method called before `connect()` |
 | `hestia.session_expired` | SDK / daemon | Session no longer valid |
 | `hestia.policy_denied` | daemon (v1+) | Policy engine denied the action |
-| `hestia.vault_denied` | daemon (v1+) | Interactive vault approval refused |
+| `hestia.vault_denied` | daemon (v2+) | Interactive vault approval refused |
 | `hestia.vault_not_found` | daemon | Credential name not in vault |
 | `hestia.vault_scope_mismatch` | daemon | Caller not in allowed_consumers or scope mismatch |
 | `hestia.action_not_found` | daemon | No in-flight action with that `action_id` |
@@ -626,8 +631,15 @@ inside the envelope. This is **Mechanism A** from ADR-0005.
 | `hestia.unknown_tool` | daemon | Tool name not in §3 |
 | `hestia.internal_error` | daemon | Catch-all; the `message` field carries detail |
 
-Codes marked `(v1+)` are reserved — SDKs MAY map them, but v0
-daemons MAY emit `hestia.internal_error` instead until v1 lands.
+Codes marked `(v1+)` (`policy_denied`, `invalid_role`) are **live as
+of v1** — the policy engine was wired 2026-05-16, so a v1+ daemon
+emits them directly; before v1, v0 daemons emitted
+`hestia.internal_error` instead. The code marked `(v2+)`
+(`vault_denied`) stays **reserved** — its only trigger, interactive
+vault approval, is deferred to v2+ (see §3.5/§3.6 and §8). Until that
+flow ships, no daemon emits `vault_denied`; SDKs MAY map it but will
+not receive it, and v0/v1 daemons emit `hestia.internal_error`
+instead. SDKs MAY map any reserved code in advance.
 
 ---
 
@@ -677,7 +689,7 @@ honesty about where it isn't yet held.
 | `PROTOCOL_VERSION` constant exists only in Rust SDK | TS, Python SDKs | Add to both — covered by `1a-4`. |
 | `TrustState` is missing `entityId`, `successCount`, `successRate` in all SDKs | All 3 SDKs | Add fields — covered by `1a-4`. |
 | ~~Error codes `policy_denied`, `invalid_role` referenced by SDKs but never emitted by daemon~~ | ~~Daemon~~ | **Resolved in v1.** The policy engine is wired (v1, 2026-05-16); these two codes are now emittable. §6.1 marks them `(v1+)`. |
-| `vault_denied` referenced by SDKs but not yet emittable | Daemon | **Still pending.** Its only trigger — interactive vault approval refused (§6.1) — is deferred to v2+ (see §3.5/§3.6 and the CHANGELOG). Reserved in §6.1 as `(v1+)` so SDKs MAY map it, but no daemon can emit it until that approval flow ships. |
+| `vault_denied` referenced by SDKs but not yet emittable | Daemon | **Still pending.** Its only trigger — interactive vault approval refused (§6.1) — is deferred to v2+ (see §3.5/§3.6 and the CHANGELOG). Reserved in §6.1 as `(v2+)` so SDKs MAY map it, but no daemon can emit it until that approval flow ships. |
 | `WitnessEntry.timestamp` is a string in SDK types but parsed as `chrono::DateTime` in Rust | Rust SDK | Internal — wire format is the string. No spec change. |
 | Daemon's `hestia://society/state` resource returns `trust_states_known` (snake_case) | None — not drift | `society/state` is an **ad-hoc stats object** (not a §5 struct); its `snake_case` keys are bound by vector P0-009 (`sovereign_lct`, `chain_length`, …). **No rename:** the earlier camelCase aspiration contradicted that vector. This is resource-specific — the four §5-typed resource bodies (`witness/recent`, `session/own`, `society/trust/{plugin_id}`, `vault/{name}`) stay `camelCase`, as vector P0-010 (`entries[0].chainPosition`) and the `witness_entry`/`trust_state` schemas require. See the per-resource casing split in §3. |
 | `synthetic` field in §3.1 `hestia_connect` input has no JSON Schema, no conformance vector, no CHANGELOG entry | Spec ↔ artifacts | Discipline gap (C5 audit P2). No v1 `hestia_connect` schema exists (only `v0/tools/hestia_connect.schema.json`); creating one is a structural prerequisite. Until then, `synthetic` is spec-documented but not artifact-conformed. |

--- a/web4-standard/schemas/presence-protocol/README.md
+++ b/web4-standard/schemas/presence-protocol/README.md
@@ -7,37 +7,54 @@ serializes a shape that doesn't validate against the schema, the
 implementation is non-conforming.
 
 The schemas mirror the protocol version. v0 schemas describe v0
-shapes. v1 schemas will live alongside v0 (e.g. `v1/tools/`) once
-v1 lands, so historical clients can validate against the version
-they speak.
+shapes. v1 schemas live alongside v0 (`v1/tools/`) so historical
+clients can validate against the version they speak. v1 has landed
+(2026-05-16); so far only `hestia_query_policy` grew its output
+shape in v1, so it is the only tool with a `v1/` schema — every
+other tool's v0 schema is still current at v1.
 
 ## Layout
 
+Each tool's input and output schemas live in a single combined file
+(`$defs/input` + `$defs/output`), not split per direction. Shared
+structs and the error envelope live under `common/`.
+
 ```
 schemas/presence-protocol/
+  README.md
   v0/
     tools/
-      hestia_connect.input.schema.json
-      hestia_connect.output.schema.json
-      hestia_begin_action.input.schema.json
-      ...
-    resources/
-      society_state.schema.json
-      trust_state.schema.json
-      witness_entry.schema.json
-      ...
+      hestia_begin_action.schema.json
+      hestia_connect.schema.json
+      hestia_query_history.schema.json
+      hestia_query_policy.schema.json
+      hestia_record_outcome.schema.json
+      hestia_request_witness.schema.json
+      hestia_vault_get.schema.json
+      hestia_vault_set.schema.json
     common/
       error_envelope.schema.json
-      r6_action.schema.json
-      ...
+      trust_state.schema.json
+      witness_entry.schema.json
+  v1/
+    tools/
+      hestia_query_policy.schema.json
 ```
+
+Note: the `hestia://society/state` resource body and the §5.2
+`R6Action` struct have no JSON Schema yet (the former is an ad-hoc
+stats object bound directly by conformance vector P0-009; the latter
+is a documentary type catalog with no wire carrier — see
+presence-protocol.md §8).
 
 ## Validation
 
-A reference validator script lives at
-`web4-standard/testing/conformance/validate-presence.py` (Step 1b).
-Implementations can run it against their own daemon's responses to
-self-check conformance before publishing.
+The conformance vectors in
+`web4-standard/testing/conformance/presence-protocol-conformance.json`
+bind each tool's output to the `$id` URLs above via `shapeMatchesSchema`.
+A standalone reference validator script (to let implementations
+self-check a live daemon's responses) is planned but not yet present
+in this repo.
 
 ## Compatibility
 

--- a/web4-standard/testing/conformance/presence-protocol-conformance.json
+++ b/web4-standard/testing/conformance/presence-protocol-conformance.json
@@ -173,7 +173,7 @@
     {
       "id": "P0-007",
       "name": "query_policy returns default-allow in v0",
-      "description": "v0 daemon is a default-allow stub. Real engine arrives in v1. Conformance only requires the shape; implementations MAY return real decisions. Note: query_policy MUST run on an action that has NOT yet had record_outcome called on it, since record_outcome consumes the action.",
+      "description": "v0 daemon is a default-allow stub. Real engine arrives in v1. Conformance only requires the shape; implementations MAY return real decisions. The shape is validated against the v1 query_policy output schema (a superset of v0's fields) so this v0 scenario passes on both v0 and v1+ daemons by design: the v0 reply {decision,reason,policyId,enforced} validates against it, and so does a v1 reply carrying ruleId/ruleName/constraints/status/nextPollMs (which the strict additionalProperties:false v0 schema would reject). Note: query_policy MUST run on an action that has NOT yet had record_outcome called on it, since record_outcome consumes the action.",
       "preconditions": ["P0-001"],
       "setup": [
         {
@@ -194,7 +194,7 @@
             "session_id": "{{P0-001.sessionId}}"
           },
           "expect": {
-            "shapeMatchesSchema": "https://web4.io/schemas/presence-protocol/v0/tools/hestia_query_policy.schema.json#/$defs/output",
+            "shapeMatchesSchema": "https://web4.io/schemas/presence-protocol/v1/tools/hestia_query_policy.schema.json#/$defs/output",
             "fieldChecks": [
               { "path": "decision", "isIn": ["allow", "deny", "warn"] },
               { "path": "reason", "isNonEmptyString": true },


### PR DESCRIPTION
## Summary

Remediation turn (C89) applying the 4 autonomous-actionable findings from the **C88** second-delta audit of `presence-protocol.md` (audit PR #379). All findings are direction-fixed — **no operator DESIGN-Q**. C88-5 INFO skipped per the audit ("safe to skip").

Edits 3 bound artifacts; **0 new files**. Disjoint from #379 (which edits only `docs/audits/`).

## Findings applied

| Group | Finding | Sev | Fix |
|-------|---------|-----|-----|
| **G1** | C88-1 | MED (the regression) | `vault_denied` / interactive vault approval → consistently **v2+** across all 6 mirror sites (§3.5 ×2, §3.6, §6.1 row tag, §6.1 footer split, §8 row's §6.1-tag reference). Closes the §8↔§6.1 contradiction the C38-2 remediation introduced (moved §8 to v2+, left §6.1/§3.5 at v1+). |
| **G2** | C88-2 | MED | Schema-dir `README.md` de-fiction: real combined-file Layout tree, present-tense v1 note, `validate-presence.py` softened to "planned", note on the two schema-less artifacts. |
| **G3** | C88-3 | MED→HIGH-lean | Repoint conformance **P0-007** `shapeMatchesSchema` v0→v1 `query_policy` output schema (verified superset — both v0 and v1 outputs validate) so a conformant v1 daemon can pass it. |
| **G4** | C88-4 | LOW | §2 qualifies `synthetic` as spec-documented but not yet artifact-conformed (see §8). |

## G1 — the headline (remediation-introduced regression closed)

The C38-2 remediation split `vault_denied` out of §8's "resolved in v1" into a v2+ "still pending" row, but left the §6.1 footer + registry tag + §3.5 marker at v1 — creating a fresh §8↔§6.1 contradiction (textbook [remediation-introduced regression](https://github.com/dp-web4/web4)). C89 finishes the skipped mirror. The two sites beyond the audit's literal 3 (§3.5 `approvalToken`, §3.6 approval-flow) are same-feature mirrors the §8 row explicitly points at via "(see §3.5/§3.6)"; aligning them prevents re-introducing the exact one-mirror-left-stale failure mode. `policy_denied`/`invalid_role` correctly stay `(v1+)` (genuinely v1-live).

## Verification

- Conformance JSON + both query_policy schemas: **valid JSON**.
- G3 superset: v0 output `{decision,reason,policyId,enforced}` **and** v1 output both validate against the v1 schema (confirmed via `jsonschema`).
- CHANGELOG already at v2+ (from C38-5) — spec now matches it; no CHANGELOG edit needed.

## Cycle status

presence-protocol **C5 → C38 → C88 → C89 cycle COMPLETE**.

## Carries (next session)

- **Cross-track** (not spec edits): author `validate-presence.py` reference validator; author the schema-less `society/state` + §5.2 `R6Action` schemas if wanted.
- Next alternation turn = **AUDIT (C90)** — society-roles 2nd-delta (C7→C39) or mrh (C10→C40-41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Policy review: APPROVED (subagent). Full session log in private-context.