### PR TITLE
Promote the generic plugin seam (hub-plugin) to open core

### DIFF
--- a/hub/Cargo.toml
+++ b/hub/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["hub-lib", "hub-daemon"]
+members = ["hub-lib", "hub-daemon", "hub-plugin"]
 resolver = "2"
 
 [workspace.package]

--- a/hub/README.md
+++ b/hub/README.md
@@ -40,6 +40,24 @@ We don't mandate the policy. We insist that whatever the policy is, is followed 
 - **Single binary, single config file** — `docker compose up` deploys; chapter organizer needs no DevOps experience
 - **Local-first** — chapter data stays in the chapter's directory; no telemetry, no vendor data extraction
 
+## Extending the hub (plugin seam)
+
+The hub is **open-core**: the daemon owns the hard parts — authenticating the
+caller, gating by chapter law, bounding results to the caller's tier, and sealing
+the response — and tools plug in behind that. The generic seam lives in the
+[`hub-plugin`](hub-plugin/) crate:
+
+- `ToolPlugin` — implement `name()` + `handle(ctx, args)`; the core runs your
+  handler only after `gate → handle → scope`.
+- `PluginCtx` — the capabilities the core *lends* a plugin (sign as the hub LCT,
+  read projected state, send a sealed payload to a peer). Deliberately generic —
+  the seam never names a specific tool.
+- `PluginRegistry::dispatch` — the canonical `gate → handle → scope` path, the
+  same contract as the daemon's channel dispatch.
+
+This is the keystone of the split: the public core ships the seam, and any
+operator can add their own (or proprietary) handlers without forking the hub.
+
 ## What this isn't (MVP scope)
 
 - Not a Member Presence Toolkit (Hestia multi-hub plugin — separate package, V2)

--- a/hub/hub-plugin/Cargo.toml
+++ b/hub/hub-plugin/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hub-plugin"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Generic hub tool-plugin seam (core owns gate/scope/seal; plugins own handlers). The open-core keystone."
+
+[dependencies]
+anyhow.workspace = true
+serde_json.workspace = true
+async-trait = "0.1"
+uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/hub/hub-plugin/src/lib.rs
+++ b/hub/hub-plugin/src/lib.rs
@@ -1,0 +1,149 @@
+//! `hub-plugin` — the generic hub tool-plugin seam.
+//!
+//! Core (the hub daemon) owns authn + policy gating + tier scoping + sealing;
+//! **plugins own the handler.** This crate is the keystone of the hub's
+//! open-core split: it defines the generic [`ToolPlugin`] contract and the
+//! `gate → handle → scope` dispatch path, and names no specific tool. Concrete
+//! handlers — generic or specialized — live in their own crates that implement
+//! [`ToolPlugin`] and register with the [`PluginRegistry`]; the core never has
+//! to know what a given tool does, only how to gate, run, and bound it.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub type LctId = Uuid;
+
+/// Who is invoking a tool (resolved by core before dispatch).
+#[derive(Clone, Debug)]
+pub struct Caller {
+    pub lct: LctId,
+    pub role: String, // "sovereign" | "citizen" | "external" | a specific role
+}
+
+/// How core bounds a plugin's result for the caller's tier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolScope {
+    /// Bounded by the tier cap (record lists).
+    Bounded,
+    /// Not bounded (summaries, a single attestation/tree).
+    Unbounded,
+}
+
+#[derive(Debug)]
+pub enum PluginError {
+    Denied(String),
+    BadRequest(String),
+    Unavailable(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for PluginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PluginError::Denied(m) => write!(f, "denied: {m}"),
+            PluginError::BadRequest(m) => write!(f, "bad request: {m}"),
+            PluginError::Unavailable(m) => write!(f, "unavailable: {m}"),
+            PluginError::Internal(m) => write!(f, "internal: {m}"),
+        }
+    }
+}
+impl std::error::Error for PluginError {}
+
+/// Capabilities core **lends** a plugin. Deliberately generic — a plugin builds
+/// whatever it needs from these; the seam never names a specific mechanism.
+#[async_trait]
+pub trait PluginCtx: Send + Sync {
+    fn caller(&self) -> &Caller;
+    /// The hub's own LCT id (its signing identity).
+    fn hub_lct(&self) -> LctId;
+    /// Sign `bytes` as the hub LCT (Ed25519, 64-byte sig). Works whether the hub
+    /// holds the key (Local) or signs via a remote callback (Hestia).
+    fn sign(&self, bytes: &[u8]) -> Result<Vec<u8>, PluginError>;
+    /// Verify side of `sign` — the hub's public key, hex.
+    fn hub_pubkey_hex(&self) -> String;
+    /// Read-only projected hub state (members/roles/…) as opaque JSON.
+    fn state(&self) -> &Value;
+    /// Send an opaque **sealed** payload to a peer LCT over the paired channel
+    /// and get the sealed response. Generic — enables fan-out/recursion and
+    /// cross-hub calls without the seam knowing the payload.
+    async fn send_to_peer(&self, peer: LctId, payload: &[u8]) -> Result<Vec<u8>, PluginError>;
+}
+
+/// A registered tool. Core has already authenticated the caller and gated the
+/// call by the time `handle` runs.
+#[async_trait]
+pub trait ToolPlugin: Send + Sync {
+    fn name(&self) -> &str;
+    /// Policy-action key for the chapter-law gate. Default `read:<name>`.
+    fn policy_action(&self) -> String {
+        format!("read:{}", self.name())
+    }
+    fn scope(&self) -> ToolScope {
+        ToolScope::Bounded
+    }
+    async fn handle(&self, ctx: &dyn PluginCtx, args: &Value) -> Result<Value, PluginError>;
+}
+
+/// Chapter-law gate (core supplies this — e.g. wrapping the PolicyEntity).
+pub trait PolicyGate: Send + Sync {
+    fn allow(&self, role: &str, action: &str) -> bool;
+}
+
+/// Tier result-bounding (core supplies this — e.g. wrapping `ReadScope`).
+pub trait Scoper: Send + Sync {
+    fn bound(&self, role: &str, result: Value) -> Value;
+}
+
+/// The registry + the canonical dispatch path. Plugins never see an un-gated
+/// call: **gate → handle → scope**, the same contract as the hub's
+/// `dispatch_channel`.
+#[derive(Default)]
+pub struct PluginRegistry {
+    tools: HashMap<String, Arc<dyn ToolPlugin>>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, plugin: Arc<dyn ToolPlugin>) {
+        self.tools.insert(plugin.name().to_string(), plugin);
+    }
+
+    pub fn names(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.tools.keys().cloned().collect();
+        v.sort();
+        v
+    }
+
+    pub async fn dispatch(
+        &self,
+        ctx: &dyn PluginCtx,
+        tool: &str,
+        args: &Value,
+        gate: &dyn PolicyGate,
+        scoper: &dyn Scoper,
+    ) -> Result<Value, PluginError> {
+        let plugin = self
+            .tools
+            .get(tool)
+            .ok_or_else(|| PluginError::BadRequest(format!("unknown tool: {tool}")))?;
+        let role = ctx.caller().role.clone();
+        let action = plugin.policy_action();
+        if !gate.allow(&role, &action) {
+            return Err(PluginError::Denied(format!("{action} denied for role {role}")));
+        }
+        let result = plugin.handle(ctx, args).await?;
+        Ok(match plugin.scope() {
+            ToolScope::Bounded => scoper.bound(&role, result),
+            ToolScope::Unbounded => result,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/hub/hub-plugin/src/tests.rs
+++ b/hub/hub-plugin/src/tests.rs
@@ -1,0 +1,109 @@
+//! The generic seam: gate → handle → scope, with a sample plugin.
+
+use super::*;
+use serde_json::json;
+
+struct MockCtx {
+    caller: Caller,
+    state: Value,
+}
+
+#[async_trait]
+impl PluginCtx for MockCtx {
+    fn caller(&self) -> &Caller {
+        &self.caller
+    }
+    fn hub_lct(&self) -> LctId {
+        Uuid::nil()
+    }
+    fn sign(&self, _bytes: &[u8]) -> Result<Vec<u8>, PluginError> {
+        Ok(vec![0u8; 64])
+    }
+    fn hub_pubkey_hex(&self) -> String {
+        "00".repeat(32)
+    }
+    fn state(&self) -> &Value {
+        &self.state
+    }
+    async fn send_to_peer(&self, _peer: LctId, _payload: &[u8]) -> Result<Vec<u8>, PluginError> {
+        Err(PluginError::Unavailable("no peer in test".into()))
+    }
+}
+
+/// A trivial bounded plugin that returns a list out of `ctx.state`.
+struct ListPlugin;
+#[async_trait]
+impl ToolPlugin for ListPlugin {
+    fn name(&self) -> &str {
+        "list_things"
+    }
+    async fn handle(&self, ctx: &dyn PluginCtx, _args: &Value) -> Result<Value, PluginError> {
+        Ok(json!({ "items": ctx.state()["items"].clone() }))
+    }
+}
+
+struct AllowAll;
+impl PolicyGate for AllowAll {
+    fn allow(&self, _r: &str, _a: &str) -> bool {
+        true
+    }
+}
+struct DenyCitizen;
+impl PolicyGate for DenyCitizen {
+    fn allow(&self, role: &str, _a: &str) -> bool {
+        role != "citizen"
+    }
+}
+/// Bounds non-sovereign callers to 2 items.
+struct CapTwo;
+impl Scoper for CapTwo {
+    fn bound(&self, role: &str, mut result: Value) -> Value {
+        if role == "sovereign" {
+            return result;
+        }
+        if let Some(items) = result.get_mut("items").and_then(|v| v.as_array_mut()) {
+            items.truncate(2);
+        }
+        result
+    }
+}
+
+fn registry() -> PluginRegistry {
+    let mut r = PluginRegistry::new();
+    r.register(Arc::new(ListPlugin));
+    r
+}
+fn ctx(role: &str) -> MockCtx {
+    MockCtx {
+        caller: Caller { lct: Uuid::new_v4(), role: role.into() },
+        state: json!({ "items": [1, 2, 3, 4] }),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_gates_then_scopes_by_tier() {
+    let r = registry();
+    // citizen → bounded to 2
+    let out = r.dispatch(&ctx("citizen"), "list_things", &json!({}), &AllowAll, &CapTwo).await.unwrap();
+    assert_eq!(out["items"].as_array().unwrap().len(), 2);
+    // sovereign → unbounded
+    let out = r.dispatch(&ctx("sovereign"), "list_things", &json!({}), &AllowAll, &CapTwo).await.unwrap();
+    assert_eq!(out["items"].as_array().unwrap().len(), 4);
+}
+
+#[tokio::test]
+async fn gate_denies_before_the_handler_runs() {
+    let r = registry();
+    let err = r
+        .dispatch(&ctx("citizen"), "list_things", &json!({}), &DenyCitizen, &CapTwo)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, PluginError::Denied(_)));
+}
+
+#[tokio::test]
+async fn unknown_tool_is_a_bad_request() {
+    let r = registry();
+    let err = r.dispatch(&ctx("citizen"), "nope", &json!({}), &AllowAll, &CapTwo).await.unwrap_err();
+    assert!(matches!(err, PluginError::BadRequest(_)));
+}


### PR DESCRIPTION
Promotes `hub-plugin` — the generic `ToolPlugin`/`PluginCtx`/`PluginRegistry` seam (gate→handle→scope) — from the private dev-hub superset to the public hub. The open-core keystone: core owns authn/gating/scoping/sealing, plugins own handlers.

**IP audit result:** hub-plugin is the only dev-hub-only crate cleanly publish-eligible (names no mechanism). The rest stays private — it's the unfiled witness-tree/constellation invention or self-declared 'potentially patentable' (M-of-N unlock engine, liveness-gated vault), pending counsel. The hub core + admin UI were already public here (and ahead of dev-hub).

Doc comment sanitized (removed example references to private handlers). 3 tests green.