### PR TITLE
Member admission queue + operator GUI (no-restart admit/deny)

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -698,6 +698,18 @@ fn event_summary(event: &HubEvent) -> String {
                 html_escape(&act.substance.uri),
             )
         }
+        HubEvent::MemberJoinRequested { member_lct_id, name, .. } => format!(
+            "🚪 join requested by {} {} <span class=\"muted\">[escalated → review]</span>",
+            short(member_lct_id),
+            name.as_deref().map(html_escape).unwrap_or_default(),
+        ),
+        HubEvent::MemberJoinResolved { request_id, approved, resolved_by, reason, .. } => format!(
+            "🚪 join {} (req {}) by {}{}",
+            if *approved { "APPROVED" } else { "DENIED" },
+            short(request_id),
+            short(resolved_by),
+            reason.as_deref().map(|r| format!(" — {}", html_escape(r))).unwrap_or_default(),
+        ),
     }
 }
 

--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -108,7 +108,8 @@ pub fn router(state: RestState) -> Router {
 
 // ---------- error ----------
 
-struct AdminError(StatusCode, String);
+#[derive(Debug)]
+pub(crate) struct AdminError(StatusCode, String);
 
 impl IntoResponse for AdminError {
     fn into_response(self) -> axum::response::Response {
@@ -716,5 +717,141 @@ fn event_summary(event: &HubEvent) -> String {
 fn short(id: &uuid::Uuid) -> String {
     let s = id.to_string();
     format!("{}…", &s[..8])
+}
+
+// ============================================================================
+// Operator plane GUI — write pages, mounted ONLY on the 127.0.0.1 operator
+// listener (the buttons POST to the loopback-only /admin/api/* surface).
+// ============================================================================
+
+const OPERATOR_BANNER: &str = r#"<div style="background:#4d3a3a;color:#f5d5d5;padding:0.5rem 0.9rem;border-radius:4px;margin-bottom:1rem;">
+  ⚙ <b>Operator plane</b> — local-only (127.0.0.1). Actions sign as the Sovereign and are witnessed to the ledger.
+  &nbsp;|&nbsp; <a href="/admin/joins" style="color:#ffd9a8">Admission queue</a>
+  &nbsp; <a href="/admin/manage" style="color:#ffd9a8">Manage members</a>
+  &nbsp; <a href="/admin" style="color:#ffd9a8">Dashboard</a>
+</div>
+<style>
+  button { background:#509982; color:#fff; border:0; border-radius:4px; padding:0.3rem 0.7rem;
+           font-size:0.8rem; cursor:pointer; margin-right:0.3rem; }
+  button:hover { background:#5fb89a; }
+  button.danger { background:#a85a5a; } button.danger:hover { background:#c06b6b; }
+</style>"#;
+
+const OPERATOR_JS: &str = r#"<script>
+async function hubAct(url, body) {
+  const r = await fetch(url, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body||{})});
+  const t = await r.text();
+  if (!r.ok) { alert('Failed ('+r.status+'): '+t); return; }
+  location.reload();
+}
+function admit(id){ if(confirm('Admit this applicant as a member? Their key is pinned live.')) hubAct('/admin/api/joins/'+id+'/admit'); }
+function deny(id){ const reason=prompt('Deny — reason (optional):'); if(reason!==null) hubAct('/admin/api/joins/'+id+'/deny',{reason:reason||null}); }
+function rekey(id){ const k=prompt('New 64-hex Ed25519 public key for member '+id+':'); if(k) hubAct('/admin/api/members/'+id+'/key',{pubkey_hex:k.trim()}); }
+function removeMember(id){ const reason=prompt('Remove member '+id+' — reason (optional):'); if(reason!==null) hubAct('/admin/api/members/'+id+'/remove',{reason:reason||null}); }
+</script>"#;
+
+pub(crate) async fn joins_page(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
+    use hub_lib::state::JoinStatus;
+    let ledger = s.ledger.lock().await;
+    let projected = HubState::project(&*ledger);
+    drop(ledger);
+
+    let mut joins: Vec<hub_lib::state::JoinRequest> = projected.pending_joins.into_values().collect();
+    joins.sort_by(|a, b| {
+        let ak = (a.status != JoinStatus::Pending, std::cmp::Reverse(a.requested_at));
+        let bk = (b.status != JoinStatus::Pending, std::cmp::Reverse(b.requested_at));
+        ak.cmp(&bk)
+    });
+    let pending = joins.iter().filter(|j| j.status == JoinStatus::Pending).count();
+
+    let mut body = String::from(OPERATOR_BANNER);
+    body.push_str("<h2>Admission queue</h2>");
+    body.push_str(&format!(
+        "<p class=\"muted\">{} pending · {} total. Law-<code>Allow</code> joins are auto-admitted and never queue; \
+         only law-<code>Escalate</code> requests land here.</p>",
+        pending, joins.len(),
+    ));
+    if joins.is_empty() {
+        body.push_str("<p class=\"muted\">No join requests waiting.</p>");
+    } else {
+        body.push_str("<table><thead><tr><th>Status</th><th>Requested</th><th>LCT</th><th>Name</th>\
+                       <th>Message</th><th>Pubkey</th><th>Actions</th></tr></thead><tbody>");
+        for j in &joins {
+            let status = match j.status {
+                JoinStatus::Pending => "<span class=\"pill pill-warn\">pending</span>",
+                JoinStatus::Approved => "<span class=\"pill\">approved</span>",
+                JoinStatus::Denied => "<span class=\"pill\">denied</span>",
+            };
+            let actions = if j.status == JoinStatus::Pending {
+                format!(
+                    "<button onclick=\"admit('{id}')\">Admit</button>\
+                     <button class=\"danger\" onclick=\"deny('{id}')\">Deny</button>",
+                    id = j.request_id
+                )
+            } else {
+                let by = j.resolved_by.map(|u| short(&u)).unwrap_or_default();
+                let reason = j.reason.as_deref().map(|r| format!(" — {}", html_escape(r))).unwrap_or_default();
+                format!("<span class=\"muted\">by {}{}</span>", by, reason)
+            };
+            let pk = &j.member_pubkey_hex[..j.member_pubkey_hex.len().min(12)];
+            body.push_str(&format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td><code>{}…</code></td><td>{}</td></tr>",
+                status,
+                j.requested_at.format("%Y-%m-%d %H:%M"),
+                short(&j.member_lct_id),
+                j.name.as_deref().map(html_escape).unwrap_or_default(),
+                j.message.as_deref().map(html_escape).unwrap_or_default(),
+                pk,
+                actions,
+            ));
+        }
+        body.push_str("</tbody></table>");
+    }
+    body.push_str(OPERATOR_JS);
+    Ok(layout(&s.hub_name, "Admission queue", &body))
+}
+
+pub(crate) async fn manage_page(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
+    let ledger = s.ledger.lock().await;
+    let projected = HubState::project(&*ledger);
+    drop(ledger);
+
+    let mut body = String::from(OPERATOR_BANNER);
+    body.push_str("<h2>Manage members</h2>");
+    body.push_str("<p class=\"muted\">Re-key (rotate a member's channel pubkey) and remove take effect live — no serve restart.</p>");
+    if projected.members.is_empty() {
+        body.push_str("<p class=\"muted\">No members.</p>");
+    } else {
+        body.push_str("<table><thead><tr><th>LCT</th><th>Name</th><th>Pubkey</th><th>Actions</th></tr></thead><tbody>");
+        for m in projected.members.values() {
+            let name = m.name.as_deref().unwrap_or("(unnamed)");
+            let pk_pill = if projected.member_pubkeys.contains_key(&m.lct_id) {
+                "<span class=\"pill\">pinned</span>"
+            } else {
+                "<span class=\"pill pill-warn\">none</span>"
+            };
+            body.push_str(&format!(
+                "<tr><td><code>{}</code></td><td>{}</td><td>{}</td>\
+                 <td><button onclick=\"rekey('{id}')\">Re-key</button>\
+                 <button class=\"danger\" onclick=\"removeMember('{id}')\">Remove</button></td></tr>",
+                m.lct_id,
+                html_escape(name),
+                pk_pill,
+                id = m.lct_id,
+            ));
+        }
+        body.push_str("</tbody></table>");
+    }
+    body.push_str(OPERATOR_JS);
+    Ok(layout(&s.hub_name, "Manage members", &body))
+}
+
+/// Operator-plane GUI pages (admit/deny + member management). Mounted ONLY on
+/// the loopback operator listener, alongside the read-only dashboard router.
+pub fn operator_router(state: RestState) -> Router {
+    Router::new()
+        .route("/admin/joins", get(joins_page))
+        .route("/admin/manage", get(manage_page))
+        .with_state(state)
 }
 

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -1029,6 +1029,7 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String, a
     if admin_port != 0 {
         let op_addr: SocketAddr = format!("127.0.0.1:{}", admin_port).parse()?;
         let operator_app = admin::router(operator_state.clone())
+            .merge(admin::operator_router(operator_state.clone()))
             .merge(crate::rest::admin_api_router(operator_state))
             .layer(axum::middleware::from_fn_with_state(operator_gate, crate::rest::lock_gate));
         match tokio::net::TcpListener::bind(op_addr).await {

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -261,6 +261,12 @@ enum Command {
         /// Bind address (default 127.0.0.1 — local-only).
         #[arg(long, default_value = "127.0.0.1")]
         bind: String,
+
+        /// Operator-plane port, always bound to 127.0.0.1 only (never the
+        /// tailnet). Serves the admit/deny/remove/re-key admin API + write GUI.
+        /// Set to 0 to disable the operator plane entirely.
+        #[arg(long, default_value_t = 8771)]
+        admin_port: u16,
     },
 
     /// Print chapter status (name, members, ledger length, head hash, port).
@@ -546,8 +552,8 @@ async fn main() -> Result<()> {
         Some(Command::Migrate { hub_dir, to }) => {
             run_migrate(hub_dir, to).await
         }
-        Some(Command::Serve { hub_dir, port, bind }) => {
-            run_serve(hub_dir, port, bind).await
+        Some(Command::Serve { hub_dir, port, bind, admin_port }) => {
+            run_serve(hub_dir, port, bind, admin_port).await
         }
         Some(Command::Status { hub_dir }) => run_status(hub_dir).await,
         Some(Command::AddMember { hub_dir, member_lct_id, name }) => {
@@ -916,7 +922,7 @@ async fn run_query(sub: QueryCommand) -> Result<()> {
     }
 }
 
-async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -> Result<()> {
+async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String, admin_port: u16) -> Result<()> {
     let config = HubConfig::load(hub_lib::hub::HubPaths::new(&hub_dir).config())?;
     let port = port_override.unwrap_or(config.daemon.mcp_port);
     let addr: SocketAddr = format!("{}:{}", bind, port).parse()?;
@@ -994,6 +1000,9 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
     // Admin UI reuses RestState (read-only; shares ledger + law snapshot).
     let admin_state = rest_state.clone();
     let gate_state = rest_state.clone();
+    // Operator plane (separate 127.0.0.1-only listener) shares the same RestState.
+    let operator_state = rest_state.clone();
+    let operator_gate = rest_state.clone();
     let app = mcp_router(mcp_state)
         .merge(rest_router(rest_state))
         .merge(admin::router(admin_state))
@@ -1010,8 +1019,38 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String) -
     println!("hub serve — {} listening on http://{}", config.hub.name, addr);
     println!("  MCP tools:    http://{}/tools", addr);
     println!("  REST v1:      http://{}/v1/", addr);
-    println!("  Admin UI:     http://{}/admin", addr);
+    println!("  Admin UI:     http://{}/admin (read-only on this plane)", addr);
     println!("  Stop:         Ctrl-C");
+
+    // Operator plane: a SECOND listener bound to 127.0.0.1 only — never the
+    // tailnet, never tailscale-served. Carries the admit/deny/remove/re-key
+    // admin API (and the write GUI). Local-presence + an ignited hub is the
+    // authorization; actions sign as the Sovereign and fail closed while locked.
+    if admin_port != 0 {
+        let op_addr: SocketAddr = format!("127.0.0.1:{}", admin_port).parse()?;
+        let operator_app = admin::router(operator_state.clone())
+            .merge(crate::rest::admin_api_router(operator_state))
+            .layer(axum::middleware::from_fn_with_state(operator_gate, crate::rest::lock_gate));
+        match tokio::net::TcpListener::bind(op_addr).await {
+            Ok(op_listener) => {
+                println!("  Operator:     http://{}/admin (LOCAL-ONLY: admit/deny/remove/re-key)", op_addr);
+                tracing::info!(operator_bind = %op_addr, "operator plane (loopback-only) starting");
+                tokio::spawn(async move {
+                    if let Err(e) = axum::serve(
+                        op_listener,
+                        operator_app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+                    )
+                    .await
+                    {
+                        tracing::error!("operator plane terminated: {e}");
+                    }
+                });
+            }
+            Err(e) => {
+                tracing::warn!("operator plane disabled — could not bind {op_addr}: {e}");
+            }
+        }
+    }
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     // `into_make_service_with_connect_info` exposes the peer `SocketAddr` to

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2536,6 +2536,50 @@ async fn deny_join(s: &RestState, request_id: Uuid, resolved_by: Uuid, reason: O
     }).await
 }
 
+/// Pin (or rotate) an existing member's channel pubkey **through the daemon**:
+/// witness `MemberKeyPinned` and update the LIVE resolver in place — the
+/// no-restart equivalent of the `hub set-member-key` CLI (which writes the store
+/// out-of-band and leaves the running daemon's resolver stale until reboot). The
+/// member must already exist; `insert` replaces the prior entry for this LCT id,
+/// so this is the re-key path (sprout's JetPack-wipe case for an existing member).
+async fn pin_member_key(s: &RestState, member_lct_id: Uuid, pubkey_hex: &str) -> Result<u64, ApiError> {
+    let lct = hub_lib::hub::hestia_sovereign_lct(member_lct_id, pubkey_hex)
+        .map_err(|e| ApiError::bad_request(format!("invalid pubkey_hex: {}", e)))?;
+    {
+        let ledger = s.ledger.lock().await;
+        if !HubState::project(&ledger).members.contains_key(&member_lct_id) {
+            return Err(ApiError::not_found(format!("no member {member_lct_id} to key")));
+        }
+    }
+    let index = witness_event(s, HubEvent::MemberKeyPinned {
+        member_lct_id,
+        member_pubkey_hex: pubkey_hex.to_string(),
+        pinned_by: s.sovereign_lct_id,
+    }).await?;
+    s.resolver.write().await.insert(lct);
+    Ok(index)
+}
+
+/// Remove a member **through the daemon**: witness `MemberRemoved` and evict them
+/// from the LIVE resolver — no restart; their envelopes stop verifying as a
+/// member immediately. (The projection also drops their pinned key, so a future
+/// restart won't re-seed them.)
+async fn remove_member_live(s: &RestState, member_lct_id: Uuid, reason: Option<String>) -> Result<u64, ApiError> {
+    {
+        let ledger = s.ledger.lock().await;
+        if !HubState::project(&ledger).members.contains_key(&member_lct_id) {
+            return Err(ApiError::not_found(format!("no member {member_lct_id} to remove")));
+        }
+    }
+    let index = witness_event(s, HubEvent::MemberRemoved {
+        member_lct_id,
+        removed_by: s.sovereign_lct_id,
+        reason,
+    }).await?;
+    s.resolver.write().await.0.remove(&member_lct_id);
+    Ok(index)
+}
+
 async fn submit_join(
     State(s): State<RestState>,
     Path(hub_id): Path<Uuid>,
@@ -3064,7 +3108,9 @@ async fn commit_proposed_event(
             .map_err(ApiError::internal)?;
         let needs = matches!(
             &entry.event,
-            HubEvent::CouncilMemberAdded { .. } | HubEvent::MemberAdded { .. }
+            HubEvent::CouncilMemberAdded { .. }
+                | HubEvent::MemberAdded { .. }
+                | HubEvent::MemberKeyPinned { .. } // live re-key: insert replaces by lct id
         );
         (entry.index, needs)
     };
@@ -3951,6 +3997,52 @@ norms:
         // Double-resolve is rejected (idempotency guard).
         assert!(approve_join(&state, request_id, state.sovereign_lct_id).await.is_err(),
             "an already-resolved request can't be approved");
+    }
+
+    #[tokio::test]
+    async fn pin_member_key_rotates_the_live_resolver_without_restart() {
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let member = Uuid::new_v4();
+        let key_a = KeyPair::generate();
+        let key_b = KeyPair::generate();
+
+        admit_member(&state, member, &key_a.verifying_key().to_hex(), Some("Rotator".into()))
+            .await.unwrap();
+        assert_eq!(state.resolver.read().await.0[&member].public_key.to_hex(),
+            key_a.verifying_key().to_hex());
+
+        // Rotate the key live — the sprout JetPack-wipe re-key case for a member.
+        pin_member_key(&state, member, &key_b.verifying_key().to_hex()).await.unwrap();
+        assert_eq!(state.resolver.read().await.0[&member].public_key.to_hex(),
+            key_b.verifying_key().to_hex(),
+            "the live resolver reflects the rotated key immediately — no serve restart");
+        let proj = { let l = state.ledger.lock().await; HubState::project(&l) };
+        assert_eq!(proj.member_pubkeys[&member], key_b.verifying_key().to_hex());
+
+        // Keying an unknown LCT errors (must be an existing member).
+        assert!(pin_member_key(&state, Uuid::new_v4(), &key_a.verifying_key().to_hex()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_member_live_evicts_from_resolver_and_projection() {
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let member = Uuid::new_v4();
+        let kp = KeyPair::generate();
+        admit_member(&state, member, &kp.verifying_key().to_hex(), Some("Goodbye".into()))
+            .await.unwrap();
+        assert!(state.resolver.read().await.0.contains_key(&member));
+
+        remove_member_live(&state, member, Some("retired".into())).await.unwrap();
+
+        assert!(!state.resolver.read().await.0.contains_key(&member),
+            "evicted from the live resolver — no restart");
+        let proj = { let l = state.ledger.lock().await; HubState::project(&l) };
+        assert!(!proj.members.contains_key(&member));
+        assert!(!proj.member_pubkeys.contains_key(&member),
+            "pinned key dropped from projection — won't be re-seeded on a future restart");
+
+        // Removing a non-member errors.
+        assert!(remove_member_live(&state, Uuid::new_v4(), None).await.is_err());
     }
 
     #[tokio::test]

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2580,6 +2580,122 @@ async fn remove_member_live(s: &RestState, member_lct_id: Uuid, reason: Option<S
     Ok(index)
 }
 
+// ============================================================================
+// Operator plane — a SEPARATE 127.0.0.1-only listener (never tailscale-served).
+// ============================================================================
+//
+// The fleet port (0.0.0.0:8770) stays read-only for admin + carries the signed
+// fleet APIs. Member-admission *writes* (admit/deny/remove/re-key) live here, on
+// a listener bound to loopback only, so the fleet cannot reach them even through
+// the tailscale TLS proxy (which forwards as 127.0.0.1 and would defeat a plain
+// loopback check on the shared port). Being on this local plane while the hub is
+// ignited IS the authorization — the actions sign as the Sovereign via the live
+// signer (they fail closed if the hub is locked). Defense-in-depth: every handler
+// also re-checks loopback.
+
+/// Reject any non-loopback caller. Redundant given the 127.0.0.1 bind, but cheap
+/// belt-and-suspenders so a future mis-bind can't silently expose operator writes.
+fn require_loopback(peer: &SocketAddr) -> Result<(), ApiError> {
+    if !peer.ip().is_loopback() {
+        return Err(ApiError {
+            status: StatusCode::FORBIDDEN,
+            message: "operator API is local-only (reach it from the hub host / a local tunnel)".to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct ReasonBody {
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct KeyBody {
+    pubkey_hex: String,
+}
+
+/// `GET /admin/api/joins` — the admission queue (pending first, newest first).
+async fn admin_list_joins(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    let projected = {
+        let ledger = s.ledger.lock().await;
+        HubState::project(&ledger)
+    };
+    let mut joins: Vec<hub_lib::state::JoinRequest> = projected.pending_joins.into_values().collect();
+    joins.sort_by(|a, b| {
+        use hub_lib::state::JoinStatus::Pending;
+        // Pending first, then most-recent request first.
+        let ap = (a.status != Pending, std::cmp::Reverse(a.requested_at));
+        let bp = (b.status != Pending, std::cmp::Reverse(b.requested_at));
+        ap.cmp(&bp)
+    });
+    let pending = joins.iter().filter(|j| j.status == hub_lib::state::JoinStatus::Pending).count();
+    Ok(Json(serde_json::json!({ "pending": pending, "total": joins.len(), "joins": joins })))
+}
+
+/// `POST /admin/api/joins/:request_id/admit` — approve a pending join (live).
+async fn admin_admit_join(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Path(request_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    let (entry_index, entry_hash) = approve_join(&s, request_id, s.sovereign_lct_id).await?;
+    Ok(Json(serde_json::json!({ "approved": true, "entry_index": entry_index, "entry_hash": entry_hash })))
+}
+
+/// `POST /admin/api/joins/:request_id/deny` — deny a pending join.
+async fn admin_deny_join(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Path(request_id): Path<Uuid>,
+    Json(body): Json<ReasonBody>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    let entry_index = deny_join(&s, request_id, s.sovereign_lct_id, body.reason).await?;
+    Ok(Json(serde_json::json!({ "denied": true, "entry_index": entry_index })))
+}
+
+/// `POST /admin/api/members/:lct_id/key` — pin/rotate a member's channel key (live).
+async fn admin_pin_key(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Path(lct_id): Path<Uuid>,
+    Json(body): Json<KeyBody>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    let entry_index = pin_member_key(&s, lct_id, &body.pubkey_hex).await?;
+    Ok(Json(serde_json::json!({ "pinned": true, "entry_index": entry_index })))
+}
+
+/// `POST /admin/api/members/:lct_id/remove` — remove a member (live eviction).
+async fn admin_remove_member(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Path(lct_id): Path<Uuid>,
+    Json(body): Json<ReasonBody>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    let entry_index = remove_member_live(&s, lct_id, body.reason).await?;
+    Ok(Json(serde_json::json!({ "removed": true, "entry_index": entry_index })))
+}
+
+/// The operator-plane write API. Mounted ONLY on the loopback operator listener.
+pub fn admin_api_router(state: RestState) -> Router {
+    Router::new()
+        .route("/admin/api/joins", get(admin_list_joins))
+        .route("/admin/api/joins/:request_id/admit", post(admin_admit_join))
+        .route("/admin/api/joins/:request_id/deny", post(admin_deny_join))
+        .route("/admin/api/members/:lct_id/key", post(admin_pin_key))
+        .route("/admin/api/members/:lct_id/remove", post(admin_remove_member))
+        .with_state(state)
+}
+
 async fn submit_join(
     State(s): State<RestState>,
     Path(hub_id): Path<Uuid>,
@@ -3997,6 +4113,61 @@ norms:
         // Double-resolve is rejected (idempotency guard).
         assert!(approve_join(&state, request_id, state.sovereign_lct_id).await.is_err(),
             "an already-resolved request can't be approved");
+    }
+
+    #[tokio::test]
+    async fn operator_api_lists_and_admits_behind_the_loopback_guard() {
+        const LAW: &str = r#"
+version: "1.0.0"
+norms:
+  - id: ADMISSION-REQUIRES-SOVEREIGN
+    selector: r6.request.action
+    operator: "=="
+    value: member_join_request
+    decision: escalate
+    priority: 100
+"#;
+        let (_tmp, state) = fresh_rest_state(Some(LAW)).await;
+        let hub_pub = state.signer.public_key().unwrap();
+        let applicant = KeyPair::generate();
+        let applicant_lct = Uuid::new_v4();
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&applicant, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Via API" }));
+        let req = ChannelRequest {
+            caller_lct_id: applicant_lct,
+            pair_id: pid,
+            sealed,
+            caller_pubkey_hex: Some(applicant.verifying_key().to_hex()),
+        };
+        let resp = channel_request(State(state.clone()), Path(state.hub_id), Json(req)).await.unwrap();
+        let out = open_resp(&applicant, &hub_pub, pid, &resp.0.sealed);
+        let request_id: Uuid = serde_json::from_value(out["request_id"].clone()).unwrap();
+
+        let loop_addr: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+        let remote_addr: SocketAddr = "10.0.0.9:5555".parse().unwrap();
+
+        // Non-loopback callers are rejected (defense-in-depth behind the bind).
+        assert_eq!(
+            admin_list_joins(State(state.clone()), ConnectInfo(remote_addr)).await.err().unwrap().status,
+            StatusCode::FORBIDDEN,
+        );
+        // Loopback lists the pending request.
+        let list = admin_list_joins(State(state.clone()), ConnectInfo(loop_addr)).await.unwrap();
+        assert_eq!(list.0["pending"], serde_json::json!(1));
+
+        // Admit via the API → member admitted live (no restart).
+        admin_admit_join(State(state.clone()), ConnectInfo(loop_addr), Path(request_id)).await.unwrap();
+        let proj = { let l = state.ledger.lock().await; HubState::project(&l) };
+        assert!(proj.members.contains_key(&applicant_lct), "admitted via the operator API");
+        assert_eq!(proj.pending_joins[&request_id].status, hub_lib::state::JoinStatus::Approved);
+
+        // A remote caller can't admit even with a valid id.
+        assert_eq!(
+            admin_admit_join(State(state.clone()), ConnectInfo(remote_addr), Path(request_id))
+                .await.err().unwrap().status,
+            StatusCode::FORBIDDEN,
+        );
     }
 
     #[tokio::test]

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -4217,6 +4217,56 @@ norms:
     }
 
     #[tokio::test]
+    async fn operator_joins_page_renders_pending_with_admit_button() {
+        const LAW: &str = r#"
+version: "1.0.0"
+norms:
+  - id: ADMISSION-REQUIRES-SOVEREIGN
+    selector: r6.request.action
+    operator: "=="
+    value: member_join_request
+    decision: escalate
+    priority: 100
+"#;
+        let (_tmp, state) = fresh_rest_state(Some(LAW)).await;
+        let hub_pub = state.signer.public_key().unwrap();
+        let applicant = KeyPair::generate();
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&applicant, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Render Me", "message": "please let me in" }));
+        let req = ChannelRequest {
+            caller_lct_id: Uuid::new_v4(),
+            pair_id: pid,
+            sealed,
+            caller_pubkey_hex: Some(applicant.verifying_key().to_hex()),
+        };
+        channel_request(State(state.clone()), Path(state.hub_id), Json(req)).await.unwrap();
+
+        let html = crate::admin::joins_page(State(state.clone())).await.unwrap().0;
+        assert!(html.contains("Admission queue"), "page title");
+        assert!(html.contains("Operator plane"), "operator banner");
+        assert!(html.contains("Render Me"), "applicant name shown");
+        assert!(html.contains("please let me in"), "applicant message shown");
+        assert!(html.contains("admit("), "Admit button wired to the API");
+        assert!(html.contains("deny("), "Deny button wired to the API");
+    }
+
+    #[tokio::test]
+    async fn operator_manage_page_renders_member_actions() {
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let member = Uuid::new_v4();
+        let kp = KeyPair::generate();
+        admit_member(&state, member, &kp.verifying_key().to_hex(), Some("Manageable".into()))
+            .await.unwrap();
+
+        let html = crate::admin::manage_page(State(state.clone())).await.unwrap().0;
+        assert!(html.contains("Manage members"));
+        assert!(html.contains("Manageable"));
+        assert!(html.contains("rekey("), "Re-key button wired");
+        assert!(html.contains("removeMember("), "Remove button wired");
+    }
+
+    #[tokio::test]
     async fn find_members_over_channel_then_degrades_when_engine_down() {
         use axum::{routing::post, Router};
 

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2376,10 +2376,24 @@ async fn request_citizenship(
                     status: StatusCode::FORBIDDEN,
                     message: "citizenship denied by hub law".to_string(),
                 }),
-                Decision::Escalate => return Err(ApiError {
-                    status: StatusCode::ACCEPTED,
-                    message: "citizenship requires escalation (admin review)".to_string(),
-                }),
+                Decision::Escalate => {
+                    // Queue for operator review (V2-16 admission queue) — witnessed,
+                    // not dropped. The applicant gets the request_id back to poll.
+                    let request_id = Uuid::new_v4();
+                    witness_event(s, HubEvent::MemberJoinRequested {
+                        request_id,
+                        member_lct_id: caller_lct_id,
+                        member_pubkey_hex: pubkey_hex.clone(),
+                        name: args.get("name").and_then(|v| v.as_str()).map(String::from),
+                        message: args.get("message").and_then(|v| v.as_str()).map(String::from),
+                        requested_at: Utc::now(),
+                    }).await?;
+                    return Ok(serde_json::json!({
+                        "admitted": false,
+                        "status": "pending_review",
+                        "request_id": request_id,
+                    }));
+                }
             }
         }
     }
@@ -2431,6 +2445,10 @@ struct JoinPayload {
     member_pubkey_hex: String,
     #[serde(default)]
     name: Option<String>,
+    /// Optional free-text note to the operator (surfaced in the review queue
+    /// when hub law escalates the request).
+    #[serde(default)]
+    message: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -2441,11 +2459,89 @@ struct JoinAccepted {
     welcome: String,
 }
 
+/// A join request that hub law escalated to operator review — queued, not yet
+/// admitted. The applicant polls / the operator actions it via the admin plane.
+#[derive(Serialize)]
+struct JoinQueued {
+    request_id: Uuid,
+    status: &'static str,
+    message: String,
+}
+
+/// Admit a member **through the daemon**: append a Sovereign-signed `MemberAdded`
+/// (pinning `member_pubkey_hex`) and insert the new member into the LIVE
+/// `MapResolver` — so their envelopes verify immediately, **no serve restart**.
+/// Shared by `submit_join` (law-`Allow`) and the operator `approve_join` path.
+/// Returns the new entry's `(index, hash)`.
+async fn admit_member(
+    s: &RestState,
+    member_lct_id: Uuid,
+    member_pubkey_hex: &str,
+    name: Option<String>,
+) -> Result<(u64, String), ApiError> {
+    let applicant_lct = hub_lib::hub::hestia_sovereign_lct(member_lct_id, member_pubkey_hex)
+        .map_err(|e| ApiError::bad_request(format!("invalid member_pubkey_hex: {}", e)))?;
+    let index = witness_event(s, HubEvent::MemberAdded {
+        member_lct_id,
+        added_by: s.sovereign_lct_id,
+        member_name: name,
+        member_pubkey_hex: Some(member_pubkey_hex.to_string()),
+    }).await?;
+    // Live resolver insert — the whole point of the no-restart path.
+    s.resolver.write().await.insert(applicant_lct);
+    let hash = s.ledger.lock().await.head_hash().to_string();
+    Ok((index, hash))
+}
+
+/// Look up a pending join request from the projection, erroring if it's unknown
+/// or already resolved (so admit/deny are idempotent-safe).
+async fn pending_join(s: &RestState, request_id: Uuid) -> Result<hub_lib::state::JoinRequest, ApiError> {
+    let jr = {
+        let ledger = s.ledger.lock().await;
+        HubState::project(&ledger).pending_joins.get(&request_id).cloned()
+    };
+    match jr {
+        None => Err(ApiError::not_found(format!("no join request {request_id}"))),
+        Some(jr) if jr.status != hub_lib::state::JoinStatus::Pending =>
+            Err(ApiError::bad_request(format!("join request {request_id} is already {:?}", jr.status))),
+        Some(jr) => Ok(jr),
+    }
+}
+
+/// Operator approves a pending join request: admit the member live (no restart)
+/// and witness the resolution. The audit trail is request → resolution + the
+/// `MemberAdded`, all signed by the Sovereign.
+async fn approve_join(s: &RestState, request_id: Uuid, resolved_by: Uuid) -> Result<(u64, String), ApiError> {
+    let jr = pending_join(s, request_id).await?;
+    let (index, hash) = admit_member(s, jr.member_lct_id, &jr.member_pubkey_hex, jr.name.clone()).await?;
+    witness_event(s, HubEvent::MemberJoinResolved {
+        request_id,
+        approved: true,
+        resolved_by,
+        reason: None,
+        resolved_at: Utc::now(),
+    }).await?;
+    Ok((index, hash))
+}
+
+/// Operator denies a pending join request: witness the resolution, admit nothing.
+async fn deny_join(s: &RestState, request_id: Uuid, resolved_by: Uuid, reason: Option<String>) -> Result<u64, ApiError> {
+    let _jr = pending_join(s, request_id).await?;
+    witness_event(s, HubEvent::MemberJoinResolved {
+        request_id,
+        approved: false,
+        resolved_by,
+        reason,
+        resolved_at: Utc::now(),
+    }).await
+}
+
 async fn submit_join(
     State(s): State<RestState>,
     Path(hub_id): Path<Uuid>,
     Json(envelope): Json<SignedEnvelope>,
-) -> Result<Json<JoinAccepted>, ApiError> {
+) -> Result<axum::response::Response, ApiError> {
+    use axum::response::IntoResponse;
     if hub_id != s.hub_id {
         return Err(ApiError::not_found(format!(
             "hub id {} does not match this hub {}", hub_id, s.hub_id
@@ -2481,98 +2577,70 @@ async fn submit_join(
     adhoc.insert(applicant_lct.clone());
     let _redeemed = verify_envelope(&envelope, &s.nonces, &adhoc, Utc::now())?;
 
-    // 3. PolicyEntity gate — admission policy from chapter law.
-    // R6Request shape: role="applicant" (not yet a member), action is
-    // the join itself, payload carries the request fields.
-    let event = HubEvent::MemberAdded {
+    // 3. PolicyEntity gate — admission policy from chapter law. The R6 payload
+    // is the MemberAdded we *would* record. Allow → auto-admit; Deny → reject;
+    // Escalate → queue for operator review (V2-16 admission queue).
+    let prospective = HubEvent::MemberAdded {
         member_lct_id: payload.member_lct_id,
         added_by: s.sovereign_lct_id,
         member_name: payload.name.clone(),
         member_pubkey_hex: Some(payload.member_pubkey_hex.clone()),
     };
-    let event_kind_str = event.kind().to_string();
-    let event_value_yaml = serde_yaml::to_value(&event)
+    let event_value_yaml = serde_yaml::to_value(&prospective)
         .map_err(|e| ApiError::internal(anyhow::anyhow!("serializing event for R6: {}", e)))?;
 
-    let law_guard = s.law.read().await;
-    if let Some(law) = law_guard.as_ref() {
-        let req = R6Request {
-            role: "applicant".to_string(),
-            action: "member_join_request".to_string(),
-            payload: event_value_yaml.clone(),
-            resource: Default::default(),
-        };
-        let outcome = law.evaluate_outcome(&req);
-        match outcome.decision {
-            Decision::Allow => { /* proceed */ }
-            Decision::Deny => {
-                return Err(ApiError {
-                    status: StatusCode::FORBIDDEN,
-                    message: format!(
-                        "membership denied by hub law (norm: {})",
-                        outcome.winning_norm.as_deref().unwrap_or("?")
-                    ),
-                });
-            }
-            Decision::Escalate => {
-                return Err(ApiError {
-                    status: StatusCode::ACCEPTED,
-                    message: format!(
-                        "membership requires escalation to {} ({}); admin review queue is V2-16",
-                        outcome.escalate_to.as_deref().unwrap_or("sovereign"),
-                        outcome.winning_norm.as_deref().unwrap_or("escalation trigger"),
-                    ),
-                });
-            }
+    let decision = {
+        let law_guard = s.law.read().await;
+        match law_guard.as_ref() {
+            None => Decision::Allow, // open-by-default when no law is set
+            Some(law) => law.evaluate_outcome(&R6Request {
+                role: "applicant".to_string(),
+                action: "member_join_request".to_string(),
+                payload: event_value_yaml,
+                resource: Default::default(),
+            }).decision,
         }
-    }
-    drop(law_guard);
-
-    // 4. Build unsigned MemberAdded entry, ask Sovereign signer to sign it,
-    // commit. Same shape as submit_event's signing path.
-    let (unsigned, intent) = {
-        let ledger = s.ledger.lock().await;
-        let unsigned = ledger.build_entry(s.sovereign_lct_id, event, Utc::now())
-            .map_err(ApiError::internal)?;
-        let intent = SignIntent {
-            request_id: Uuid::new_v4(),
-            hub_id: s.hub_id,
-            hub_name: s.hub_name.clone(),
-            actor_lct_id: s.sovereign_lct_id,
-            ledger_index: unsigned.entry.index,
-            event_kind: event_kind_str.clone(),
-            event: serde_json::to_value(&unsigned.entry.event)
-                .map_err(|e| ApiError::internal(anyhow::anyhow!("serializing event for intent: {}", e)))?,
-        };
-        (unsigned, intent)
     };
 
-    let signing_bytes = unsigned.signing_bytes.clone();
-    let signature = s.signer
-        .sign(s.sovereign_lct_id, &signing_bytes, &intent)
-        .await
-        .map_err(|e| ApiError::internal(anyhow::anyhow!("Sovereign signer denied/failed: {}", e)))?;
-
-    let entry_index;
-    let entry_hash;
-    {
-        let mut ledger = s.ledger.lock().await;
-        let entry = ledger.append_signed(unsigned, signature).await
-            .map_err(ApiError::internal)?;
-        entry_index = entry.index;
-        entry_hash = entry.entry_hash.clone();
+    match decision {
+        Decision::Deny => Err(ApiError {
+            status: StatusCode::FORBIDDEN,
+            message: "membership denied by hub law".to_string(),
+        }),
+        Decision::Allow => {
+            // Auto-admit, live (no restart).
+            let (entry_index, entry_hash) = admit_member(
+                &s, payload.member_lct_id, &payload.member_pubkey_hex, payload.name.clone(),
+            ).await?;
+            Ok(Json(JoinAccepted {
+                member_lct_id: payload.member_lct_id,
+                entry_index,
+                entry_hash,
+                welcome: format!("welcome to {}", s.hub_name),
+            }).into_response())
+        }
+        Decision::Escalate => {
+            // Queue for operator review — witnessed, NOT dropped (closes the
+            // V2-16 gap). The operator admits/denies via the admin plane.
+            let request_id = Uuid::new_v4();
+            witness_event(&s, HubEvent::MemberJoinRequested {
+                request_id,
+                member_lct_id: payload.member_lct_id,
+                member_pubkey_hex: payload.member_pubkey_hex.clone(),
+                name: payload.name.clone(),
+                message: payload.message.clone(),
+                requested_at: Utc::now(),
+            }).await?;
+            Ok((
+                StatusCode::ACCEPTED,
+                Json(JoinQueued {
+                    request_id,
+                    status: "pending_review",
+                    message: format!("join request queued for operator review at {}", s.hub_name),
+                }),
+            ).into_response())
+        }
     }
-
-    // 5. Add the new member's pubkey to the live resolver so future
-    // member-signed envelopes from them verify without a serve restart.
-    s.resolver.write().await.insert(applicant_lct);
-
-    Ok(Json(JoinAccepted {
-        member_lct_id: payload.member_lct_id,
-        entry_index,
-        entry_hash,
-        welcome: format!("welcome to {}", s.hub_name),
-    }))
 }
 
 // ---------- PolicyEntity gate helper (V2-8 §4) ----------
@@ -3804,11 +3872,85 @@ norms:
             sealed,
             caller_pubkey_hex: Some(applicant.verifying_key().to_hex()),
         };
-        let err = channel_request(State(state.clone()), Path(state.hub_id), Json(req))
+        let resp = channel_request(State(state.clone()), Path(state.hub_id), Json(req))
             .await
-            .err()
-            .expect("join should be escalated, not admitted");
-        assert_eq!(err.status, StatusCode::ACCEPTED, "escalate → 202");
+            .expect("escalated join is queued (200 sealed), not an error");
+        let out = open_resp(&applicant, &hub_pub, pid, &resp.0.sealed);
+        assert_eq!(out["admitted"], serde_json::json!(false), "escalate → not admitted");
+        assert_eq!(out["status"], serde_json::json!("pending_review"));
+        let request_id: Uuid = serde_json::from_value(out["request_id"].clone())
+            .expect("a request_id was returned");
+
+        // It is witnessed as a Pending entry in the admission queue, not dropped.
+        let projected = {
+            let ledger = state.ledger.lock().await;
+            HubState::project(&ledger)
+        };
+        let jr = projected.pending_joins.get(&request_id).expect("queued for review");
+        assert_eq!(jr.status, hub_lib::state::JoinStatus::Pending);
+
+        // The operator approves it → member admitted live, no restart; status flips.
+        let (_idx, _hash) = approve_join(&state, request_id, state.sovereign_lct_id)
+            .await
+            .expect("approve should admit the member");
+        let after = {
+            let ledger = state.ledger.lock().await;
+            HubState::project(&ledger)
+        };
+        assert_eq!(after.pending_joins[&request_id].status, hub_lib::state::JoinStatus::Approved);
+        assert!(after.members.contains_key(&jr.member_lct_id), "approved applicant is now a member");
+        assert!(after.member_pubkeys.contains_key(&jr.member_lct_id), "their pubkey is pinned");
+        assert!(state.resolver.read().await.0.contains_key(&jr.member_lct_id),
+            "and they are in the LIVE resolver — no serve restart needed");
+    }
+
+    #[tokio::test]
+    async fn deny_join_records_denial_and_admits_nobody() {
+        const LAW: &str = r#"
+version: "1.0.0"
+norms:
+  - id: ADMISSION-REQUIRES-SOVEREIGN
+    selector: r6.request.action
+    operator: "=="
+    value: member_join_request
+    decision: escalate
+    priority: 100
+"#;
+        let (_tmp, state) = fresh_rest_state(Some(LAW)).await;
+        let hub_pub = state.signer.public_key().unwrap();
+        let applicant = KeyPair::generate();
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&applicant, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Reject Me" }));
+        let req = ChannelRequest {
+            caller_lct_id: Uuid::new_v4(),
+            pair_id: pid,
+            sealed,
+            caller_pubkey_hex: Some(applicant.verifying_key().to_hex()),
+        };
+        let resp = channel_request(State(state.clone()), Path(state.hub_id), Json(req))
+            .await.unwrap();
+        let out = open_resp(&applicant, &hub_pub, pid, &resp.0.sealed);
+        let request_id: Uuid = serde_json::from_value(out["request_id"].clone()).unwrap();
+        let member_lct = {
+            let ledger = state.ledger.lock().await;
+            HubState::project(&ledger).pending_joins[&request_id].member_lct_id
+        };
+
+        deny_join(&state, request_id, state.sovereign_lct_id, Some("not this time".into()))
+            .await.expect("deny should record a denial");
+
+        let after = {
+            let ledger = state.ledger.lock().await;
+            HubState::project(&ledger)
+        };
+        assert_eq!(after.pending_joins[&request_id].status, hub_lib::state::JoinStatus::Denied);
+        assert_eq!(after.pending_joins[&request_id].reason.as_deref(), Some("not this time"));
+        assert!(!after.members.contains_key(&member_lct), "denied applicant is NOT a member");
+
+        // Double-resolve is rejected (idempotency guard).
+        assert!(approve_join(&state, request_id, state.sovereign_lct_id).await.is_err(),
+            "an already-resolved request can't be approved");
     }
 
     #[tokio::test]

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -56,6 +56,38 @@ pub enum HubEvent {
         reason: Option<String>,
     },
 
+    /// A prospective member submitted a join request that hub law **escalated**
+    /// to operator review (V2-16 admission queue). The applicant self-vouches
+    /// `member_pubkey_hex` (the hub bootstraps signature verification from it);
+    /// nothing is admitted until a matching `MemberJoinResolved{approved:true}`
+    /// — and the actual `MemberAdded` — is recorded by the Sovereign. Law-`Allow`
+    /// joins are auto-admitted and skip the queue; law-`Deny` joins are rejected
+    /// and never recorded. `request_id` ties the request to its resolution.
+    MemberJoinRequested {
+        request_id: Uuid,
+        member_lct_id: Uuid,
+        member_pubkey_hex: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        /// Optional free-text note from the applicant (shown to the operator).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+        requested_at: DateTime<Utc>,
+    },
+
+    /// An operator (Sovereign) resolved a pending join request — approved or
+    /// denied. On approval a `MemberAdded` is recorded alongside (the actual
+    /// admission); this event closes the queue entry, recording who decided and
+    /// why. The membrane is fully auditable: request → resolution, both witnessed.
+    MemberJoinResolved {
+        request_id: Uuid,
+        approved: bool,
+        resolved_by: Uuid,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        resolved_at: DateTime<Utc>,
+    },
+
     /// A role assignment was changed.
     RoleAssigned {
         role: SocietyRole,
@@ -363,6 +395,8 @@ impl HubEvent {
             Self::Genesis { .. } => "genesis",
             Self::MemberAdded { .. } => "member_added",
             Self::MemberRemoved { .. } => "member_removed",
+            Self::MemberJoinRequested { .. } => "member_join_requested",
+            Self::MemberJoinResolved { .. } => "member_join_resolved",
             Self::RoleAssigned { .. } => "role_assigned",
             Self::EventRecorded { .. } => "event_recorded",
             Self::CharterAmended { .. } => "charter_amended",

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -275,6 +275,10 @@ impl HubState {
                         }
                     }
                 }
+                // Drop the pinned channel key too — otherwise a removed member's
+                // key lingers in the projection and gets re-seeded into the
+                // resolver on the next serve restart (they'd still verify).
+                self.member_pubkeys.remove(member_lct_id);
             }
             HubEvent::MemberJoinRequested {
                 request_id, member_lct_id, member_pubkey_hex, name, message, requested_at,

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -66,8 +66,48 @@ pub struct HubState {
     /// Cleared on hub recovery via projection from the ledger.
     pub pairs: BTreeMap<Uuid, PairState>,
 
+    /// V2-16 admission queue: `request_id` → join request (pending or resolved).
+    /// Built from `MemberJoinRequested`/`MemberJoinResolved`. The operator GUI
+    /// lists `Pending` entries and approves/denies them; law-`Allow` joins are
+    /// auto-admitted and never appear here.
+    pub pending_joins: BTreeMap<Uuid, JoinRequest>,
+
     /// Last seen index from the ledger (for cache invalidation in future).
     pub last_index: u64,
+}
+
+/// V2-16: one entry in the admission queue, projected from
+/// `MemberJoinRequested` (creates it `Pending`) and `MemberJoinResolved`
+/// (transitions to `Approved`/`Denied`). The applicant's self-vouched
+/// `member_pubkey_hex` is what the Sovereign pins on approval.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JoinRequest {
+    pub request_id: Uuid,
+    pub member_lct_id: Uuid,
+    pub member_pubkey_hex: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    pub requested_at: DateTime<Utc>,
+    pub status: JoinStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_by: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JoinStatus {
+    /// Awaiting operator Admit/Deny (law escalated it).
+    Pending,
+    /// Operator approved; a `MemberAdded` was recorded.
+    Approved,
+    /// Operator denied; no admission recorded.
+    Denied,
 }
 
 /// PAIRED-CHANNELS Sprint B: projected state of a single pair.
@@ -234,6 +274,32 @@ impl HubState {
                             }
                         }
                     }
+                }
+            }
+            HubEvent::MemberJoinRequested {
+                request_id, member_lct_id, member_pubkey_hex, name, message, requested_at,
+            } => {
+                self.pending_joins.insert(*request_id, JoinRequest {
+                    request_id: *request_id,
+                    member_lct_id: *member_lct_id,
+                    member_pubkey_hex: member_pubkey_hex.clone(),
+                    name: name.clone(),
+                    message: message.clone(),
+                    requested_at: *requested_at,
+                    status: JoinStatus::Pending,
+                    resolved_by: None,
+                    reason: None,
+                    resolved_at: None,
+                });
+            }
+            HubEvent::MemberJoinResolved {
+                request_id, approved, resolved_by, reason, resolved_at,
+            } => {
+                if let Some(jr) = self.pending_joins.get_mut(request_id) {
+                    jr.status = if *approved { JoinStatus::Approved } else { JoinStatus::Denied };
+                    jr.resolved_by = Some(*resolved_by);
+                    jr.reason = reason.clone();
+                    jr.resolved_at = Some(*resolved_at);
                 }
             }
             HubEvent::MemberSkillDeclared { member_lct_id, skill, .. } => {


### PR DESCRIPTION
Operator-driven member admission: a pending-request queue, live (no-restart) admit/deny/re-key/remove, and a clickable local GUI. Addresses the two operator pains — *"we shouldn't need to restart the hub to admit a member"* and *"I want a list and a way to admit/deny with a click."*

## Why a restart was needed (and why it no longer is)
The only thing that forced restarts was the **CLI** (`set-member-key`/`remove-member`) writing the encrypted store *out-of-band* from the running daemon, leaving its in-memory `MapResolver` stale. Everything routed *through* the daemon updates the resolver live. So the fix is: route admission through the daemon.

## Sprints
1. **Pending queue** — witnessed `MemberJoinRequested`/`MemberJoinResolved` + `pending_joins` projection. Escalated joins are queued (not dropped — closes the long-standing "admin review queue is V2-16" TODO). `admit_member()` extracted as the shared live-admission helper. Law `Allow`→auto-admit, `Deny`→reject, `Escalate`→queue.
2. **Live key-pin + remove** — `pin_member_key()` (re-key in place) and `remove_member_live()` (witness + evict from the resolver); fixed a latent bug where `MemberRemoved` left the pinned key in the projection.
3. **Operator write API** — a **second listener bound 127.0.0.1 only** (`--admin-port`, default 8771; 0 disables), never tailscale-served. Closes the hole where the tailscale TLS proxy forwards as loopback and would defeat a plain loopback check on the shared port. Authorization = local presence + an ignited hub (signs as Sovereign, fails closed while locked); handlers re-check loopback as defense-in-depth.
4. **Clickable GUI** — `/admin/joins` (Admit/Deny) + `/admin/manage` (Re-key/Remove), hand-rolled to match the existing dashboard. Operator pages 404 on the fleet plane.

## Decisions (operator-confirmed)
- GUI on a **separate local operator port** (not the tailnet).
- Admission default: **law decides, queue on escalate**.

## Tests
26 daemon + 155 lib green. New coverage: escalate→queue→approve admits live (in the resolver, no restart); deny records denial + admits nobody; re-key reflects in the live resolver immediately; remove evicts from resolver + projection; operator API lists + admits behind a loopback guard (403 for remote); both GUI pages render with wired buttons.

The dual-listener behavior is verified live against the ignited production hub at deploy.