### PR TITLE
Operator nav links + proactive Add-member action

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -65,6 +65,8 @@ const STYLE: &str = r#"
 "#;
 
 fn layout(hub_name: &str, title: &str, body: &str) -> Html<String> {
+    // Joins/Manage are operator-plane pages (127.0.0.1 only); on the read-only
+    // fleet plane they 404, which is the honest signal that admin writes aren't there.
     let nav = r#"<nav>
       <a href="/admin">Overview</a>
       <a href="/admin/members">Members</a>
@@ -73,6 +75,8 @@ fn layout(hub_name: &str, title: &str, body: &str) -> Html<String> {
       <a href="/admin/law">Law</a>
       <a href="/admin/council">Council</a>
       <a href="/admin/pairs">Pairs</a>
+      <a href="/admin/joins">Joins ⚙</a>
+      <a href="/admin/manage">Manage ⚙</a>
     </nav>"#;
     Html(format!(
         "<!doctype html><html><head><meta charset=\"utf-8\">\
@@ -747,6 +751,13 @@ function admit(id){ if(confirm('Admit this applicant as a member? Their key is p
 function deny(id){ const reason=prompt('Deny — reason (optional):'); if(reason!==null) hubAct('/admin/api/joins/'+id+'/deny',{reason:reason||null}); }
 function rekey(id){ const k=prompt('New 64-hex Ed25519 public key for member '+id+':'); if(k) hubAct('/admin/api/members/'+id+'/key',{pubkey_hex:k.trim()}); }
 function removeMember(id){ const reason=prompt('Remove member '+id+' — reason (optional):'); if(reason!==null) hubAct('/admin/api/members/'+id+'/remove',{reason:reason||null}); }
+function addMember(){
+  const lct=document.getElementById('add-lct').value.trim();
+  const pubkey_hex=document.getElementById('add-key').value.trim();
+  const name=document.getElementById('add-name').value.trim();
+  if(!lct||!pubkey_hex){ alert('LCT id and pubkey (64 hex) are required.'); return; }
+  hubAct('/admin/api/members/add',{lct_id:lct,pubkey_hex:pubkey_hex,name:name||null});
+}
 </script>"#;
 
 pub(crate) async fn joins_page(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -816,7 +827,22 @@ pub(crate) async fn manage_page(State(s): State<RestState>) -> Result<Html<Strin
     drop(ledger);
 
     let mut body = String::from(OPERATOR_BANNER);
-    body.push_str("<h2>Manage members</h2>");
+
+    // Proactive admission: the Sovereign adds a known member directly (e.g. a
+    // fleet machine whose pubkey is already committed in fleet-identity), without
+    // waiting for them to submit a join request. Live — no restart.
+    body.push_str("<h2>Add a member</h2>");
+    body.push_str(
+        "<p class=\"muted\">Add a known member directly (Sovereign act). Takes effect live — no restart.</p>\
+         <div style=\"display:grid;grid-template-columns:max-content 1fr;gap:0.4rem 0.6rem;max-width:760px;align-items:center;\">\
+         <label>LCT id</label><input id=\"add-lct\" placeholder=\"uuid\" style=\"font-family:monospace;padding:0.3rem;\">\
+         <label>Pubkey (64 hex)</label><input id=\"add-key\" placeholder=\"Ed25519 public key, hex\" style=\"font-family:monospace;padding:0.3rem;\">\
+         <label>Name</label><input id=\"add-name\" placeholder=\"(optional)\" style=\"padding:0.3rem;\">\
+         <span></span><span><button onclick=\"addMember()\">Add member</button></span>\
+         </div>",
+    );
+
+    body.push_str("<h2 style=\"margin-top:1.5rem\">Members</h2>");
     body.push_str("<p class=\"muted\">Re-key (rotate a member's channel pubkey) and remove take effect live — no serve restart.</p>");
     if projected.members.is_empty() {
         body.push_str("<p class=\"muted\">No members.</p>");

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2695,12 +2695,42 @@ async fn admin_remove_member(
     Ok(Json(serde_json::json!({ "removed": true, "entry_index": entry_index })))
 }
 
+#[derive(Deserialize)]
+struct AddMemberBody {
+    lct_id: Uuid,
+    pubkey_hex: String,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// `POST /admin/api/members/add` — the Sovereign adds a *known* member directly
+/// (e.g. a fleet machine whose pubkey is already committed), without waiting for
+/// a self-submitted join request. Live (no restart). This is the proactive
+/// counterpart to the request-driven queue; it's a Sovereign act, so it isn't
+/// law-gated (the operator IS the authority), same stance as the add-member CLI.
+async fn admin_add_member(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(body): Json<AddMemberBody>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    {
+        let ledger = s.ledger.lock().await;
+        if HubState::project(&ledger).members.contains_key(&body.lct_id) {
+            return Err(ApiError::bad_request(format!("{} is already a member", body.lct_id)));
+        }
+    }
+    let (entry_index, entry_hash) = admit_member(&s, body.lct_id, &body.pubkey_hex, body.name).await?;
+    Ok(Json(serde_json::json!({ "added": true, "entry_index": entry_index, "entry_hash": entry_hash })))
+}
+
 /// The operator-plane write API. Mounted ONLY on the loopback operator listener.
 pub fn admin_api_router(state: RestState) -> Router {
     Router::new()
         .route("/admin/api/joins", get(admin_list_joins))
         .route("/admin/api/joins/:request_id/admit", post(admin_admit_join))
         .route("/admin/api/joins/:request_id/deny", post(admin_deny_join))
+        .route("/admin/api/members/add", post(admin_add_member))
         .route("/admin/api/members/:lct_id/key", post(admin_pin_key))
         .route("/admin/api/members/:lct_id/remove", post(admin_remove_member))
         .with_state(state)
@@ -4178,6 +4208,31 @@ norms:
                 .await.err().unwrap().status,
             StatusCode::FORBIDDEN,
         );
+    }
+
+    #[tokio::test]
+    async fn operator_add_member_admits_a_known_member_live() {
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let kp = KeyPair::generate();
+        let lct = Uuid::new_v4();
+        let loop_addr: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+        let remote_addr: SocketAddr = "10.0.0.9:5555".parse().unwrap();
+        let body = || AddMemberBody { lct_id: lct, pubkey_hex: kp.verifying_key().to_hex(), name: Some("Sprout".into()) };
+
+        // Remote callers are rejected.
+        assert_eq!(
+            admin_add_member(State(state.clone()), ConnectInfo(remote_addr), Json(body()))
+                .await.err().unwrap().status,
+            StatusCode::FORBIDDEN,
+        );
+        // Loopback adds the member live (in the resolver, no restart).
+        admin_add_member(State(state.clone()), ConnectInfo(loop_addr), Json(body())).await.unwrap();
+        let proj = { let l = state.ledger.lock().await; HubState::project(&l) };
+        assert!(proj.members.contains_key(&lct));
+        assert!(proj.member_pubkeys.contains_key(&lct));
+        assert!(state.resolver.read().await.0.contains_key(&lct), "in the live resolver");
+        // Double-add is rejected.
+        assert!(admin_add_member(State(state.clone()), ConnectInfo(loop_addr), Json(body())).await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two operator-UX gaps from live use: (1) nav had no Joins/Manage links (added; they 404 on the read-only fleet plane by design); (2) no way to proactively admit a known member — added POST /admin/api/members/add + an Add-member form on /admin/manage (Sovereign act, live, no restart). Explains the empty queue (request-driven). 27 daemon + 155 lib green.