### PR TITLE
Operator-plane port 8772 + fix /admin 500 on ignited encrypted hub

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -26,7 +26,6 @@ use axum::{
     Router,
 };
 use hub_lib::events::HubEvent;
-use hub_lib::init::load_society;
 use hub_lib::signer::RemoteSigner; // signer_kind() — signer is now a concrete SwappableSigner
 use hub_lib::state::HubState;
 
@@ -140,7 +139,7 @@ async fn overview(State(s): State<RestState>) -> Result<Html<String>, AdminError
     let last_20: Vec<_> = entries.iter().rev().take(20).cloned().collect();
     drop(ledger);
 
-    let society = load_society(&s.paths.root).await?;
+    let society = s.society().await?;
     let law_guard = s.law.read().await;
     let (law_version, norms, procedures) = match &*law_guard {
         Some(l) => (l.version.clone(), l.norms.len(), l.procedures.len()),
@@ -218,7 +217,7 @@ async fn members(State(s): State<RestState>) -> Result<Html<String>, AdminError>
 }
 
 async fn roles(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
-    let society = load_society(&s.paths.root).await?;
+    let society = s.society().await?;
     let ledger = s.ledger.lock().await;
     let projected = HubState::project(&*ledger);
     drop(ledger);

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -264,8 +264,9 @@ enum Command {
 
         /// Operator-plane port, always bound to 127.0.0.1 only (never the
         /// tailnet). Serves the admit/deny/remove/re-key admin API + write GUI.
-        /// Set to 0 to disable the operator plane entirely.
-        #[arg(long, default_value_t = 8771)]
+        /// Set to 0 to disable the operator plane entirely. (8771 is taken by the
+        /// membox sidecar, so the default is 8772.)
+        #[arg(long, default_value_t = 8772)]
         admin_port: u16,
     },
 

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -349,6 +349,16 @@ impl RestState {
         hub_lib::store::open_hub_store_with_key(&self.paths.root, key)
     }
 
+    /// Read the society via the **in-memory-keyed** store. Unlike
+    /// `init::load_society` (which re-opens the store from disk with no key and
+    /// thus fails on an ignited *encrypted* hub), this uses the runtime store key,
+    /// so admin/read handlers work after ignition.
+    pub async fn society(&self) -> anyhow::Result<web4_core::society::Society> {
+        let store = self.open_store().await?;
+        store.read_society().await?
+            .ok_or_else(|| anyhow::anyhow!("no society found in hub store"))
+    }
+
     /// Construct a **locked shell**: the encrypted state store could not be opened
     /// (no key — total enclosure), so the hub comes up serving only the unlock path.
     /// Identity (hub_id / name / founding sovereign) is read from the clear tier-0


### PR DESCRIPTION
Deploy fixes for #391: (1) operator default port 8771 collided with the membox sidecar → 8772; (2) /admin 500 — load_society re-opened the encrypted store keyless; now reads via the in-memory-keyed store (RestState::society()). 26 daemon + 155 lib tests green.