### PR TITLE
docs(hub): refresh public docs to current capabilities

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -6,7 +6,7 @@
 > Production and advanced development continue in a separate private repository;
 > features may land here later behind stable plugin interfaces.
 
-A single-binary Rust daemon (~6 MB) that turns a community chapter into a sovereign Web4 society — 7 roles, signed founding charter, append-only witnessed ledger, MCP HTTP server, admin CLI, Docker deployment. First deployment target: a pilot community chapter. Any community willing to operate as a Web4 society can use the same software.
+A single-binary Rust daemon (~6 MB) that turns a community chapter into a sovereign Web4 society — 7 roles, signed founding charter, append-only witnessed ledger, and a multi-surface API: a small MCP `/tools/*` convenience surface, a full REST `/v1` API, a sealed member↔hub channel, and an operator admin web GUI — all driven by the same admin CLI and Docker deployment. First deployment target: a pilot community chapter. Any community willing to operate as a Web4 society can use the same software.
 
 ## Witnessed law
 
@@ -15,7 +15,7 @@ The hub does **not** dictate how a society runs — it makes *whatever law the s
 - **Signed, machine-readable law.** A society's rules — admission, role authority, thresholds, what escalates — are a law the PolicyEntity gate evaluates before every consequential act. It is **inspectable by anyone** (`GET /v1/hubs/:id/law`), *including while the hub's vault is locked*: the rules are public even when the hub can't yet act on them.
 - **Changeable only with authority, and witnessed.** Amending the law requires unlock + signing and lands as a `LawAmended` event on the **append-only, hash-chained, witnessed ledger** — alongside every membership, role, skill, and intro act. You cannot quietly change the rules.
 - **Fail-closed secrets.** The Sovereign key is encrypted at rest; the daemon never silently writes a plaintext key (an empty passphrase is allowed but must be *explicit*). A hub whose vault is locked **degrades to a read-only no-LCT surface** rather than running ungoverned.
-- **Governed startup (design posture).** Unlocking a hub is itself meant to be an auditable, governed act — automatable or human-gated per the society's own law, but always recorded. Locked-mode ships today; the witnessed M-of-N / hardware-bound unlock is the roadmap. *Convenience is policy; the audit trail is not.*
+- **Governed startup (shipped).** Unlocking a hub is itself an auditable, governed act — automatable or human-gated per the society's own law, but always recorded. Locked-mode ships today, and so does the **generic tier-2 M-of-N unlock seam** (`POST /v1/hubs/:id/unlock/challenge` + `/unlock/attest`): the hub mints the challenge, ledgers every step, and defers the quorum decision to an optional private verifier (`HUB_UNLOCK_VERIFIER`). With no verifier installed, tier-2 unlock reports N/A (501) and the hub runs unaffected — the novel quorum logic is pluggable, the seam is public. *Convenience is policy; the audit trail is not.*
 
 We don't mandate the policy. We insist that whatever the policy is, is followed verifiably.
 
@@ -28,8 +28,8 @@ We don't mandate the policy. We insist that whatever the policy is, is followed 
 | 0 | Workspace scaffold + PRD + sprint plan | ✓ |
 | 1 | Society instantiation (7 roles + signed charter) | ✓ |
 | 2 | Chapter ledger (hash-chained signed event log) | ✓ |
-| 3 | MCP HTTP server (`/tools/*` for all operations) | ✓ |
-| 4 | Admin CLI parity via HubSession | ✓ |
+| 3 | HTTP surface — small MCP `/tools/*` convenience set + full REST `/v1` API + sealed member channel | ✓ |
+| 4 | Admin CLI + operator admin web GUI | ✓ |
 | 5 | Docker package + first-chapter demo scripts | ✓ (Docker untested on dev machine; first operator with Docker should report) |
 | 6 | Pilot-organizer docs + polish | ✓ |
 
@@ -38,7 +38,7 @@ We don't mandate the policy. We insist that whatever the policy is, is followed 
 - **Web4 society shell** — uses `web4-core` + `web4-trust-core` directly; no reimplementation of LCT / T3/V3 / MRH / ATP / R6 primitives
 - **AGPL-3.0-or-later** — patent grant per web4 root `PATENTS.md`; any community can fork
 - **Single binary, single config file** — `docker compose up` deploys; chapter organizer needs no DevOps experience
-- **Local-first** — chapter data stays in the chapter's directory; no telemetry, no vendor data extraction
+- **Local-first, encrypted at rest** — chapter data stays in the chapter's directory; no telemetry, no vendor data extraction. The SQLCipher state store, the identity vault, and the ledger are all encrypted on disk with a key derived from the vault passphrase, held in memory only after ignition
 
 ## Extending the hub (plugin seam)
 
@@ -62,9 +62,9 @@ operator can add their own (or proprietary) handlers without forking the hub.
 
 - Not a Member Presence Toolkit (Hestia multi-hub plugin — separate package, V2)
 - Not the Central Overlay layer (cross-chapter federation, global skill graph — V2)
-- Not a public web UI for members (admin CLI + MCP is the MVP surface)
+- Not a *member-facing* public web UI — that's still out of scope. (An **operator/admin web GUI does ship**: a read-only dashboard at `/admin` on the fleet port, plus a write-capable operator plane — admit/deny admissions, add/re-key/remove members — at `/admin/joins` and `/admin/manage`, bound to 127.0.0.1 only on the admin port, default 8772.)
 - Not Slack-integrated (deferred until pilot empirically defines coexistence requirements)
-- Not ACT-anchored (local file ledger for MVP; ACT anchoring is V2)
+- Not ACT-anchored (ledger persists to a local `file` backend or a SQLCipher-encrypted `sqlite` backend; ACT anchoring is V2)
 - Not Hardbound-policy-integrated (chapter law is text; full enforcement requires resolving Hardbound's canonical Web4 alignment debt)
 
 See `docs/PRD.md` §5 for full out-of-scope rationale.
@@ -79,6 +79,8 @@ cargo build --release
 # 5-minute demo
 HUB=$PWD/target/release/hub bash examples/first-chapter.sh
 ```
+
+**Vault / unlock-first reality.** A sealed hub boots **locked** — every endpoint returns 503 except the unlock path — and is ignited with `hub unlock` (which presents the passphrase once and never stores it). CLI acts that touch the vault (`gen-lct`, `init`, …) resolve the passphrase from `HUB_PASSPHRASE` or a TTY prompt (an empty value is allowed but must be explicit). See [`docs/QUICKSTART.md`](docs/QUICKSTART.md) and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md).
 
 Or, with Docker (untested on dev machine; first operator with Docker, please report):
 
@@ -107,42 +109,132 @@ cd web4/hub
 cargo build --release
 ./target/release/hub --version    # → hub 0.1.0-alpha.0
 ./target/release/hub --help       # → list of subcommands
-cargo test --release              # → 30 tests should pass
+cargo test --release              # → the full suite should pass
 ```
 
 ## CLI surface
 
+Run `hub --help` for the authoritative list. Highlights:
+
 ```
-hub gen-lct <path>                                  Generate a fresh LCT + keypair
-hub init <name> --sovereign-lct <path>              Bootstrap a chapter society
-hub status <chapter-dir>                            Chapter summary
-hub add-member <chapter-dir> <lct-id> [--name]      Add a member
-hub remove-member <chapter-dir> <lct-id>            Remove a member
-hub assign-role <chapter-dir> <role> <role-lct> <member-lct>
-                                                    Assign a role
-hub record-event <chapter-dir> <kind> <title> [--attended-by lct1,lct2,...]
+# Identity & vault
+hub gen-lct <path> [--entity-type T]                 Generate a fresh LCT + keypair
+hub seal-identity <path>                             Encrypt a plaintext identity file in place
+hub export-public-identity <hub-dir>                 Write the clear tier-0 public-identity.json
+hub rotate-passphrase <hub-dir>                      Re-key the vault to an operator-chosen passphrase
+hub unlock [--port N]                                Ignite a locked, running hub (stub-console plugin)
+
+# Society lifecycle
+hub init <name> --sovereign-lct <path> [--storage file|sqlite]
+                                                    Bootstrap a chapter society
+hub status <hub-dir>                                 Chapter summary
+hub migrate <hub-dir> --to file|sqlite              Migrate the storage backend
+hub serve <hub-dir> [--port N] [--bind addr] [--admin-port N]
+                                                    Run the HTTP server (REST + MCP + admin)
+hub verify-ledger <hub-dir>                          Verify the chain end-to-end
+
+# Members, roles, events, skills
+hub add-member <hub-dir> <lct-id> [--name]          Add a member
+hub remove-member <hub-dir> <lct-id> [--reason]     Remove a member
+hub assign-role <hub-dir> <role> <member-lct-id>    Assign a role (role LCT is society-managed)
+hub set-member-key <hub-dir> <member-lct-id> <pubkey-hex>
+                                                    Pin/rotate a member's channel public key
+hub record-event <hub-dir> <kind> <title> [--attended-by lct1,lct2,...]
                                                     Record a chapter event
-hub declare-skill <chapter-dir> <member-lct> <skill>
-                                                    Declare a skill for a member
-hub query members <chapter-dir>                     List members
-hub query skill <chapter-dir> <query>               Find members by skill (substring)
-hub query chapter <chapter-dir>                     Chapter identity + role fill
-hub serve <chapter-dir> [--port N] [--bind addr]    Run MCP HTTP server
-hub verify-ledger <chapter-dir>                     Verify the chain end-to-end
+hub declare-skill <hub-dir> <member-lct> <skill>    Declare a skill for a member
+hub set-profile <hub-dir> <member-lct> KEY=VALUE... Update member profile fields
+
+# Law
+hub init-law [output] [--force]                     Write a starter chapter-law template
+hub set-law <hub-dir> <yaml> [--diff-summary ...]   Set/amend chapter law (ledgers LawAmended)
+hub get-law <hub-dir>                                Print the current chapter law
+
+# Sovereign Council (V2-9)
+hub council add <hub-dir> <member-lct-id> --pubkey HEX [--name]   Admit a co-Sovereign
+hub council remove <hub-dir> <member-lct-id> [--kind] [--reason]  Remove a holder
+hub council set-threshold <hub-dir> <m>             Set the M-of-N threshold
+hub council show <hub-dir>                           Show council state
+
+# Paired channels (V2 PAIRED-CHANNELS) — see docs/PAIRED-CHANNELS.md
+hub envelope-sign --identity P --nonce N --payload JSON          Build a SignedEnvelope for REST
+hub pair-generate-ephemeral                          Fresh X25519 ephemeral keypair (forward secrecy)
+hub pair-encrypt / pair-decrypt ...                  Seal/open a pair-message body
+
+# Query
+hub query members <hub-dir>                          List members
+hub query skill <hub-dir> <query>                    Find members by skill (substring)
+hub query chapter <hub-dir>                          Chapter identity + role fill
 ```
 
-## MCP HTTP endpoints (when `hub serve` is running)
+## HTTP surface (when `hub serve` is running)
+
+### MCP `/tools/*` — convenience subset
+
+A small, unauthenticated localhost convenience surface — **not** the full API; the
+REST `/v1` API below is the canonical write path.
 
 ```
 GET  /tools                       Tool catalog
-GET  /tools/query_chapter         Chapter identity + role-fill snapshot
+GET  /tools/query_hub             Hub identity + role-fill + recent events
+                                  (/tools/query_chapter is a back-compat alias)
 GET  /tools/list_members          Current member projection
 GET  /tools/find_skill?q=...      Skill substring match
 POST /tools/add_member            { member_lct_id, name? }
-POST /tools/assign_role           { role, role_lct_id, member_lct_id }
+POST /tools/assign_role           { role, member_lct_id }  (role_lct_id optional; society-managed)
 POST /tools/record_event          { event_kind, title, attended_by?, held_at? }
 POST /tools/declare_skill         { member_lct_id, skill }
 ```
+
+### REST `/v1` API — the full surface
+
+```
+GET  /.well-known/web4-hub.json                       Tier-0 discovery (did:web4, pubkey, founder)
+GET  /v1/hubs/:id/law                                 Public chapter law (readable while locked)
+POST /v1/auth/challenge                               Mint an envelope-signing nonce
+POST /v1/hubs/:id/events                              Submit a signed, law-gated act
+GET  /v1/hubs/:id/state                               Projected state (tier-scoped)
+POST /v1/hubs/:id/unlock                              Tier-1 passphrase ignition (127.0.0.1)
+POST /v1/hubs/:id/unlock/challenge | /unlock/attest   Tier-2 M-of-N unlock seam (501 w/o verifier)
+POST /v1/hubs/:id/members/join                        Member admission request → law gate → queue
+POST /v1/hubs/:id/channel                             Sealed member↔hub channel (see below)
+*    /v1/hubs/:id/council/{propose,sign,proposals}    Sovereign Council proposal flow
+*    /v1/hubs/:id/pairs/...                            Paired member↔member channels
+*    /v1/hubs/:id/{credential,vp/request,vp/response} EUDI / OID4VC (see below)
+```
+
+### Operator admin web GUI (admin port, default 8772, 127.0.0.1-only)
+
+Read-only dashboard at `/admin` (overview, members, roles, ledger, law, council,
+pairs) plus a write-capable operator plane: the admission queue at `/admin/joins`
+(Admit/Deny live, no restart) and member management at `/admin/manage`
+(add / re-key / remove), backed by the `/admin/api/*` endpoints.
+
+### Member admission flow
+
+An external entity calls `request_citizenship` (or `POST /v1/hubs/:id/members/join`).
+The chapter-law gate evaluates it: **Allow** admits immediately, **Deny** rejects (403),
+**Escalate** parks the request in the operator admission queue (202), where an operator
+Admits or Denies it live from `/admin/joins`.
+
+### Sealed member↔hub channel
+
+`POST /v1/hubs/:id/channel` carries a sealed, authenticated request whose inner tool is
+one of: `find_members`, `request_intro` / `list_intros` / `respond_intro`,
+`notifications` (drains the per-citizen sealed mailbox), `referenced_act`, and
+`constellation_challenge` / `present_constellation` (assurance-tier bindings). The same
+`gate → handle → scope` contract as the [plugin seam](#extending-the-hub-plugin-seam)
+applies to every channel tool.
+
+### Paired channels, Council & EUDI
+
+- **Paired member↔member channels** — request / confirm / revoke pairs and exchange
+  end-to-end-sealed messages (X25519 + ChaCha20-Poly1305, optional forward secrecy).
+  See [`docs/PAIRED-CHANNELS.md`](docs/PAIRED-CHANNELS.md).
+- **Sovereign Council** — propose / sign / threshold M-of-N governance over council-gated
+  acts (data model + management ship now; threshold enforcement is Phase 2).
+- **EUDI / OID4VC** — the hub issues membership credentials (OID4VCI, SD-JWT-VC) and
+  verifies presentations (OID4VP) as a relying party, anchored to its `did:web4` identity.
+  See [`docs/V2-V3-ARCHITECTURE.md`](docs/V2-V3-ARCHITECTURE.md).
 
 ## License
 

--- a/hub/docs/BACKEND-OPTIONS.md
+++ b/hub/docs/BACKEND-OPTIONS.md
@@ -19,12 +19,20 @@ A hub stores three kinds of state:
 2. **Append-only signed event log** — the ledger. Hash-chained for
    integrity, signed per-entry for authenticity.
 3. **Sidecar records** — V2-9 P2 council proposals (mutable
-   open → committed/rejected/expired lifecycle).
+   open → committed/rejected/expired lifecycle), and pair-message
+   logs.
 
 All three sit behind the `HubStore` trait
 ([`hub-lib/src/store.rs`](../hub-lib/src/store.rs)). Backends are
 swappable; data is portable. `hub migrate` moves an existing chapter
 between any two implemented backends byte-for-byte (no re-signing).
+
+Not all hub data lives in `HubStore`. The membox search **cart** is a
+*pure index* — it stores only `{member_lct, score}` and holds **no
+member PII at rest**. Search hits are enriched on the read path from
+the authoritative (now encrypted) member registry, so member PII lives
+exactly once, in the hub's own store, not duplicated into the sidecar
+index.
 
 ### Hard constraints on any backend
 
@@ -64,11 +72,17 @@ commitments) and aren't negotiable:
 | Atomicity | Append via `O_APPEND`; state via temp-then-rename |
 | Cost | Disk only |
 | Lock-in | Zero. Plain files, inspectable with `cat` / `jq` |
+| At-rest encryption | None at the storage layer — files are plaintext on disk. Pair with an encrypted volume / TPM-sealed dir for confidentiality. |
 | Sovereignty fit | ✅ Maximum — operator literally holds the bytes |
 | Hardware-binding fit | ✅ Pairs cleanly with TPM-sealed dir / encrypted volume |
 
 **Best for:** Single-machine hubs, R&D, chapters small enough for the full
 ledger to live in RAM. The MVP default.
+
+**Confidentiality note:** the `file` backend writes plaintext. Unlike
+`sqlite` (now SQLCipher-encrypted at rest), `file` relies on the
+surrounding filesystem (encrypted volume, TPM-sealed dir) for
+confidentiality of the bytes.
 
 **Limits:** No concurrent multi-process writers (file lock would help but
 isn't implemented). Linear ledger scan for queries. Backup = `tar`.
@@ -76,7 +90,8 @@ isn't implemented). Linear ledger scan for queries. Backup = `tar`.
 ### `sqlite` — single-file embedded SQL  ✅ shipped (V2-2)
 
 ```
-<chapter-dir>/chapter.db   # single SQLite file (+ WAL/SHM transient)
+<chapter-dir>/hub.db   # single SQLite file, SQLCipher-encrypted at rest (+ WAL/SHM transient)
+                       # legacy chapter.db is read in place as a fallback
 ```
 
 | Property | Value |
@@ -85,10 +100,11 @@ isn't implemented). Linear ledger scan for queries. Backup = `tar`.
 | Locality | One file, anywhere |
 | Multi-tenancy | One chapter per file |
 | Atomicity | `INTEGER PRIMARY KEY` on `idx` enforces append-only at the index level; WAL mode for concurrent readers |
-| Cost | Disk + bundled sqlite library |
-| Lock-in | Low. Open with `sqlite3 chapter.db`, dump back to file backend |
-| Sovereignty fit | ✅ Same as file — single artifact you own |
-| Hardware-binding fit | ✅ Same as file |
+| Cost | Disk + bundled SQLCipher library (`rusqlite` "bundled-sqlcipher") |
+| At-rest encryption | ✅ SQLCipher under a key derived (Argon2id) from the vault passphrase; on-disk bytes are ciphertext. Plaintext→encrypted migration happens in place on first keyed open. |
+| Lock-in | Low. Open with a SQLCipher-enabled `sqlite3` + `PRAGMA key`, dump back to file backend |
+| Sovereignty fit | ✅ Same as file — single artifact you own, and now encrypted at rest |
+| Hardware-binding fit | ✅ Same as file; the at-rest key ties to the vault passphrase |
 
 **Best for:** Single-machine hubs that want one artifact to back up, faster
 ledger queries (indexed by `idx`), or transactional state-doc writes.
@@ -118,8 +134,9 @@ chapters. Same `HubStore` trait.
 many hubs and wants shared ops + backup + monitoring. Federated
 deployments where chapters share an operator but not sovereignty.
 
-**Limits:** Async client (`tokio-postgres` / `sqlx`) — see [§Async trait](#open-design-question-async-trait)
-below. Network round-trips on every op (acceptable for hubs serving
+**Limits:** Async client (`tokio-postgres` / `sqlx`) — fits the now-async
+`HubStore` trait (see [§RESOLVED: async trait](#resolved-async-trait-option-b-shipped)
+below). Network round-trips on every op (acceptable for hubs serving
 human-scale request rates).
 
 ### `dynamodb` — AWS managed NoSQL  💭 candidate
@@ -250,54 +267,52 @@ read-only projection (which is fine, just a different abstraction).
 
 ---
 
-## Open design question: async trait
+## RESOLVED: async trait (option B shipped)
 
-The `HubStore` trait is currently synchronous. Network-backed
-backends (Postgres, DynamoDB, S3) MUST do I/O on the tokio runtime
-to participate in the axum daemon's async model.
+This was an open design question (sync vs async `HubStore`). It is now
+**resolved and implemented**: `HubStore` is an **`#[async_trait]`**
+trait (`Send + Sync`) with all methods `async`. Option B shipped.
 
-Three options to resolve:
+How it plays out in the code today:
 
-### A. Wrap calls in `spawn_blocking` (status quo)
+- **Network backends** (DynamoDB; Postgres later) do real `.await`s
+  on tokio.
+- **In-process backends** (`file`, `sqlite`) implement the async
+  signatures with bodies that complete synchronously — no
+  `spawn_blocking`, no actual suspension. `SqliteBackend` wraps its
+  `rusqlite::Connection` in a `std::sync::Mutex` so it is `Sync`
+  (the async-trait default future `Send` bound transitively requires
+  `self: Sync` for `&self` methods); the lock is uncontended in the
+  one-daemon-per-hub case.
+- Every call site `.await`s store calls — consistent with the
+  daemon's other awaits (envelope verify, signer roundtrip).
+- `async_trait` boxes a `Box<dyn Future>` per call; this was the
+  accepted cost for a uniform, object-safe (`Box<dyn HubStore>`)
+  abstraction.
 
-What I did for V2-9 P2 proposal storage — handler spawns a blocking
-task that opens the store + runs the sync operation. Works today,
-zero trait changes, but:
+The original trade-off analysis (the rejected options) is preserved
+below for context.
 
-- Sequentializes I/O behind the rayon-blocking-pool worker count
-- Hidden cost (the blocking pool defaults are tuned for occasional
-  blocking, not "every request")
-- Forces store re-open on every request (no connection pooling)
+### Rejected: A — wrap calls in `spawn_blocking`
 
-### B. `#[async_trait]` on `HubStore`
+The pre-refactor status quo. Worked, zero trait changes, but
+sequentialized I/O behind the blocking-pool worker count, carried
+hidden blocking-pool cost on every request, and forced a store
+re-open per request (no connection pooling).
 
-Convert to async-first. Sync backends (`file`, `sqlite`) implement
-the async signature with `async fn` that just runs synchronously —
-no `spawn_blocking` needed because the work is in-process and fast.
-Network backends do real awaits.
+### Rejected: C — split `HubStore` (sync) + `HubStoreAsync` (async)
 
-Cost: every call site needs `.await`. Boxing overhead per call
-(`async_trait` allocates a `Box<dyn Future>`).
+Two traits, two impl families, converters between them, doubled
+tests. Rejected for the duplication cost.
 
-### C. Split into `HubStore` (sync) + `HubStoreAsync` (async) traits
+### Why B
 
-Two traits, two impl families. Higher-layer code uses one or the
-other. Migration boundary is the daemon: pick async if any backend
-is network-backed.
-
-Cost: trait duplication; converters between the two; tests doubled.
-
-### Recommendation
-
-**B (`#[async_trait]`).** Pay the boxing cost once, get a uniform
-abstraction, and the daemon-internal call sites already await
-elsewhere (envelope verify, signer roundtrip, etc.) so adding
-`.await` to store calls is consistent.
-
-This is a one-sprint refactor that should land **before** the first
-network-backed backend, not as part of it. Otherwise we pay the
-`spawn_blocking` tax permanently on `file`/`sqlite` and end up with
-async only on the new backend (inconsistent).
+Pay the boxing cost once, get a uniform abstraction, and the
+daemon-internal call sites already await elsewhere, so adding
+`.await` to store calls is consistent. It landed **before** the
+first network-backed backend rather than as part of it, so
+`file`/`sqlite` never paid a permanent `spawn_blocking` tax and the
+abstraction stays consistent across backends.
 
 ---
 
@@ -308,23 +323,34 @@ the bytes without the operator's involvement?**
 
 | Backend | Bytes-readable-by |
 |---|---|
-| `file` (on operator's disk) | Just the operator |
-| `sqlite` (same disk) | Just the operator |
+| `file` (on operator's disk) | Just the operator (plaintext on disk — anyone with disk access) |
+| `sqlite` (same disk) | Just the operator — and disk access **alone is insufficient**: on-disk bytes are SQLCipher ciphertext requiring the vault passphrase |
 | `postgres` (self-hosted) | Operator + anyone with DB access |
 | `postgres` (RDS / Aurora) | + AWS, by way of platform access |
 | `dynamodb` | + AWS, same |
 | `s3` (any cloud) | + provider |
 | `cloudflare-d1` / `vercel-postgres` | + provider |
 
-For the chapter state itself, this matters less than it sounds —
-it's all signed and not encrypted by design (the data is public to
-chapter members + auditors; the integrity guarantee comes from
-signatures, not from confidentiality).
+The encryption posture now differs by backend. The `sqlite` backend is
+**encrypted at rest** (SQLCipher, key derived from the vault passphrase),
+so possession of the `hub.db` file is not enough to read the bytes —
+disk access without the passphrase yields only ciphertext. The `file`
+backend is still plaintext on disk (lean on an encrypted volume / TPM
+for confidentiality). The cloud backends store whatever the provider
+holds; some support bring-your-own-key envelope encryption (KMS), but
+that's a different trust model from SQLCipher-under-the-operator's-passphrase.
+
+Integrity, separately, comes from the signed hash-chain on every
+backend (auditors can verify the chain regardless of where the bytes
+live). Encryption at rest is an *added* confidentiality layer, not a
+replacement for signatures.
 
 For an emerging Hestia-mode hub where Hestia holds the keys and the
-hub holds the data: a cloud-hosted hub is *fine*, because the cloud
-provider sees signed-but-public state, not secrets. The vault stays
-on the operator's hardware.
+hub holds the data: a cloud-hosted hub is still *fine* for integrity,
+but note that a cloud provider sees whatever that backend stores in
+its infrastructure — only the local `sqlite` backend gives you
+SQLCipher-at-rest under your own passphrase today. The vault stays on
+the operator's hardware regardless.
 
 The argument for `file` / `sqlite` over cloud-hosted backends is
 operational, not constitutional:

--- a/hub/docs/CHAPTER-LAW.md
+++ b/hub/docs/CHAPTER-LAW.md
@@ -1,122 +1,268 @@
 # Web4 Community Hub — Chapter Law
 
-The chapter's **charter** is the constitutional document the Sovereign signs at chapter founding. It's plain-text-with-structure (JSON in MVP) and lives at `<chapter-dir>/charter.json`. Its sha256 hash is stored in `society.json`'s `charter_hash` field, so any tampering with the charter invalidates the society state's link to it.
+Two distinct documents govern a chapter, and it's worth keeping them straight:
 
-## What's in the default charter
+- The **charter** (`<chapter-dir>/charter.json`) is the constitutional preamble
+  the Sovereign signs at founding. It's plain-text-with-structure (JSON) and its
+  sha256 is pinned in `society.json`'s `charter_hash` field — tamper-evident, but
+  prose. It says *who the chapter is*.
+- **Chapter law** is a separate, signed **YAML** document with a typed schema. It
+  says *what the hub will and won't do*. Unlike the charter, chapter law is
+  **machine-readable and enforced**: the PolicyEntity gate evaluates every act and
+  every gated read against it before anything commits.
 
-`hub init` writes a minimal default:
+This doc is about chapter law — the enforced half.
 
-```json
-{
-  "schema_version": "0.1",
-  "hub_name": "Your Chapter Name",
-  "founded_at": "2026-06-07T17:36:21.939166474Z",
-  "founding_sovereign_lct_id": "...",
-  "preamble": "This is the founding charter of...",
-  "rules": [],
-  "amendments": []
-}
+## The law document
+
+Chapter law is a single YAML file matching `web4-standard/core-spec/chapter-law-schema.md`,
+parsed into the typed `Law` struct in `hub-lib/src/law.rs`. Top-level sections:
+
+| Section | Shape | Purpose |
+|---|---|---|
+| `version` | semver string (required) | e.g. `"1.0.0"`. |
+| `norms` | list | The atomic rules. Each is `selector`/`operator`/`value` → `decision`. |
+| `procedures` | list | `requires_witnesses` / `requires_quorum` / `applies_to`. |
+| `delegation` | object | `max_depth` (≥ 0), `requires_approval`, `allowed_roles`. |
+| `escalation` | list | `condition` (an R6 expression) + `escalate_to` (a role). |
+| `admission` | object | `open`, `requires_sponsor`, `sponsor_role`, `min_trust_score` (0–1). |
+| `atp_issuance` | object | `mint_authority` (a role), `max_mint_per_cycle` (≥ 0), `distribution`. |
+| `custom_predicates` | list | Community-defined predicates (reserved; not yet evaluated). |
+
+### Norms
+
+A norm is the atomic unit of law:
+
+```yaml
+norms:
+  - id: ATP-LIMIT                 # unique within the file
+    selector: r6.resource.atp     # what to look at on the request
+    operator: ">"                 # how to compare
+    value: 100                    # what to compare against
+    decision: deny                # allow | deny | escalate
+    priority: 10                  # higher wins on conflict (default 0)
+    description: "No single action may spend more than 100 ATP"
 ```
 
-The default `preamble` says the chapter is constituted as a Web4 society, operates by chapter law, and amends via the witnessed process the law itself defines. That's enough to legitimately operate but doesn't say much about how *your* chapter actually wants to work.
+**Selectors** address the R6 request being evaluated:
+`r6.role`, `r6.request.action`, `r6.request.payload.<field>` (dot-path into the
+event payload), and `r6.resource.<key>` (quantifiable costs like `atp`,
+`witness_count`). A selector that doesn't resolve means the norm simply doesn't
+fire.
+
+**The nine operators** (schema §2): `<=`, `>=`, `==`, `!=`, `<`, `>`, `in`,
+`not_in`, `matches`. The four comparison operators require both sides numeric.
+`==`/`!=` use deep value equality. `in`/`not_in` expect a list. (`matches` —
+regex — is reserved and currently a no-op.)
+
+**Decisions**: `allow`, `deny`, `escalate`.
+
+### Evaluation semantics
+
+`Law::evaluate_outcome()` (the function the gate calls) works like this:
+
+1. Every norm whose selector resolves and whose operator matches **fires**.
+2. Among firing norms, the **highest `priority` wins** (ties broken by
+   first-defined).
+3. **`Deny` is terminal** — a winning Deny short-circuits; no escalation can
+   override it.
+4. Otherwise, any matching `escalation` trigger produces `Escalate` (with its
+   `escalate_to` role). A norm that resolves to `Escalate` but has no explicit
+   target defaults to `sovereign`.
+5. **Silence is consent**: if no norm and no trigger fires, the default is
+   `Allow`. An empty law (just a `version`) allows everything — open by default.
+
+## The CLI
+
+There is a full law CLI (in `hub-daemon/src/main.rs`). It is *not* a hand-edit
+workflow:
+
+```bash
+# 1. Write the starter template (embedded in the binary; validated on write)
+hub init-law ./hub-law.yaml
+
+# 2. Edit it, then apply it to a chapter. set-law parses + validates,
+#    writes the signed YAML to chapter storage, and appends a witnessed
+#    LawAmended event to the ledger.
+hub set-law ./my-chapter ./hub-law.yaml --diff-summary "raise ATP ceiling"
+
+# 3. Read back the law currently in force
+hub get-law ./my-chapter
+
+# If `hub serve` is running, reload the live law slot without a restart:
+curl -X POST http://<host>/v1/admin/reload-law
+```
+
+`hub init-law` ships a starter template (from `examples/starter-law.yaml`),
+sanity-validated against the schema before it's written. `hub set-law` rejects
+the file loudly on the first validation error — operators get one clear message
+per fix (bad semver, duplicate norm id, unknown role, out-of-range trust score,
+etc.), so malformed law never reaches the ledger.
+
+## The PolicyEntity gate is live
+
+The Law Oracle publishes the law; the **PolicyEntity** enforces it. This is not a
+V2 aspiration — the gate runs today.
+
+### On writes (every act)
+
+Every act, before it commits, is turned into an `R6Request` and run through
+`Law::evaluate_outcome()`. This happens in both transports:
+
+- REST: `hub-daemon/src/rest.rs` (~L1697), and on the pair endpoints too.
+- MCP: `hub-daemon/src/mcp.rs` (~L384).
+
+The decision maps directly to HTTP status:
+
+| Decision | Result |
+|---|---|
+| **Allow** | The act proceeds and commits to the ledger. |
+| **Deny** | `HTTP 403` — the act is rejected (response names the winning norm). |
+| **Escalate** | `HTTP 202` — held for review by the `escalate_to` role; not committed. |
+
+If no law is loaded, acts proceed (open-by-default) — the same behavior as before
+a chapter sets law.
+
+### On reads (gated queries)
+
+The PolicyEntity gates queries the same way it gates writes (schema §8). Channel
+read tools run through `gate_read()` (rest.rs), which evaluates a request with
+`action = "read:<tool>"` — e.g. `read:find_members`. Read actions are namespaced
+with the `read:` prefix so a read norm can never collide with an act (event-kind)
+norm. Same Allow/Deny/Escalate → proceed/403/202 mapping. This is how a chapter
+restricts *who can run member discovery*, scoped per tier.
+
+### Admission via law
+
+Joining is admission-by-law. A join request (the encrypted
+`request_citizenship` path, and the plaintext `/members/join`) is evaluated with
+`action = member_join_request`, `role = applicant`:
+
+- **Allow** → the applicant is auto-admitted (the Sovereign signs a `MemberAdded`
+  pinning their pubkey; they're added to the resolver so their next channel is as
+  a citizen).
+- **Deny** → `HTTP 403`, rejected.
+- **Escalate** → a `MemberJoinRequested` event is **witnessed** with status
+  `pending_review`, and the applicant gets a `request_id` to poll. That witnessed
+  pending event *is* the admission queue the operator actions — nothing is
+  silently dropped.
+
+The `admission` section of the law (`open`, `requires_sponsor`, `sponsor_role`,
+`min_trust_score`) is the natural place to express this, but any norm matching
+`r6.request.action == "member_join_request"` participates.
+
+## Audit trail
+
+Law is always signed and auditable — the hub binary contains no hardcoded policy;
+it's a law interpreter. Every `hub set-law` appends a `LawAmended` ledger event
+carrying `new_law_sha256` (the canonical sha256 of the YAML), `version`,
+`amended_by`, and an optional `diff_summary`. Because every amendment is on the
+chain with its hash, any party can walk the ledger, follow the `LawAmended`
+events, and reconstruct exactly which law was in force at any historical point.
 
 ## What chapter law should cover (suggested topics)
 
-The Web4 spec leaves chapter law unspecified by design — each chapter is sovereign. A practical starter set of topics:
+The schema gives you the mechanism; the policy is yours. A practical starter set
+of topics to encode:
 
 ### Member admission
 
-- Who can become a Citizen? (open, invite-only, vetted, etc.)
-- What's the process? (self-application, sponsor-required, vote, etc.)
-- What information is shared on admission? (skill declarations? affiliations?)
+- Who can become a Citizen? (`admission.open`, `requires_sponsor`.)
+- What's the gate? Auto-admit, sponsor-required, or queue-for-review (Escalate)?
+- What minimum trust, if any? (`admission.min_trust_score`.)
 
 ### Member departure + removal
 
-- Voluntary departure: what triggers `MemberRemoved`? (formal request? inactivity threshold?)
-- Involuntary removal: under what conditions? Who decides? (Sovereign? Policy Entity? majority of other members?)
-- What happens to T3 / skill declarations on departure?
+- Involuntary removal: under what conditions, and who decides? Encode as a norm
+  on `r6.request.action == "member_removed"` — Deny outright, or Escalate to
+  Sovereign.
 
 ### Role rotation
 
-- How often are roles rotated? (annually? on request? never?)
-- Who can nominate a role-filler? Who confirms? (Sovereign? existing role-holder?)
-- What's the consent step? (assignee LCT signs acceptance — already enforced by `hub assign-role`)
+- Who can assign roles? A common pattern: `r6.request.action == "assign_role"` →
+  `escalate` to Sovereign or Administrator. (The assignee LCT still signs
+  acceptance — enforced by `hub assign-role` independent of law.)
 
 ### Treasury policy
 
-- What gets reified as ATP? (sweat-equity hours? sponsor inflow? attendance?)
-- Who can authorize ATP allocations? (Treasurer alone? Treasurer + Sovereign?)
-- What's the conservation invariant in practice? (just the technical sum-preservation, or also "no chapter ATP leaves without recorded justification")
+- Who mints ATP and how much per cycle? (`atp_issuance.mint_authority`,
+  `max_mint_per_cycle`.)
+- Cap single-action spend with a norm on `r6.resource.atp`.
 
-### Events
+### Events + consequential actions
 
-- What counts as a recordable chapter event? (only chapter-organized? affiliated meetups too?)
-- Who's authorized to record events? (Administrator? Anyone with Citizen?)
-- What attendance attestation is acceptable? (self-report? door-check? RSVP confirmed?)
+- Require independent witnesses or a quorum for weighty acts
+  (`procedures.requires_witnesses` / `requires_quorum`, scoped by `applies_to`).
 
-### Amendments
+### Escalation + delegation
 
-- How does the charter get amended? (Sovereign-only? Sovereign + chapter vote? consensus of N role-holders?)
-- What's the proposal-and-review window? (immediate? 7 days? 30 days?)
-- How are amendments recorded? (Already enforced: each amendment is a `CharterAmended` ledger entry; the new `charter_hash` replaces the old one in `society.json`.)
+- Which conditions always go to a human? (`escalation` triggers, e.g.
+  `"r6.resource.atp > 50" → escalate_to: sovereign`.)
+- How deep may authority be delegated, and to which roles?
+  (`delegation.max_depth`, `allowed_roles`.)
 
 ### Federation
 
-- What's the chapter's posture toward federation with other chapters? (open / curated / closed)
-- Who can negotiate inter-society protocols? (Sovereign? Witness?)
-- How are imported reputation tensors weighted? (Full trust? Capped? Per-source override?) — V2 feature; this column will matter when the inter-society protocol is exercised.
-
-## How to amend the charter
-
-1. **Edit `<chapter-dir>/charter.json`** directly. Add rules to the `rules` array, modify the preamble, etc. (V2 will provide a structured CLI for this; MVP is hand-edit.)
-2. **Compute the new hash** — when you run any `hub` command that touches the chapter, it'll catch a hash mismatch on read. The official path:
-   ```bash
-   # Hand-compute would be:
-   #   python3 -c "import json,hashlib; c=json.load(open('charter.json')); print('sha256:'+hashlib.sha256(json.dumps(c,separators=(',',':')).encode()).hexdigest())"
-   # But MVP doesn't have a `hub amend-charter` command yet — V2.
-   ```
-3. **Record a `CharterAmended` event in the ledger** with the new hash. **MVP gap**: there's no CLI for this yet (would be `hub amend-charter <chapter-dir> --diff-summary "..."` or similar). For now the recommended flow is to leave the charter at its default and document chapter law externally (e.g. in a markdown doc in the chapter dir alongside the charter) until V2 ships the amendment flow.
+- Posture toward other chapters, and how imported reputation is weighted. The
+  schema's `custom_predicates` slot is reserved for chapter-specific predicates
+  the cross-chapter exchange will exercise.
 
 ## What chapter law is NOT
 
 - Not a binding legal document outside the chapter's own membership.
-- Not a substitute for actual law (employment, finance, etc. as applicable to the chapter's operations).
-- Not consulted by the Hardbound policy engine in MVP (that's V2 — once Hardbound's canonical Web4 alignment debt is resolved, the Policy Entity role can mechanically enforce machine-readable rules from the charter).
-
-For MVP, chapter law is **social infrastructure** — the agreed-upon way the chapter operates, witnessed and tamper-evident via the ledger but enforced by chapter members' good faith.
+- Not a substitute for actual law (employment, finance, etc.) where applicable.
+- Not the charter. The charter is signed prose; chapter law is the enforced,
+  machine-readable rules. They reference each other but are distinct documents.
 
 ## Template
 
-A starter charter for a community chapter might look like:
+`hub init-law` writes a validated starter. A community chapter's law might look
+like:
 
+```yaml
+version: "1.0.0"
+
+norms:
+  - id: ATP-CEILING
+    selector: r6.resource.atp
+    operator: ">"
+    value: 100
+    decision: deny
+    priority: 10
+    description: "No single action may spend more than 100 ATP"
+
+  - id: ROLE-ASSIGNMENT-REVIEW
+    selector: r6.request.action
+    operator: "=="
+    value: assign_role
+    decision: escalate
+    priority: 20
+    description: "Role assignment is reviewed by the Sovereign"
+
+procedures:
+  - id: WITNESS-3
+    requires_witnesses: 3
+    applies_to: "consequential_actions"
+
+escalation:
+  - condition: "r6.resource.atp > 50"
+    escalate_to: sovereign
+    description: "High-ATP actions escalate to Sovereign"
+  - condition: "r6.request.action == 'amend_charter'"
+    escalate_to: sovereign
+
+admission:
+  open: false
+  requires_sponsor: true
+  sponsor_role: citizen
+  min_trust_score: 0.3
+  description: "Closed admission — an existing citizen must sponsor"
+
+atp_issuance:
+  mint_authority: treasurer
+  max_mint_per_cycle: 1000
+  distribution: proportional_to_contribution
 ```
-Preamble: This is the founding charter of <Chapter Name>. The chapter is
-constituted as a Web4 society for the purpose of advancing AI literacy,
-community engagement, and humans-in-the-loop AI development at the
-<location/scope>. Members hold portable identity (LCT) and accrue
-reputation (T3/V3) by attested contribution.
 
-Rules:
-  1. Membership is open to anyone who attends a chapter event in good
-     standing and requests admission.
-  2. The chapter holds at least one public event per month.
-  3. Event attendance is recorded as a witnessed ledger entry by the
-     Administrator role within 7 days.
-  4. Charter amendments require the Sovereign's signature and a 14-day
-     notice period to current Citizens.
-  5. The chapter federates with other community chapters per the Central
-     overlay protocol (when Central is established).
-
-Treasury policy:
-  - 1 ATP = 1 hour of attested chapter work (event organizing, mentorship,
-    code contribution to chapter projects).
-  - Sponsor inflow is reified at par with the sponsor's stated value.
-  - ATP allocations require Treasurer signature.
-
-Amendment process:
-  - Sovereign proposes amendments.
-  - 14-day notice via chapter Slack + email.
-  - Sovereign signs to ratify; CharterAmended event recorded.
-```
-
-Adapt to your chapter's needs. The hub's job is to witness whatever you decide; the deciding is yours.
+Adapt it to your chapter, then `hub set-law` it. The hub witnesses the amendment
+and enforces the result; the deciding is yours.

--- a/hub/docs/HESTIA-MODE.md
+++ b/hub/docs/HESTIA-MODE.md
@@ -1,19 +1,36 @@
 # Hestia Mode
 
-**Status:** V2-7 Step 3b — landed end-to-end including the ergonomic `hub init --sovereign-hestia` CLI. Hub binary holds NO Sovereign keypair during init or serve.
+**Status:** Landed end-to-end, including the ergonomic `hub init --sovereign-hestia` CLI. Hestia mode is now one `SignerKind` under the broader **SwappableSigner** model (below). Hub binary holds NO Sovereign keypair during init or serve in this mode.
 
-In Hestia mode, the hub holds **NO Sovereign keypair**. Every signature attributed to the Sovereign is produced by a remote signer (Hestia) that the hub calls over HTTP. This honors architecture commitment #8 (secrets in vault only) on the hub side.
+## The signer abstraction (the real model)
+
+The hub does not have a binary "Local vs Hestia" personality. Every signature
+flows through **one `SwappableSigner`** (`hub-lib/src/signer.rs`) that wraps a
+`RemoteSigner` whose `SignerKind` is one of:
+
+- **`LocalKeypair`** — `LocalKeypairSigner`, signs in-process from a keypair the hub holds.
+- **`HestiaCallback`** — `HestiaCallbackSigner`, POSTs a sign-request to the operator's Hestia vault over HTTP; the hub only ever sees a public key (to verify) and signatures Hestia returns. *This is "Hestia mode."*
+- **`Locked`** — `LockedSigner`, fail-closed: every key op is denied. The hub still runs (serves tier-0 reads, accepts unlock) but cannot sign until ignited.
+
+Because the seam is `s.signer.sign(..)` everywhere, the backing signer can be
+**swapped at runtime** (`SwappableSigner::swap`) with no restart and no change
+at any call site. This is what makes the locked-shell → ignited transition (§
+*Locked shell + ignition*) possible.
+
+In **Hestia mode**, the hub holds **NO Sovereign keypair**: the installed signer
+is `HestiaCallback`, and every Sovereign signature is produced remotely. This
+honors architecture commitment #8 (secrets in vault only) on the hub side.
 
 ## Why this matters
 
-The MVP convention — operator's IdentityFile sitting on disk, hub loads it at `serve` time, hub keeps the keypair in process — is convenient but conflicts with commitment #8. A compromised hub process = compromised Sovereign keys. Hestia mode moves the keypair into the operator's Hestia vault; the hub only ever sees a public key (to verify) and signatures Hestia returns. Compromising the hub no longer compromises the Sovereign.
+The MVP convention — operator's IdentityFile sitting on disk, hub loads it at `serve` time, hub keeps the keypair in process — is convenient but conflicts with commitment #8. A compromised hub process = compromised Sovereign keys. Hestia mode moves the keypair into the operator's Hestia vault; the hub only ever sees a public key (to verify) and signatures Hestia returns. Compromising the hub no longer compromises the Sovereign. The `Locked` kind goes further still: a hub can boot with *no* usable key at all and be ignited in place.
 
 ## What's the same
 
 - Chapter storage (`charter.json` / `society.json` / `chapter.db`): identical layout.
 - Ledger entries: identical schema. The signature in each entry is now Hestia-produced rather than hub-produced; the chain verifies the same way.
 - REST API surface: identical endpoints, identical wire shapes.
-- MCP tool surface: **disabled** in Hestia mode (MCP still loads keypair directly; signer integration arrives in V2-7 Step 4).
+- MCP / plugin tool surface: routes through the signer abstraction. `PluginCtx::sign` signs as the hub LCT whether the hub holds the key (Local) or signs via a remote callback (Hestia) — it is **not** disabled in Hestia mode.
 - Sync CLI acts (`hub add-member`, etc.): refuse with a clear error pointing operators to REST.
 
 ## What's different
@@ -22,11 +39,18 @@ The MVP convention — operator's IdentityFile sitting on disk, hub loads it at 
 |---|---|---|
 | Sovereign keypair | In hub process | In Hestia vault only |
 | `[sovereign]` config | `lct_path = "..."` | `hestia_callback_url`, `lct_id`, `pubkey_hex` |
-| Genesis signing | Hub signs in-process | Hub posts to Hestia callback (TODO: ergonomic init CLI) |
+| Genesis signing | Hub signs in-process | Hub posts to Hestia callback (via `hub init --sovereign-hestia`) |
 | REST event signing | Hub signs in-process | Hub posts to Hestia callback per event |
-| MCP server | Enabled | Disabled (sub the REST API) |
+| MCP server | Enabled | Enabled (plugin `sign` routes through the signer → Hestia callback) |
 | Sync CLI acts | Enabled | Disabled (use REST API) |
-| verify-ledger | Loads IdentityFile | Uses pubkey from config |
+| verify-ledger | Loads IdentityFile for the pubkey | Uses pubkey from config |
+
+> **Note (encrypted-at-rest):** the identity-resolution column above is only
+> half the story. `verify-ledger` opens the hub's state store, and on a hub
+> whose store is encrypted at rest it must derive the SQLCipher key from the
+> vault passphrase (`HUB_PASSPHRASE` / TTY prompt) to open it — fail-closed
+> otherwise. On such a hub `verify-ledger` cannot run unattended without the
+> passphrase, in either signing mode.
 
 ## Configuration
 
@@ -118,16 +142,57 @@ ls ./my-chapter                       # → charter.json, society.json, ledger.j
                                       #   (no IdentityFile copied or needed)
 
 # 5. Serve + drive a REST event
-hub serve ./my-chapter --port 8770    # → "MCP tools: (disabled — Hestia-mode chapter)"
-                                      # → REST: every event signed via the Hestia callback
+hub serve ./my-chapter --port 8770    # → MCP tools enabled; plugin `sign` routes through the signer
+                                      # → REST + MCP: every event signed via the Hestia callback
 ```
 
 After init, the hub process at no point sees the private key. The chain still verifies because the pubkey is in `config.toml`.
 
-## What's still ahead (V2-7 §4)
+## What's still ahead
 
-- **MCP signer integration**: MCP tools currently refuse to open Hestia-mode chapters with a clear error pointing to REST. Once MCP routes through the signer abstraction (same shape as REST does today), MCP tools work on Hestia chapters too.
 - **Sync CLI acts on Hestia chapters**: design TBD — sync CLI on async-signing wants either an async-CLI variant or block_on'd internal client.
+
+*(Done since this doc was first written: **MCP signer integration** — MCP/plugin tools now route through the signer abstraction (`PluginCtx::sign`), the same shape REST uses, so they work on Hestia chapters too.)*
+
+## Locked shell + ignition (runtime model)
+
+A hub whose state is encrypted at rest boots **unlock-first**. On `serve` the
+daemon tries to open the encrypted store with whatever key is available — and
+keeps **no passphrase on disk or in env**, by doctrine. If the store opens
+(plaintext / NULL-keyed / fresh hub) it boots normally. If it fails closed
+(encrypted, no key), the hub starts in a **locked shell**: it installs a
+`LockedSigner`, serves only tier-0 reads (e.g. `GET /v1/hubs/:id/law`), and
+refuses to sign or open channels — every key op denied, fail-closed.
+
+The hub is then **ignited in place** (no restart) by presenting the passphrase
+to an unlock slot, which derives the key, opens the store, and
+`SwappableSigner::swap`s the real `LocalKeypairSigner` in for the
+`LockedSigner`. Unlock slots:
+
+- `POST /v1/hubs/:id/unlock` — tier-1 stub-console / passphrase unlock; local-only + rate-limited.
+- `POST /v1/hubs/:id/unlock/challenge` + `POST /v1/hubs/:id/unlock/attest` — tier-2 M-of-N witnessed unlock: the hub mints a challenge, admins attest, a private verifier plugin judges the quorum (501 when no verifier is configured).
+
+## Encrypted-at-rest identity + its CLI
+
+The Sovereign identity is stored encrypted (the vault doctrine: a private key is
+never written in the clear; "no passphrase" must be an explicit NULL choice,
+never a silent default). Supporting CLI:
+
+- `hub seal-identity <path>` — migrate a plaintext IdentityFile to an encrypted vault in place (re-writes encrypted under the resolved passphrase; an already-encrypted file is re-keyed).
+- `hub rotate-passphrase <hub-dir>` — rotate the vault passphrase to an operator-chosen (memorable) one; re-keys both the identity and the SQLCipher state store. Interactive (run at a console).
+- `hub export-public-identity <hub-dir>` — export just the public identity (seeds the pubkey-only material a peer / resolver needs, without the private key).
+
+Passphrase resolution is fail-closed everywhere: `HUB_PASSPHRASE` env (set,
+including empty = a deliberate NULL) → interactive TTY prompt → error. There is
+no silent "use plaintext" outcome.
+
+## EUDI: the hub as credential issuer + verifier
+
+At society scale the hub speaks **EUDI** wallet protocols, and this is the most
+prominent consumer of the `RemoteSigner` abstraction:
+
+- **OID4VCI (issuer).** The hub issues `Web4Membership` **SD-JWT-VC** credentials to its own members, signing the credential through its `RemoteSigner` — so issuance works whether the hub holds the key (Local) or signs via the Hestia callback (it may hold no keys in process at all). Routes: `GET /v1/hubs/:id/.well-known/openid-credential-issuer` (issuer metadata), `POST /v1/hubs/:id/nonce`, `POST /v1/hubs/:id/credential`. The holder-key proof in the credential request — which must be a pinned member key — is the auth (credential issuance is a direct wallet pull, not a sealed-channel tool).
+- **OID4VP (verifier / relying party).** The hub verifies presentations: `POST /v1/hubs/:id/vp/request`, `POST /v1/hubs/:id/vp/response`. `web4-core::oid4vc` / `sd_jwt_vc` do the heavy lifting; the REST handlers are thin wrappers.
 
 ## See also
 

--- a/hub/docs/PAIRED-CHANNELS.md
+++ b/hub/docs/PAIRED-CHANNELS.md
@@ -1,6 +1,6 @@
 # LCT Paired Channels — PRD
 
-**Status:** Architecture + sprint plan. Not yet implemented.
+**Status:** Sprints A–F shipped; G/H/I/J follow-on.
 **Audience:** Anyone implementing the sprints, anyone evaluating "what is a Web4 channel", anyone integrating Hestia / ACT / future societies with hub-mediated comms.
 **Spans repos:** `web4-core` (ECDH primitive), `web4/hub` (events, state, endpoints, law integration).
 
@@ -81,8 +81,8 @@ Each term in `Web4 = MCP + RDF + LCT + T3/V3*MRH + ATP/ADP` gets activated by pa
 
 The hub already exposes MCP endpoints. Two ways paired channels engage MCP:
 
-1. **New MCP-callable surface for channel ops** — `pair_request`, `pair_send`, `pair_recv`, `pair_list`. The channel mechanism itself is a Web4 primitive reached through the same tool-call shape as everything else.
-2. **Channels are the transport for hub-mediated MCP tool calls** (post-2026-06-09 reframe; see §0.1 + Sprint J). Citizen-tier-and-above tool calls on the hub MCP server travel over a paired channel between caller-LCT and hub-LCT. The channel is the I/O membrane through which the contract surface operates. *"The channel IS the identity."*
+1. **REST surface for pair lifecycle ops.** Pairing is driven through the signed-envelope REST endpoints, not bespoke MCP verbs: `POST pairs/request`, `POST pairs/{id}/confirm`, `POST pairs/{id}/revoke`, `GET pairs`, `GET pairs/{id}`, and `POST/GET pairs/{id}/messages` (the canonical list is in §4.4). The pair mechanism is a Web4 primitive reached through the same envelope-signing shape as every other consequential act.
+2. **The member↔hub sealed channel is the transport for hub-mediated tool calls** (post-2026-06-09 reframe; see §0.1 + Sprint J). Citizen-tier-and-above tool calls travel over `POST /v1/hubs/{id}/channel` between caller-LCT and hub-LCT — the sealed request authenticates the caller (AEAD open) AND decrypts in one step, and the response is sealed back. The channel tool set is: `query_hub`, `list_members`, `find_skill`, `find_members`, `request_intro`, `list_intros`, `respond_intro`, `notifications`, `referenced_act`, `constellation_challenge`, `present_constellation` (plus `request_citizenship` for the external tier). The channel is the I/O membrane through which the contract surface operates. *"The channel IS the identity."*
 
 ### RDF — ontological backbone
 
@@ -171,16 +171,26 @@ pub pairs: BTreeMap<Uuid, PairState>,
 
 pub struct PairState {
     pub id: Uuid,
-    pub a: Uuid,                    // initiator LCT
-    pub b: Uuid,                    // counterparty LCT
+    pub initiator: Uuid,            // initiator LCT
+    pub counterparty: Uuid,         // counterparty LCT
     pub purpose: String,
-    pub status: PairStatus,         // Pending | Active | Revoked | Expired
-    pub created_at: DateTime<Utc>,
+    pub status: PairStatus,         // stored: Pending | Active | Revoked
+    pub proposed_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
     pub confirmed_at: Option<DateTime<Utc>>,
     pub revoked_at: Option<DateTime<Utc>>,
+    pub revocation_kind: Option<PairRevocationKind>,
+    pub revocation_reason: Option<String>,
     pub message_count: u64,         // for V3 trust accrual signal
+    // Sprint F: per-session ephemeral X25519 pubkeys (hex) for forward secrecy
+    pub initiator_ephemeral_pub_hex: Option<String>,
+    pub counterparty_ephemeral_pub_hex: Option<String>,
 }
 ```
+
+The stored `PairStatus` enum is only `Pending | Active | Revoked`. `Expired`
+is **derived**, not stored — `PairState::effective_status(now)` returns
+`"expired"` when an `Active` pair is past its `expires_at`.
 
 Projection updates on each lifecycle event. Existing per-member views in admin UI gain a "pairs" tab.
 
@@ -306,18 +316,24 @@ Each sprint is sized for one focused work session. Sprints land in the order lis
 
 ### Sprint J — Channel-multiplex the hub MCP/REST tool endpoints
 
-**Status:** gating for the contract-call reframe (§0.1). Should land before G/H/I make full sense.
+**Status:** *Member↔hub sealed channel SHIPPED.* The transport itself —
+`POST /v1/hubs/{id}/channel`, with caller authentication via AEAD open, tier
+resolution from the channel binding, `gate_read` PolicyEntity-on-reads, and
+`ReadScope` tier bounding — is live (`dispatch_channel` in `rest.rs`). What
+remains pending is only **multiplexing the legacy plaintext tool endpoints**
+(`declare_skill` / `record_event`) over the channel; the channel-native tool
+set already runs sealed.
 
-**Motivation:** HUB's authz/confidentiality model (`hub-to-legion-authz-confidentiality-model-2026-06-09.md`, canonical home [`V2-V3-ARCHITECTURE.md` §8](V2-V3-ARCHITECTURE.md)) requires citizen-tier-and-above tool calls to travel over paired channels — *the channel IS the identity*. The current tool endpoints (POST `/tools/declare_skill`, etc.) take HTTP+TLS POST requests and authenticate by request payload, which is the bearer-token-style framing the model explicitly rejects.
+**Motivation:** HUB's authz/confidentiality model (`hub-to-legion-authz-confidentiality-model-2026-06-09.md`, canonical home [`V2-V3-ARCHITECTURE.md` §8](V2-V3-ARCHITECTURE.md)) requires citizen-tier-and-above tool calls to travel over the sealed channel — *the channel IS the identity*. The remaining legacy plaintext tool endpoints authenticate by request payload, which is the bearer-token-style framing the model explicitly rejects; they are the ones still to migrate.
 
-**Goal:** route state-mutating and citizen-tier-and-above tool calls through established paired channels. The pair channel between the requestor's LCT and the hub's LCT becomes the wire over which the tool request travels, with the response re-encrypted over the same channel.
+**Goal:** route the remaining state-mutating legacy tools through the sealed channel. The channel between the requestor's LCT and the hub's LCT is the wire over which the tool request travels, with the response sealed back over the same channel.
 
 **Deliverables:**
-- Tool dispatch reads the request from the channel ciphertext (AEAD open), evaluates per PolicyEntity + Law Oracle, writes the response back to the same channel re-encrypted.
-- Tier resolution from channel binding: the channel's counterparty LCT determines tier (no-LCT / external / citizen / role / constellation) per HUB's authz model.
-- Witnessing residue per smart-contract proposal §6.5: hash of (request, response) committed to the ledger as the V3 attestation signal.
-- Existing `open_channel` + `HubChannel` (member-↔-hub channel, hestia integration) is the V1 transport — reuse, don't re-design.
-- HTTP plaintext POST endpoints remain available for no-LCT-tier (public, plaintext) only; citizen-tier-and-above are refused with `capability_violation` witnessed.
+- **Shipped:** Channel dispatch reads the request from the channel ciphertext (AEAD open), resolves tier from the counterparty LCT (no-LCT / external / citizen / sovereign), evaluates per PolicyEntity (`gate_read`) + bounds results by `ReadScope`, and seals the response back.
+- **Shipped:** Tier resolution from channel binding (`dispatch_channel`): caller is `sovereign` / `citizen` (member) / external; external LCTs may only `request_citizenship`.
+- **Pending:** Witnessing residue per smart-contract proposal §6.5 (hash of (request, response) committed to the ledger as the V3 attestation signal) for the multiplexed legacy tools.
+- **Shipped:** The member↔hub `channel_request` path is the V1 transport — reuse, don't re-design.
+- **Pending:** retiring the plaintext POST tool endpoints (`declare_skill` / `record_event`) at citizen-tier-and-above, refusing them with `capability_violation` witnessed once multiplexed.
 
 **Tests:**
 - Smoke: open channel as citizen, call `declare_skill` over the channel, verify ledger event + queryable state both update + response received over channel.
@@ -410,11 +426,72 @@ Sprint J is the operational landing point for the smart-contract proposal's auth
 
 **MVP (Sprints A-F):** shipped 2026-06-08.
 
-**Next concrete commit candidate (Sprint J):** channel-multiplex the hub tool endpoints. The smallest version is probably: route `declare_skill` over an existing `HubChannel` end-to-end, verify the smoke test, and refuse plaintext POST at citizen-tier with `capability_violation` witnessed. Once that one tool works end-to-end on the channel, the others follow the same pattern.
+**Sprint J — what already ships:** the member↔hub sealed channel (`POST /v1/hubs/{id}/channel`) is live, with the channel-native tool set (`query_hub`, `list_members`, `find_skill`, `find_members`, `request_intro`/`list_intros`/`respond_intro`, `notifications`, `referenced_act`, `constellation_challenge`/`present_constellation`, and `request_citizenship` for the external tier) running sealed under tier resolution + `gate_read` + `ReadScope`. The remaining work is narrow: multiplex the legacy plaintext tools (`declare_skill` / `record_event`) over the same channel and then refuse their plaintext POST at citizen-tier with `capability_violation` witnessed. Once one legacy tool works end-to-end on the channel, the others follow the same pattern.
 
 Sprint J's smoke harness should also include the conjunction check from §6.3 of the smart-contract proposal — for every state-mutating tool, assert ledger event AND queryable state both update (PR #292's lesson made permanent).
 
 **Then:** G/H/I in order, gated on proposal §6 settling.
+
+---
+
+## 10. Shipped reality (as built)
+
+The sprint plan above is the design narrative; this section records what is
+actually live in the code, beyond what the plan's framing alone conveys.
+
+### 10.1 The member↔hub sealed channel is the realized transport
+
+`POST /v1/hubs/{id}/channel` (`channel_request` → `dispatch_channel` in
+`rest.rs`) is the working sealed transport for citizen-tier reads/acts. Sealing
+uses **X25519 ECDH + ChaCha20-Poly1305** (the same primitives §4.1 specifies):
+the sealed request authenticates the caller (AEAD open) *and* decrypts in one
+step, and the response is sealed back over the same channel. Tier is resolved
+from the channel binding (sovereign / citizen-member / external), reads pass
+`gate_read` (PolicyEntity) and are bounded by `ReadScope` for the tier.
+
+### 10.2 Consent intros — the bootstrap for direct member↔member pairs
+
+`request_intro` / `list_intros` / `respond_intro` (channel tools) implement the
+consent half of discovery. An intro is mutual-approval: when the target
+accepts, **each party is handed the other's pinned pubkey** (`peer_lct` +
+`peer_pubkey_hex`), which is exactly what a direct member↔member pair_channel
+needs to derive its shared secret. Because both halves ride the sealed channel,
+both parties hold pinned channel keys by the time an intro is accepted.
+
+### 10.3 Semantic member discovery — `find_members`
+
+`find_members` is live: the hub is the front door (gating + tier scoping), and
+membot is the engine (the sidecar does embedding + 3-signal search). `top_k` is
+bounded by the tier cap; member names are re-attached from the hub's
+authoritative encrypted registry (PII lives once, in the hub, not the cart).
+
+### 10.4 Notification poll-floor + referenced acts
+
+`notifications` is the delivery floor: a citizen drains its pending sealed
+notices from the per-LCT queue (push to a registered LCT-MCP endpoint is the
+future optimization on the same queue). `referenced_act` lets a caller witness
+a generic `web4_core::act::Act` addressed to a core `ActAddress`
+(Peer/Citizen/Role/Society/FutureSelf), with a `content_hash` so the witnessed
+record binds to a specific version and can't silently drift. Together they back
+the hub→citizen push used when an intro is accepted (`notify:intro_accepted`).
+
+### 10.5 Constellation attestation
+
+`constellation_challenge` mints a nonce bound to the `pair_id`;
+`present_constellation` verifies a `ConstellationAttestation` whose owner key is
+checked against the caller's **pinned** resolver pubkey (no pinned key =
+reject; never fall back to a self-carried key). The derived assurance tier binds
+to the channel `pair_id` — the `assurance` hook `ReadScope` reserves. The member
+side ships in hestia (`core/src/constellation.rs`); this is the verifier half.
+
+### 10.6 The pair CLI
+
+The `hub` binary ships client-side pair crypto so smoke scripts and operators
+can drive the channel end-to-end:
+
+- `hub pair-generate-ephemeral` — mint a per-session ephemeral X25519 keypair (Sprint F forward secrecy).
+- `hub pair-encrypt` — seal a plaintext to a peer pubkey under a `pair_id` (X25519 ECDH + ChaCha20-Poly1305).
+- `hub pair-decrypt` — the symmetric inverse; errors if AEAD fails.
 
 ---
 

--- a/hub/docs/PRD.md
+++ b/hub/docs/PRD.md
@@ -7,6 +7,8 @@
 **License:** AGPL-3.0-or-later (inherits web4 root)
 **Repo location:** `web4/hub/` (new Cargo workspace, sibling to `web4/web4-core/` and `web4/web4-trust-core/`)
 
+> **STATUS as of 2026-06:** This is the original pre-build PRD. Much of the "Out of scope (V2+)" list below has since shipped: encrypt-at-rest vault/SQLCipher state, machine-enforced chapter law (PolicyEntity gate), sealed member channels + intros + `find_members`, EUDI/`did:web4`, Sovereign Council M-of-N, admin/operator web UI + admission queue, and the open-core plugin seam. The "Out of scope" list below was the **pre-build** scope; items now shipped are annotated inline (**SHIPPED**). For the live architecture see `docs/V2-V3-ARCHITECTURE.md` and the README.
+
 ---
 
 ## 1. Background
@@ -35,7 +37,7 @@ A single-binary Rust daemon that implements a minimum-viable Web4 society:
 
 - **7-role state**: Sovereign, Law-Oracle, Policy-Entity, Treasurer, Administrator, Archivist, Citizen
 - **Founding charter** signed by Sovereign LCT
-- **Append-only witnessed event ledger**, file-persisted
+- **Append-only witnessed event ledger** (file-persisted in the MVP; storage is now backend-abstracted and **encrypted-at-rest by default** — file is one backend among several)
 - **MCP server** as the I/O membrane (per Web4 canonical equation: MCP is *the* outward-facing surface, not an optional accessory)
 - **Admin CLI** for chapter operators (parallel to MCP for human use)
 - **Docker compose** deployment (`docker compose up` brings up the daemon)
@@ -59,13 +61,13 @@ Inheritance discipline matters because (per `CLAUDE.md`): web4 is in *developmen
 
 These are deliberately deferred. Each is real but not MVP.
 
-- **Member Presence Toolkit (Hestia multi-hub extension)**: separate package. Members read the hub via MCP in MVP; the per-member portable-identity layer comes in a follow-on.
+- **Member Presence Toolkit (Hestia multi-hub extension)**: separate package. Members read the hub via MCP in MVP; the per-member portable-identity layer comes in a follow-on. **PARTLY SHIPPED:** members are no longer MCP-read-only — sealed member↔hub channels, paired member↔member channels, `find_members` (semantic discovery), and `request_intro`/`respond_intro` consent flows all ship. Hestia-as-a-separate-package is still true.
 - **Central Overlay**: cross-chapter federation, global skill graph, partner-lab programmatic aggregation. Phase 3 in the inventory doc. MVP is one chapter.
-- **Public web UI for members**: admin CLI + chapter README is the MVP surface. Web UI is V2 (likely Tauri or Leptos to stay Rust-aligned, but format TBD).
+- **Public web UI for members**: admin CLI + chapter README is the MVP surface. Web UI is V2 (likely Tauri or Leptos to stay Rust-aligned, but format TBD). **PARTLY SHIPPED:** an operator/admin web UI ships — read-only dashboard at `/admin` plus a write-capable operator plane (admit/deny admissions, add/re-key/remove members, no restart) bound to `127.0.0.1:8772`. A *member-facing* public web UI is still future.
 - **Slack bot integration**: deferred until one chapter is running and Slack-coexistence requirements are empirical, not designed. Concrete > speculative.
-- **ACT-anchored ledger**: MVP uses local file ledger. ACT anchoring is V2 — useful for tamper-evidence at federation scale but not needed for a single chapter.
-- **Hardbound policy engine integration**: MVP encodes chapter law as text (Sovereign-signed but not machine-enforced). Full policy enforcement is V2 — and requires resolving the Hardbound canonical Web4 alignment debt (per `CANONICAL_AUDIT.md` 2026-01-31).
-- **Federation between chapters**: inter-society protocol exists in spec; MVP doesn't exercise it. V2.
+- **ACT-anchored ledger**: MVP uses local file ledger. ACT anchoring is V2 — useful for tamper-evidence at federation scale but not needed for a single chapter. **PARTLY SHIPPED:** storage is now backend-abstracted (file / SQLite / DynamoDB) and the ledger is **SQLCipher-encrypted at rest** by default. ACT anchoring specifically is still future.
+- **Hardbound policy engine integration**: MVP encodes chapter law as text (Sovereign-signed but not machine-enforced). Full policy enforcement is V2 — and requires resolving the Hardbound canonical Web4 alignment debt. **SHIPPED (hub-native):** chapter law is now **machine-enforced** — the PolicyEntity gate evaluates every consequential request against the signed law and returns Allow/Deny/Escalate, on writes *and* reads. The *Hardbound* policy-engine integration specifically (the licensable enterprise layer) remains a separate V2+ track.
+- **Federation between chapters**: inter-society protocol exists in spec; MVP doesn't exercise it. V2. **PARTLY SHIPPED:** inter-society primitives now ship — `find_members`, `request_intro`/`respond_intro`, `did:web4` + EUDI credentials, and the `GET /.well-known/web4-hub.json` discovery endpoint. The Central Overlay (cross-chapter aggregation / global skill graph) is still future.
 - **Skill attestation by chapter witnesses (T3 accrual)**: MVP records skill *declarations*; T3 attestation chain is V2.
 
 ## 6. Users + use cases
@@ -92,7 +94,7 @@ These are deliberately deferred. Each is real but not MVP.
 - Role assignments land in the ledger as witnessed events
 
 ### FR3 — Event ledger
-- Append-only JSONL at `<chapter-dir>/ledger.jsonl`
+- Append-only JSONL at `<chapter-dir>/ledger.jsonl` (MVP default; the ledger is now one backend among several behind a storage abstraction, encrypted-at-rest by default)
 - Each entry: timestamp, actor LCT, action, payload, signature, prev-entry hash
 - Verifier via web4-core's existing chain verifier — no new verifier code
 - Events include: member added, member removed, role assigned, event recorded, charter amended
@@ -166,11 +168,11 @@ These don't block MVP build but will influence V2 + pilot operations. They need 
 7. Partner-lab engagement model (Citizen role vs peer-society federation)
 8. Existing community member directory backward-compatibility (migration shape)
 
-Full context: `private-context/proposals/2026-06-06-aic-hub-package/06-inventory-and-build-plan.md` §Open questions.
+Full context: pilot inventory + build plan (internal `private-context` proposal, not part of this public repo).
 
 ## 13. References
 
-- pilot inventory + build plan: `private-context/proposals/2026-06-06-aic-hub-package/06-inventory-and-build-plan.md`
+- pilot inventory + build plan: internal `private-context` proposal (not part of this public repo)
 - Web4 canonical equation + ontology: `web4/CLAUDE.md`, `web4/STATUS.md`
 - Web4 standard specs: `web4/web4-standard/core-spec/`
 - Web4 core implementation (Rust + Python): `web4/web4-core/`, `web4/web4-trust-core/`

--- a/hub/docs/QUICKSTART.md
+++ b/hub/docs/QUICKSTART.md
@@ -21,13 +21,44 @@ The daemon is local-first. There is no central server, no cloud account, no vend
 ## What you'll do in the next 30 minutes
 
 1. Get a `hub` binary (build from source OR pull the Docker image)
-2. Generate a Sovereign identity
-3. Initialize your chapter
-4. Add 1-2 members + declare skills
-5. Record a first event
-6. Start the MCP server and query it
+2. Set `HUB_PASSPHRASE` (the secret that guards your hub's vault)
+3. Generate a Sovereign identity
+4. Initialize your chapter
+5. Add 1-2 members + declare skills
+6. Record a first event
+7. Start the server, unlock (ignite) it, and query it
 
 If any step doesn't work, see [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+---
+
+## Step 0: Set `HUB_PASSPHRASE` first
+
+The hub follows a **vault doctrine**: a private key is never written to disk in
+the clear, and "no passphrase" must be an *explicit* choice rather than a silent
+default. Several commands — `hub gen-lct`, `hub init`, `hub verify-ledger`,
+`hub export-public-identity` — therefore need a passphrase to run. The cleanest
+way to supply it is the `HUB_PASSPHRASE` environment variable:
+
+```bash
+export HUB_PASSPHRASE='choose-a-strong-passphrase'
+```
+
+This one secret encrypts your Sovereign identity **and** your hub's state store
+(both at rest). Guard it like the master key it is — **if you lose it, the
+identity and state are unrecoverable** (see Step 2).
+
+Two important nuances:
+
+- **Empty is allowed, but must be explicit.** `HUB_PASSPHRASE=` (set to an empty
+  value) is a deliberate *NULL passphrase* choice — the vault is still encrypted,
+  but it's openable by anyone. Use this only for throwaway demos.
+- **Unset + no terminal = hard error.** If `HUB_PASSPHRASE` is unset and there's
+  no TTY to prompt (CI, a script, a container), the affected commands fail closed
+  with *"refusing to write a plaintext private key"*. At an interactive shell
+  they'll instead prompt you for the passphrase.
+
+The examples below assume `HUB_PASSPHRASE` is exported in your shell.
 
 ---
 
@@ -59,26 +90,41 @@ Docker version is convenient but adds the wrap-everything-in-a-container layer t
 ## Step 2: Generate a Sovereign identity
 
 ```bash
+# HUB_PASSPHRASE must be set (see Step 0) — gen-lct refuses to write a
+# plaintext key.
 hub gen-lct ./sovereign.json
 ```
 
-This creates `sovereign.json`. **It contains private key material.** Treat it like an SSH key:
+This creates `sovereign.json` as an **encrypted vault** (it starts with the
+`W4VT` magic, not JSON). The private key is encrypted at rest under your
+`HUB_PASSPHRASE` — so the file itself is no longer the secret to protect; the
+**passphrase is**.
 
-```bash
-chmod 600 ./sovereign.json
-```
+That changes the old "treat it like an SSH key" advice:
 
-Do not commit this file to git. Keep a backup somewhere safe.
+- **Guard `HUB_PASSPHRASE`, not the file.** The encrypted vault is useless to an
+  attacker without the passphrase. Conversely, **lose the passphrase and the
+  identity is gone** — there is no recovery path and no stored copy.
+- A `chmod 600 ./sovereign.json` is still tidy hygiene, and you should still keep
+  a backup of the file, but neither helps if the passphrase is lost.
+- Don't commit `sovereign.json` to git, and never put `HUB_PASSPHRASE` in a file
+  that lands in git either.
+
+(Used an empty `HUB_PASSPHRASE=`? Then the vault *is* openable by anyone — re-key
+it with a real passphrase via `hub rotate-passphrase` before going live.)
 
 ---
 
 ## Step 3: Initialize your chapter
 
+`hub init` reads your (encrypted) Sovereign identity and writes the hub's state
+store, so `HUB_PASSPHRASE` must still be set (Step 0):
+
 ```bash
 # File-backed (default; MVP-compatible JSON/JSONL layout)
 hub init "Your Chapter Name" --sovereign-lct ./sovereign.json
 
-# Or SQLite-backed (one chapter.db file; better for ops)
+# Or SQLite-backed (one chapter.db file; better for ops — encrypted at rest)
 hub init "Your Chapter Name" --sovereign-lct ./sovereign.json --storage sqlite
 ```
 
@@ -99,7 +145,8 @@ See [`STORAGE.md`](STORAGE.md) for backend comparison and migration (`hub migrat
 
 ## Step 4: Add members + declare skills
 
-Each member needs their own LCT. For an MVP demo, you can generate test ones:
+Each member needs their own LCT. For an MVP demo, you can generate test ones
+(again with `HUB_PASSPHRASE` set — these are encrypted vaults too):
 
 ```bash
 hub gen-lct ./alice.json
@@ -120,6 +167,28 @@ hub add-member ./your-chapter-name "$BOB_ID" --name "Bob"
 hub declare-skill ./your-chapter-name "$ALICE_ID" "Medical Imaging RAG"
 hub declare-skill ./your-chapter-name "$BOB_ID" "Distributed Systems"
 ```
+
+### Two ways members get in
+
+The `hub add-member` above is the **Sovereign-side** path: you, holding the
+chapter's authority, add a member you already know. Use it for bootstrapping and
+for members whose public id you've been handed out-of-band.
+
+Once your hub is serving (Step 7), there's also a **request-driven** path that
+needs no Sovereign action up front:
+
+1. A prospective member POSTs a signed join request to
+   `POST /v1/hubs/<hub-id>/members/join` (the request carries their own LCT id +
+   public key, signed with their key).
+2. Your hub's **law gate** (the PolicyEntity, evaluating the request as
+   `role="applicant"`) decides: *Allow* admits them immediately, *Deny* rejects
+   with a 403, *Escalate* parks the request in an operator review queue.
+3. For escalated requests you (the operator) **Admit** or **Deny** them live from
+   the operator plane (Step 7) — no restart, no re-keying. Admission appends a
+   Sovereign-signed `MemberAdded` and pins their pubkey so their next request
+   authenticates as a citizen.
+
+Both paths converge on the same witnessed ledger entry; pick whichever fits.
 
 ---
 
@@ -143,28 +212,85 @@ hub status ./your-chapter-name                    # one-line summary
 
 ---
 
-## Step 7: Start the MCP server
+## Step 7: Start the server, then unlock (ignite) it
 
 ```bash
 hub serve ./your-chapter-name
 ```
 
-By default this binds to `127.0.0.1:8770` (local-only, safe). In another terminal:
+`hub serve` starts **two listeners**:
+
+- **Fleet plane** — default `127.0.0.1:8770` (`--bind` / `--port` to change). This
+  is the read-only dashboard + the MCP tools and REST APIs.
+- **Operator plane** — `127.0.0.1:8772`, **always loopback-only** (never bound to
+  the network, regardless of `--bind`). This carries the admit/deny/remove/re-key
+  admin actions and the write GUI. Change it with `--admin-port`, or disable it
+  entirely with `--admin-port 0`.
+
+### Ignite the vault (`hub unlock`)
+
+Because your hub's state store is encrypted (Step 0) and the daemon never reads
+the passphrase from the environment at serve time, an encrypted hub **boots into
+a locked shell**: it comes up, but returns `503` on essentially everything except
+the unlock path (and a little tier-0 discovery: `/.well-known/web4-hub.json`,
+the public law, and OID4VCI issuer metadata). You'll see a warning in the log and
+this on requests:
+
+> `hub vault is locked — ignite it first (run hub unlock)`
+
+Ignite it at runtime, from the hub host, in another terminal:
+
+```bash
+# export-public-identity ONCE per hub first (see below), then:
+hub unlock            # defaults to the hub on port 8770; prompts for the passphrase
+```
+
+`hub unlock` prompts for the passphrase in *its* UI (or reads `HUB_PASSPHRASE`),
+uses it once over the loopback-only `/unlock` slot, and **never stores it**. The
+slot is rate-limited and 127.0.0.1-only. After it succeeds the hub serves
+citizen-tier requests normally.
+
+> First-time setup: run `hub export-public-identity ./your-chapter-name` once
+> (needs `HUB_PASSPHRASE`). It writes a clear `public-identity.json` so a locked
+> shell can identify itself on `/.well-known` and accept your `hub unlock`. Skip
+> this and the locked shell can't self-identify.
+
+### Query it
+
+Once unlocked, in another terminal:
 
 ```bash
 curl http://127.0.0.1:8770/tools | python3 -m json.tool
 curl http://127.0.0.1:8770/tools/list_members | python3 -m json.tool
 ```
 
+Operator actions (admitting the join requests from Step 4, removing members,
+re-keying channels) live on the operator plane:
+
+```
+http://127.0.0.1:8772/admin
+```
+
 Stop the server with Ctrl-C.
 
-For network-accessible deploy (e.g. on a small VPS for chapter-wide access), bind to all interfaces:
+For network-accessible deploy (e.g. on a small VPS for chapter-wide access), bind
+the **fleet** plane to all interfaces — the operator plane stays loopback-only by
+design:
 
 ```bash
 hub serve ./your-chapter-name --bind 0.0.0.0 --port 8770
 ```
 
-Pair with a reverse proxy + TLS termination (caddy/nginx) for production. MVP itself doesn't terminate TLS.
+Pair with a reverse proxy + TLS termination (caddy/nginx) for production. MVP
+itself doesn't terminate TLS. To reach the operator plane on a remote box, tunnel
+to it over SSH (`ssh -L 8772:127.0.0.1:8772 ...`) rather than exposing it.
+
+### Changing the passphrase later
+
+To rotate the vault secret to a new operator-chosen one: stop the hub, run
+`hub rotate-passphrase ./your-chapter-name` (re-keys the identity + state store),
+then start it again — it boots locked, so ignite it with `hub unlock` using the
+**new** phrase.
 
 ---
 
@@ -173,6 +299,8 @@ Pair with a reverse proxy + TLS termination (caddy/nginx) for production. MVP it
 Periodically (or after any concerning event):
 
 ```bash
+# Needs HUB_PASSPHRASE: verify-ledger opens the encrypted state store, so on an
+# encrypted hub it errors without the passphrase (that's expected, not corruption).
 hub verify-ledger ./your-chapter-name
 ```
 

--- a/hub/docs/ROLES.md
+++ b/hub/docs/ROLES.md
@@ -66,4 +66,64 @@ Each role's LCT can independently:
 - Be rotated to a new filling entity without breaking the chapter's accountability chain
 - Be inspected via `hub query chapter <chapter-dir>` (which shows role-id ↔ filler-id pairs)
 
-In MVP, the daemon signs all ledger entries with the Sovereign keypair regardless of which role "did" the action (the event's `assigned_by`/`recorded_by` field captures the actor at the data layer). V2 will let each role-filler hold their own keypair and sign role-scoped events directly.
+For single-signer acts, the daemon commits ledger entries under the founding
+Sovereign's executor signature regardless of which role "did" the action (the
+event's `assigned_by`/`recorded_by` field captures the actor at the data layer).
+That's *not* the whole story, though: on the **council path**, co-Sovereign
+holders hold their **own** keypairs and counter-sign acts via
+`SignedEnvelope`s. Each vote is a full, independently verifiable envelope, and
+`CouncilProposal::unique_signers()` counts distinct holder signatures toward the
+M-of-N threshold (see `hub-lib/src/proposal.rs`). So role-fillers holding their
+own keys and signing directly is already real for the Sovereign Council — see
+below.
+
+## Sovereign Council — multi-Sovereign M-of-N
+
+A chapter need not have a single founder holding the Sovereign key forever. The
+**Sovereign Council** is a set of co-Sovereigns who jointly authorize chapter
+acts under an M-of-N threshold.
+
+State (`hub-lib/src/state.rs`):
+
+- `council_holders` — the co-Sovereign LCT ids beyond the founding Sovereign.
+- `council_pubkeys` — each holder's pinned public key, so their envelopes verify
+  without an external registry.
+- `council_threshold` — `(m, n)` where **N is derived as `holders + 1`** (the
+  founding Sovereign always counts as one holder). Removing a holder re-derives
+  N and clamps M down if needed.
+
+Events (ledger-audited): `CouncilMemberAdded`, `CouncilMemberRemoved`,
+`CouncilThresholdChanged`.
+
+CLI:
+
+```bash
+hub council add <chapter-dir> <member-lct-id> --pubkey <hex> [--name ...]
+hub council remove <chapter-dir> <member-lct-id> [--kind resigned|ejected|elected] [--reason ...]
+hub council set-threshold <chapter-dir> <m>      # N derived from holders + 1
+hub council show <chapter-dir>
+```
+
+### The propose / sign flow
+
+When the threshold is **1-of-N** (or no threshold is set), single-signer commits
+still work — the act commits on first signature, with a council audit trail.
+
+When the threshold is **M ≥ 2**, single-signer commits are **blocked**: the
+`/events` and pair endpoints return `HTTP 409` and redirect callers to the
+council flow. Acts then aggregate counter-signatures:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /v1/hubs/:id/council/propose` | A holder proposes an act (their envelope is the first vote). |
+| `POST /v1/hubs/:id/council/sign` | Another holder counter-signs an open proposal by id. |
+| `GET /v1/hubs/:id/council/proposals` | List proposals. |
+| `GET /v1/hubs/:id/council/proposals/:id` | Inspect one proposal. |
+
+Each signature is a `SignedEnvelope` stored in the proposal (not a bare
+signature), so every vote stays independently re-verifiable after the fact. Only
+council holders (including the founding Sovereign) may propose or sign; members
+cannot. When unique holder signatures reach M, the hub appends the proposed event
+to the ledger and marks the proposal `Committed` with the resulting
+`entry_index`. Proposals expire after a TTL (default 24h) if the threshold isn't
+met.

--- a/hub/docs/SPRINTS.md
+++ b/hub/docs/SPRINTS.md
@@ -3,6 +3,8 @@
 **Companion to:** `PRD.md`
 **Date:** 2026-06-07
 
+> **STATUS as of 2026-06:** The MVP (Sprints 0–6) shipped, and substantial V2 work has since shipped on top of it (encrypt-at-rest, machine-enforced chapter law, sealed member channels, EUDI/`did:web4`, Sovereign Council, operator web UI + admission queue, plugin seam). This document remains an accurate record of the MVP build. For everything after the MVP, see `docs/V2-V3-ARCHITECTURE.md` and the README.
+
 Sprints are **capability-defined**, not calendar-defined. Each sprint produces a verifiable milestone — a thing that builds, runs, and demonstrates a specific capability. Pace is set by the work, not by weeks. Each sprint's exit criteria must be met before the next sprint starts.
 
 The whole sprint plan is one stack of seven sprints (Sprint 0 through Sprint 6). After Sprint 6, MVP is shippable.
@@ -176,12 +178,14 @@ The whole sprint plan is one stack of seven sprints (Sprint 0 through Sprint 6).
 
 ## Post-MVP: triggers for V2
 
+> **STATUS as of 2026-06: these triggers have FIRED.** V2 work is underway and much of it has shipped. See `docs/V2-V3-ARCHITECTURE.md` for current state. Annotations below mark what each trigger produced.
+
 After Sprint 6 ships, MVP is in pilot. V2 work starts when one of these triggers fires:
 
-- **Pilot chapter requests web UI** (likely first ask — CLI suffices for the organizer but members want a browser surface)
-- **Second chapter wants to federate** (triggers inter-society protocol implementation)
-- **Pilot chapter wants T3 attestation by witnesses** (triggers reputation pipeline beyond raw skill declarations)
-- **Partner lab asks for programmatic engagement** (triggers cross-society MCP federation work)
-- **A deployment's central operator asks for cross-chapter observability** (triggers Central Overlay phase)
+- **Pilot chapter requests web UI** (likely first ask — CLI suffices for the organizer but members want a browser surface) — **FIRED:** operator/admin web UI shipped (`/admin` dashboard + write-capable operator plane on `127.0.0.1:8772`).
+- **Second chapter wants to federate** (triggers inter-society protocol implementation) — **FIRED (in part):** inter-society primitives shipped — `find_members`, `request_intro`/`respond_intro`, `did:web4`/EUDI, `/.well-known/web4-hub.json` discovery. Central Overlay aggregation still future.
+- **Pilot chapter wants T3 attestation by witnesses** (triggers reputation pipeline beyond raw skill declarations) — **FIRED (in part):** constellation attestation (hub-side verify + challenge/present) shipped; the full T3-accrual reputation pipeline is still future.
+- **Partner lab asks for programmatic engagement** (triggers cross-society MCP federation work) — partly addressed by sealed channels + intros + EUDI credentials.
+- **A deployment's central operator asks for cross-chapter observability** (triggers Central Overlay phase) — still future.
 
 Each trigger defines its own sprint stack. V2 planning is deferred until a trigger fires; sprint-planning-in-advance for hypothetical V2 work is drift.

--- a/hub/docs/STORAGE.md
+++ b/hub/docs/STORAGE.md
@@ -6,11 +6,31 @@ The hub stores chapter state — charter, society, ledger — behind a `HubStore
 
 ---
 
-## Posture: secrets-free by design
+## Posture: secrets-free AND encrypted-at-rest
 
-The storage layer NEVER holds secrets. Private keys, vault contents, API credentials — none of these belong here. They live in Hestia's vault and are accessed under the vault's authority + need-to-know gate. Chapter storage is signed (for integrity) but not encrypted (for confidentiality of the data itself). If something in the chapter must be confidential, that's a vault-side concern, not a storage-side concern.
+The storage layer NEVER holds secrets. Private keys, vault contents, API credentials — none of these belong here. They live in Hestia's vault and are accessed under the vault's authority + need-to-know gate. That part is unchanged and constitutional.
 
-This is constitutional. See `V2-V3-ARCHITECTURE.md` §Load-bearing commitment #8.
+What *is* in the store — the member roster, pinned member pubkeys, pairings, profiles, the ledger — is confidential even though it isn't a signing key. So the `sqlite` backend is now **encrypted at rest** (SQLCipher) under a key derived from the same vault passphrase that guards the identity. Storage is therefore signed (for integrity), access-gated (authority + need-to-know), *and* encrypted (for confidentiality of the bytes on disk). The on-disk `hub.db` is ciphertext; opening it requires the vault passphrase. See [§At-rest encryption model](#at-rest-encryption-model) below.
+
+This closes the gap where a sealed hub protected its key but everything it *knew* sat in world-readable plaintext next to the encrypted identity. The secrets-free invariant (no private keys in the store) still holds. This is constitutional. See `V2-V3-ARCHITECTURE.md` §Load-bearing commitment #8.
+
+---
+
+## At-rest encryption model
+
+Applies to the `sqlite` backend (the `file` backend is plaintext on disk; pair it with an encrypted volume / TPM-sealed dir for confidentiality).
+
+**Key derivation.** The SQLCipher key is derived from the vault passphrase with **Argon2id**, salted per-hub. The salt lives clear (salts aren't secret) at `<hub-dir>/.store-salt`, generated once on first use. Same passphrase + same salt → same 32-byte key.
+
+**De-env'd, held in memory.** The passphrase is **not read from the environment at runtime**. After ignition the daemon derives the key once and holds it in memory, then re-opens the store via `open_hub_store_with_key(hub_dir, Some(key))`. The key is applied to each connection with `PRAGMA key` before any other access. (`derive_store_key` is the explicit-passphrase entry point used at ignition.)
+
+**Ignition / locked-shell boot (fail-closed).** On `hub serve`, the daemon tries to open the store with whatever key is available — which is *none*, since no passphrase sits on disk or in env. If the store opens (plaintext / NULL-keyed / fresh hub), it boots normally. If it fails closed (encrypted, no key), it boots a **LOCKED SHELL** that serves only the unlock path; `hub unlock` ignites it at runtime, deriving the key and swapping in the real store in memory. An encrypted DB with no key never opens silently and is never corrupted — it fails closed.
+
+**Plaintext → encrypted in-place migration.** A legacy plaintext `hub.db` is upgraded to ciphertext on its first keyed open: the WAL is checkpointed, `sqlcipher_export` copies the full schema + data into a freshly-keyed copy, and that copy atomically replaces the original (stale plaintext WAL/SHM sidecars are cleared). All rows and ledger order are preserved; the operation is crash-safe (it writes a temp file then renames).
+
+**Rekey via `rotate-passphrase`.** `hub rotate-passphrase <hub-dir>` re-keys the state DB in place: it opens with the current key, verifies it decrypts, then `PRAGMA rekey`s to the new key (and re-seeds the protected vault tier under the new phrase). It's interactive (console only) and aborts without changing anything if the current passphrase doesn't decrypt. Restart the hub afterward — it boots locked and is ignited with `hub unlock` using the new phrase.
+
+**Ledger included.** The ledger lives in the same encrypted DB, so it is encrypted at rest too. Integrity still comes from the signed hash-chain; encryption at rest is an added confidentiality layer, not a replacement for signatures.
 
 ---
 
@@ -42,16 +62,19 @@ Trade-offs:
 ```
 <chapter-dir>/
 ├── config.toml          # operator config
-├── chapter.db           # SQLite database — all chapter state
-├── chapter.db-wal       # SQLite WAL (transient)
-└── chapter.db-shm       # SQLite shared-memory (transient)
+├── .store-salt          # per-hub salt for the SQLCipher key derivation
+├── hub.db               # SQLite database — all chapter state (SQLCipher-encrypted at rest)
+├── hub.db-wal           # SQLite WAL (transient)
+└── hub.db-shm           # SQLite shared-memory (transient)
 ```
+
+(Hub dirs created before the chapter→hub rename hold a legacy `chapter.db`; it is read in place as a fallback — no forced rename. New stores are always `hub.db`.)
 
 Schema:
 ```sql
 CREATE TABLE metadata (
-    key   TEXT PRIMARY KEY,   -- "charter" | "society"
-    value TEXT NOT NULL        -- canonical JSON
+    key   TEXT PRIMARY KEY,   -- "charter" | "society" | "law"
+    value TEXT NOT NULL        -- canonical JSON (or law YAML)
 );
 
 CREATE TABLE ledger_entries (
@@ -60,7 +83,9 @@ CREATE TABLE ledger_entries (
 );
 ```
 
-Pragmas: `foreign_keys=ON`, `journal_mode=WAL`, `synchronous=NORMAL`.
+Encryption: when a key is available, the connection is **SQLCipher-keyed** via `PRAGMA key` *before any other access* (and a legacy plaintext DB is migrated to ciphertext in place on first keyed open). With no key, a plaintext/fresh DB opens as-is but an already-encrypted DB fails closed. See [§At-rest encryption model](#at-rest-encryption-model).
+
+Pragmas (set after keying): `foreign_keys=ON`, `journal_mode=WAL`, `synchronous=NORMAL`.
 
 Best for:
 - Single-machine operators who want a single-file artifact
@@ -69,7 +94,7 @@ Best for:
 - Operators wanting cleaner filesystem layout
 
 Trade-offs:
-- Less human-inspectable than JSON files (need `sqlite3 chapter.db`)
+- Less human-inspectable than JSON files (need `sqlite3 hub.db` — and a plain `sqlite3` build **can't open the encrypted DB at all** without the SQLCipher key; you'd open it with a SQLCipher-enabled build and `PRAGMA key`)
 - One file holds everything → backup strategy concentrates on one artifact
 
 ### `dynamodb` (V2-Sprint2, opt-in via `dynamodb` feature)
@@ -90,7 +115,7 @@ Schema (single-table-design):
 
 **Atomic append.** `PutItem` with `ConditionExpression: attribute_not_exists(SK)` is the primitive — equivalent to sqlite's `INTEGER PRIMARY KEY` constraint. Concurrent appenders racing at the same index → exactly one commits, the other gets `ConditionalCheckFailedException` and propagates as the existing "ledger advanced between build_entry and append_signed" stale-detection.
 
-**Wiring status.** The backend implementation is shipped (`hub_lib::dynamodb_store::DynamoDbBackend`). CLI integration for `hub init --storage dynamodb` and `hub serve` against a dynamodb-backed chapter is **not yet** wired — `open_chapter_store_with(dir, BackendKind::Dynamodb)` returns an error pointing operators at the Rust API. Wiring needs a `[storage]` block in `config.toml` to record table name + hub_id (so future `hub serve` can dispatch). That's a follow-up sprint.
+**Wiring status.** The backend implementation is shipped (`hub_lib::dynamodb_store::DynamoDbBackend`). CLI integration for `hub init --storage dynamodb` and `hub serve` against a dynamodb-backed chapter is **not yet** wired — `open_hub_store_with(dir, BackendKind::Dynamodb)` returns an error pointing operators at the Rust API. Wiring needs a `[storage]` block in `config.toml` to record table name + hub_id (so future `hub serve` can dispatch). That's a follow-up sprint.
 
 **Testing.** No in-process tests (AWS SDK doesn't have a clean offline mode). Manual smoke against DynamoDB Local:
 
@@ -125,7 +150,7 @@ hub init "Lisbon" --sovereign-lct sov.json
 hub init "Lisbon" --sovereign-lct sov.json --storage sqlite
 ```
 
-The `--storage` flag accepts: `file`, `sqlite` (aliases: `files`, `jsonl`, `sqlite3`, `db`).
+The `--storage` flag accepts: `file` (aliases: `files`, `jsonl`) and `sqlite` (aliases: `sqlite3`, `db`). `dynamodb` (aliases: `dynamo`, `ddb`) parses but errors at store-open time — it can't be constructed from a hub dir alone (see the dynamodb section). Anything else is rejected.
 
 ---
 
@@ -137,9 +162,9 @@ hub migrate <chapter-dir> --to <file|sqlite>
 
 What it does:
 
-1. Auto-detects the source backend (`chapter.db` present → sqlite; else → file).
+1. Auto-detects the source backend (`hub.db` — or legacy `chapter.db` — present → sqlite; else → file).
 2. If source == target, no-op.
-3. Opens the target backend (creates `chapter.db` for sqlite).
+3. Opens the target backend (creates `hub.db` for sqlite; if a passphrase is set, the new sqlite DB is SQLCipher-encrypted).
 4. Copies charter, society, and every ledger entry **byte-for-byte**. No re-signing, no chain rebuild — the migrated chapter's `head_hash` is identical to the source's.
 5. Renames source artifacts to `.pre-migration` suffixes so they remain recoverable for rollback but don't interfere with auto-detection on future opens.
 6. Runs `verify-ledger` end-to-end on the migrated chapter. Errors loudly if anything failed.
@@ -170,7 +195,7 @@ The `head_hash` after migration matches the source's head_hash. That equality is
 
 If you decide to roll back:
 1. Stop any running `hub serve` for this chapter.
-2. Delete `chapter.db` (and any `.db-wal` / `.db-shm` files).
+2. Delete `hub.db` (and any `.db-wal` / `.db-shm` files).
 3. Rename `.pre-migration` files back to their originals (strip the suffix).
 4. Run `hub verify-ledger <chapter-dir>` to confirm.
 
@@ -178,7 +203,7 @@ If you decide to roll back:
 
 Operator discretion. Some patterns:
 - Keep them for one full chapter cycle to ensure no edge cases surface.
-- Remove them after a backup of `chapter.db` is taken.
+- Remove them after a backup of `hub.db` is taken.
 - Long-term retention is harmless except for disk-space pressure.
 
 ---
@@ -193,22 +218,44 @@ Operator discretion. Some patterns:
 
 ## Extending: adding a new backend
 
-Implement the `HubStore` trait:
+Implement the `HubStore` trait. It is an **`#[async_trait]`** trait (`Send + Sync`); every method is `async` so the trait composes with network-backed backends that do real I/O, while in-process backends (`file`, `sqlite`) just complete synchronously inside the async body. Several methods have defaults (law, council proposals, pair messages) so a minimal backend only has to implement charter/society/ledger:
 
 ```rust
-pub trait HubStore: Send {
+#[async_trait::async_trait]
+pub trait HubStore: Send + Sync {
     fn backend_kind(&self) -> BackendKind;
-    fn read_charter(&self) -> Result<Option<Charter>>;
-    fn write_charter(&mut self, charter: &Charter) -> Result<()>;
-    fn read_society(&self) -> Result<Option<Society>>;
-    fn write_society(&mut self, society: &Society) -> Result<()>;
-    fn ledger_load_all(&self) -> Result<Vec<LedgerEntry>>;
-    fn ledger_append(&mut self, entry: &LedgerEntry) -> Result<()>;
-    fn ledger_is_empty(&self) -> Result<bool> { /* default */ }
+
+    // Charter (immutable post-genesis)
+    async fn read_charter(&self) -> Result<Option<Charter>>;
+    async fn write_charter(&mut self, charter: &Charter) -> Result<()>;
+
+    // Society state
+    async fn read_society(&self) -> Result<Option<Society>>;
+    async fn write_society(&mut self, society: &Society) -> Result<()>;
+
+    // Ledger (append-only, hash-chained)
+    async fn ledger_load_all(&self) -> Result<Vec<LedgerEntry>>;
+    async fn ledger_append(&mut self, entry: &LedgerEntry) -> Result<()>;
+    async fn ledger_is_empty(&self) -> Result<bool> { /* default: load_all */ }
+
+    // Law (signed YAML; default impls return None / bail)
+    async fn read_law(&self) -> Result<Option<String>> { /* default */ }
+    async fn write_law(&mut self, yaml: &str) -> Result<()> { /* default */ }
+
+    // Council proposals (default impls bail "unsupported")
+    async fn write_proposal(&mut self, p: &CouncilProposal) -> Result<()> { /* default */ }
+    async fn read_proposal(&self, id: Uuid) -> Result<Option<CouncilProposal>> { /* default */ }
+    async fn list_proposals(&self) -> Result<Vec<CouncilProposal>> { /* default */ }
+    async fn delete_proposal(&mut self, id: Uuid) -> Result<()> { /* default */ }
+
+    // Pair messages (default impls bail "unsupported")
+    async fn append_pair_message(&mut self, msg: &PairMessage) -> Result<()> { /* default */ }
+    async fn list_pair_messages(&self, pair_id: Uuid, since_seq: Option<u64>)
+        -> Result<Vec<PairMessage>> { /* default */ }
 }
 ```
 
-Wire into `BackendKind` enum + `BackendKind::FromStr` parser + `open_chapter_store_with` factory + the migration tool's `preserved_artifacts` step (so source-side cleanup knows what to rename).
+Wire into `BackendKind` enum + `BackendKind::FromStr` parser + `open_hub_store_with` factory + the migration tool's `preserved_artifacts` step (so source-side cleanup knows what to rename).
 
 Don't add secret-handling operations to the trait. Don't add anything that requires the trait to learn about chapter-specific business logic. The trait is bytes-in / bytes-out for chapter state; everything else (validation, signing, authorization) is the layers above.
 
@@ -218,7 +265,7 @@ Don't add secret-handling operations to the trait. Don't add anything that requi
 
 - `BACKEND-OPTIONS.md` — design exploration of the wider backend space
   (DynamoDB, Postgres, S3, edge-SQL, distributed consensus) + the
-  async-trait open question that gates the first network-backed backend
+  (now-resolved) async-trait decision behind the network-backed backends
 - `V2-V3-ARCHITECTURE.md` §Load-bearing commitment #8 (secrets posture)
 - `hub-lib/src/store.rs` (trait + backends)
 - `hub-lib/src/ledger.rs` (uses `HubStore` for persistence; owns chain integrity)

--- a/hub/docs/TROUBLESHOOTING.md
+++ b/hub/docs/TROUBLESHOOTING.md
@@ -26,13 +26,145 @@ Then `cargo build --release` again.
 
 ---
 
+## Vault & passphrase
+
+The hub follows a **vault doctrine**: private keys are never written in the clear,
+and hub state is encrypted at rest. Most of the "why won't this run?" surprises
+trace back to `HUB_PASSPHRASE` not being set. See [`QUICKSTART.md`](QUICKSTART.md)
+Step 0 for the full model.
+
+### `hub gen-lct` / `hub init` fail: "refusing to write a plaintext private key"
+
+The full message is *"HUB_PASSPHRASE is not set and there is no terminal to prompt
+— refusing to write a plaintext private key (vault doctrine)."* You hit this in a
+script, CI job, or container where there's no TTY to prompt. Set the passphrase:
+
+```bash
+export HUB_PASSPHRASE='your-passphrase'
+hub gen-lct ./sovereign.json
+```
+
+An empty passphrase is allowed but must be **explicit** — `HUB_PASSPHRASE=`
+(empty value) is a deliberate NULL choice (encrypted, but openable by anyone).
+Leaving the variable *unset* is what triggers the error. At an interactive shell
+the command will instead prompt you rather than erroring.
+
+### "identity at X is an encrypted vault — set HUB_PASSPHRASE to unlock it"
+
+A command tried to load your `sovereign.json` (or another identity file) and found
+an encrypted vault (it starts with the `W4VT` magic) but no passphrase to open it.
+Set `HUB_PASSPHRASE` (an empty value `HUB_PASSPHRASE=` is accepted if the vault was
+sealed with a NULL passphrase):
+
+```bash
+export HUB_PASSPHRASE='your-passphrase'
+```
+
+### "hub state at X is encrypted but no HUB_PASSPHRASE is set"
+
+Seen from `hub verify-ledger` (and other commands that open the state store) on an
+encrypted hub. **This is expected, not corruption** — the SQLCipher state store
+needs tier-1 ignition (the passphrase) to open. Set `HUB_PASSPHRASE` and re-run:
+
+```bash
+export HUB_PASSPHRASE='your-passphrase'
+hub verify-ledger ./your-chapter-name
+```
+
+(Note: `hub serve` is the exception — it deliberately does *not* read the
+passphrase from the environment at serve time; instead it boots a locked shell and
+waits for `hub unlock`. See "Locked hub" below.)
+
+### Rotating or recovering the passphrase
+
+To change the vault passphrase to a new operator-chosen one:
+
+```bash
+# Stop the hub first.
+pkill -f 'target/release/hub serve'
+
+# Re-keys the Sovereign identity + the SQLCipher state store + the protected tier.
+# Prompts for the current passphrase, then the new one (twice).
+hub rotate-passphrase ./your-chapter-name
+
+# Start the hub again — it boots LOCKED. Ignite with the NEW phrase:
+hub serve ./your-chapter-name
+hub unlock     # in another terminal; enter the new passphrase
+```
+
+**There is no passphrase recovery.** The passphrase is never stored anywhere. If
+you lose it, the encrypted identity and state store are **unrecoverable** — there
+is no backdoor and no reset that preserves the data. Back up the passphrase the
+way you'd back up a root key.
+
+---
+
+## Locked hub / `hub unlock`
+
+### `hub serve` came up but everything returns 503
+
+Your hub state is encrypted, so on boot/restart the daemon comes up in a
+**degraded locked shell**. The error body reads:
+
+> `hub vault is locked — ignite it first (run hub unlock); only the unlock path is served while locked`
+
+While locked, only a tiny tier-0 allowlist answers: the discovery doc
+(`/.well-known/web4-hub.json`), the public law (`.../law`), the OID4VCI issuer
+metadata (`.../.well-known/openid-credential-issuer`), and the unlock slot itself.
+Everything else is `503` by design. Ignite it from the hub host:
+
+```bash
+hub unlock      # defaults to port 8770; prompts for the passphrase (or reads HUB_PASSPHRASE)
+```
+
+The unlock slot is loopback-only (127.0.0.1) and rate-limited; the passphrase is
+used once and never stored.
+
+### `hub unlock` can't identify the hub / no `public-identity.json`
+
+A locked shell needs a clear `public-identity.json` to self-identify on
+`/.well-known` and accept the unlock. If you never exported it, run once (with
+`HUB_PASSPHRASE` set):
+
+```bash
+hub export-public-identity ./your-chapter-name
+```
+
+Then restart `hub serve` and try `hub unlock` again.
+
+### Operator plane (port 8772) is unreachable
+
+`hub serve` starts a second listener — the **operator plane** — at
+`127.0.0.1:8772` (admit/deny/remove/re-key + write GUI at `/admin`). Common
+reasons it's not reachable:
+
+- **It's loopback-only by design.** It is *never* bound to the network, even with
+  `--bind 0.0.0.0`. To reach it on a remote host, tunnel: `ssh -L 8772:127.0.0.1:8772 user@host`.
+- **It was disabled.** `--admin-port 0` turns the operator plane off entirely.
+  Pick a port (default 8772) with `--admin-port`. (8771 is taken by the membox
+  sidecar, hence the 8772 default.)
+- **The hub is still locked.** The operator plane is behind the same lock-gate —
+  it also returns 503 until you `hub unlock`.
+
+### tier-2 M-of-N unlock returns 501
+
+`POST .../unlock/challenge` (the Sovereign-Council M-of-N unlock) returns *"tier-2
+M-of-N unlock is not available on this hub (no unlock verifier plugin
+configured)"*. **This is expected, not a bug** — the M-of-N quorum logic lives in a
+separate verifier binary that isn't installed by default. It's N/A unless you set
+`HUB_UNLOCK_VERIFIER` to point at that verifier. Use the tier-1 passphrase path
+(`hub unlock`) instead.
+
+---
+
 ## `hub init`
 
 ### "Sovereign LCT path / No such file or directory"
 
-You passed `--sovereign-lct path/to/file.json` but the file doesn't exist. Generate one first:
+You passed `--sovereign-lct path/to/file.json` but the file doesn't exist. Generate one first (with `HUB_PASSPHRASE` set — see "Vault & passphrase" above):
 
 ```bash
+export HUB_PASSPHRASE='your-passphrase'
 hub gen-lct ./sovereign.json
 hub init "Chapter Name" --sovereign-lct ./sovereign.json
 ```
@@ -94,11 +226,22 @@ Same root cause class as hash mismatch — content was edited (signature now mis
 
 ### "entry N actor LCT not found by lookup"
 
-The verifier needs to look up the actor LCT to validate signatures. MVP only knows the Sovereign LCT (loaded from `config.toml`'s `sovereign.lct_path`). If a ledger entry's actor is *not* the Sovereign (e.g. a member who signed their own action — V2 capability), the MVP verifier can't look them up.
+The verifier needs to look up the actor LCT to validate signatures. The resolver
+is seeded from the ledger itself, so it now knows more than just the founding
+Sovereign:
 
-Workarounds:
-- Ensure all your ledger entries' `actor_lct_id` is the Sovereign's (which is what MVP CLI/MCP both produce — they always sign as Sovereign).
-- For V2 / client-signed entries, the verifier needs an extended LCT registry. Not in MVP.
+- the **founding Sovereign** (from `config.toml`'s `sovereign.lct_path`),
+- every **Sovereign-Council holder** (their pubkey is pinned into the ledger when
+  you run `hub council add`), and
+- every **admitted member** whose pubkey was pinned at admission — both those
+  added via `hub add-member`/`hub set-member-key` with a pinned key and those who
+  self-joined via `POST /v1/hubs/<id>/members/join`.
+
+So this error now means a ledger entry's actor genuinely isn't in any of those
+sets — e.g. a member who signed an action but whose pubkey was never pinned. Fix
+the gap by pinning that member's channel key (`hub set-member-key <dir> <lct-id>
+<pubkey-hex>`) so future verification can resolve them; entries signed before a key
+was pinned can't be retroactively resolved.
 
 ### Sovereign LCT path resolution errors after moving the chapter dir
 
@@ -146,15 +289,22 @@ If something is wedged beyond troubleshooting and you want to start over:
 # Stop any running daemons
 pkill -f 'target/release/hub serve'
 
-# Remove chapter dir (this destroys all chapter state — irreversible)
+# Remove chapter dir (this destroys all chapter state — irreversible).
+# This also removes the encrypted state store, the clear public-identity.json,
+# and the protected.hvlt tier that live inside it. For a partial reset that
+# keeps the dir, at minimum remove these two:
+#   rm -f ./your-chapter-name/public-identity.json ./your-chapter-name/protected.hvlt
 rm -rf ./your-chapter-name/
 
 # Remove or regenerate the Sovereign LCT (this orphans any prior chapters
 # signed by it — only do this if you're fully resetting)
 rm ./sovereign.json
+
+# HUB_PASSPHRASE must be set — gen-lct and init both need it (vault doctrine).
+export HUB_PASSPHRASE='your-passphrase'
 hub gen-lct ./sovereign.json
 
-# Re-init
+# Re-init (still needs HUB_PASSPHRASE)
 hub init "Your Chapter Name" --sovereign-lct ./sovereign.json
 ```
 

--- a/hub/docs/V2-V3-ARCHITECTURE.md
+++ b/hub/docs/V2-V3-ARCHITECTURE.md
@@ -111,24 +111,25 @@ The hub binary does NOT contain:
 
 ### 4. Storage is backend-abstracted from V2 day one
 
-Not retrofitted. Trait + implementations from the first commit of V2-B5:
+**SHIPPED.** Not retrofitted. The `HubStore`/`ChapterStore` trait + implementations are live:
 - `InMemoryBackend` — tests + ephemeral
-- `SqliteBackend` — single-machine production, ≤~100k members per chapter
-- `PostgresBackend` — multi-tenant, multi-chapter, the cloud-scale answer
-- `S3CompatibleColdStorage` — archive tier for old ledger pages
+- `FileBackend` — the MVP file ledger, now one backend behind the trait
+- `SqliteBackend` — single-machine production; **SQLCipher-encrypted at rest by default**
+- `DynamoDB` backend — opt-in via the `dynamodb` feature
+- `PostgresBackend` / `S3CompatibleColdStorage` — multi-tenant + cold-archive tiers still on the roadmap
 
-File-based `ledger.jsonl` from MVP becomes one backend among many. Migration tool to convert MVP chapters to SQLite or Postgres ships with V2-B5.
+File-based `ledger.jsonl` from MVP is now one backend among many, and the migration tool (`hub migrate`) to convert MVP chapters to another backend has shipped.
 
 The Ledger trait pattern web4-core already uses for LCT anchoring is the model. Hub's chapter event ledger gets the same shape.
 
 ### 5. Multi-Sovereign Council from the start (no single-founder pattern)
 
-Single-Sovereign is a special case of M-of-N where M=N=1. The architecture handles M-of-N natively:
+**SHIPPED.** Single-Sovereign is a special case of M-of-N where M=N=1. The architecture handles M-of-N natively, and the Sovereign Council data model + propose/sign/threshold flow is live:
 - Sovereigns are admitted, retire, get ejected, are member-elected per chapter law
-- Consequential Sovereign actions require N-of-M signatures
+- Consequential Sovereign actions require N-of-M signatures (propose → sign → threshold enforcement, with `proposal_ref` linking committed acts back to the proposal for single-pane audit)
 - Election as constitutional escape valve when Council fails
 
-This is a web4-core upstream change (multi-fill RoleAssignment with threshold semantics). PRs first; hub uses upstream once merged.
+The threshold-signing semantics landed in the hub directly (data model + management + admin UI + M-of-N enforcement).
 
 ### 6. AI is a first-class role-filler
 
@@ -159,6 +160,8 @@ The community evolves the hub. We ship the foundation; communities adapt + exten
 
 ### 8. Secrets in the vault only; access on verified authority + need-to-know; ZKP preferred
 
+> **SHIPPED (hub-native enclosure):** the original framing put all secrets in an *external* Hestia vault and called the hub's plaintext identity JSON an anti-pattern to be deprecated. The hub now carries its own fail-closed encrypt-at-rest enclosure: the Sovereign identity is **encrypted at rest** (with `hub seal-identity` to migrate a plaintext identity in place), the hub boots **unlock-first** into a degraded **locked shell** (tier-0 surface) with **no stored passphrase**, ignites at runtime via an unlock seam (incl. a tier-2 M-of-N witnessed unlock grant), and supports `rotate-passphrase` (operator-chosen secret). SQLCipher-encrypted state + encrypted ledger complete the enclosure. The external-Hestia path remains valid; the hub no longer *requires* it to protect its own keys.
+
 Three rules, in order of specificity:
 
 **A. Vault is the exclusive home of secrets.** Private keys, API credentials, sealing material, any secret the system needs — all live in Hestia's vault. The hub never stores secrets. The hub's databases, ledgers, society state, charters, role assignments — all of it is public-by-design within the chapter (signed for integrity, not encrypted for confidentiality of the data itself). If something needs to be secret, it belongs in a vault, not in chapter storage.
@@ -170,7 +173,7 @@ Three rules, in order of specificity:
 Implications across tracks:
 - **Track H (Hestia)**: vault interface design must support ZKP-producing operations, not just "give me the credential" or "sign this payload." The vault is the privacy-preserving prover. The vault enforces the authority+need-to-know gate at access time. See addendum to Track H delegation post.
 - **Track U (web4-core)**: signature primitives may need ZKP-variant additions (predicate proofs over membership, threshold proofs over T3/V3 scores, range proofs for ATP balances). Likely a U5 sprint once Hestia's ZKP requirements crystallize.
-- **Track B (hub)**: storage is secrets-free **by design** — the trait surface never includes secret material. Identity files in MVP (private key sitting in a JSON file the hub reads) are an anti-pattern under this commitment; they're tolerated through V2-7 only as a bootstrap convenience, then deprecated when Hestia-as-Sovereign ships. Query handlers enforce need-to-know via the law (PolicyEntity gates queries the same way it gates writes).
+- **Track B (hub)**: storage is secrets-free **by design** — the trait surface never includes secret material. The MVP plaintext-identity-file anti-pattern has been **resolved hub-side**: the Sovereign identity is now encrypted at rest behind the fail-closed vault (see the SHIPPED note above), so the bootstrap convenience no longer leaves a key in plaintext. Query handlers enforce need-to-know via the law — **PolicyEntity gates reads the same way it gates writes (shipped).**
 
 This is constitutional alongside #1 (law) and #2 (Hestia). Privacy and authority discipline is foundational to the whole stack; bolting it on later means redesigning every interface.
 
@@ -207,17 +210,17 @@ PRs go to dp-web4/web4. Decided per PR whether this or another session handles e
 
 Application infrastructure built on Hestia, web4-core, ACT.
 
-- **B1**: Member-role refactor — Citizen-default; non-Sovereign roles unfilled at genesis. Founder fills Sovereign + Citizen only. *Independent of other tracks; ships first.*
-- **B2**: Hestia-LCT-as-Sovereign integration — `hub init` accepts existing Hestia LCT; deprecate anonymous-Sovereign pattern. *Needs H2.*
-- **B3**: Sovereign Council mechanics — multi-fill at the role level; admit/retire/eject/elect event types; M-of-N signature validation. *Needs U1+U2.*
-- **B4**: Law parser + interpreter — read signed law file; validate signatures; evaluate requests against rules. PolicyEntity role calls into this. *Needs U3.*
-- **B5**: Storage backend abstraction — Trait + SqliteBackend + PostgresBackend impls; migration tool from file-based MVP. *Foundation for scale.*
-- **B6**: Multi-tenant deployment — schema-per-chapter (default) or tenant-id-column (high-density) within one Postgres deployment; one-chapter-per-process for max isolation. *Needs B5.*
-- **B7**: Member self-add request flow — `MemberJoinRequested` event; admin review surface; chapter-law-policy hook. *Needs H3 and B4.*
-- **B8**: AI role-filler runtime — process supervision (spawning + monitoring AI agents per role); ATP accounting per AI action; T3 scoring; escalation event routing. *Needs U2+U4 and B4.*
-- **B9**: Admin web UI — askama server-rendered HTML; member view + admin view + Sovereign Council interface + escalation review queue. *Needs B7 (review queue), B8 (escalations).*
-- **B10**: HTTPS + caddy convention — reverse-proxy pattern; well-known URI for discovery. *Needs B9.*
-- **B11**: Cloud deployment artifacts — helm chart for k8s + terraform modules for AWS/GCP/Azure. Platform-agnostic via clean storage + reverse-proxy abstractions. *Needs B5+B10.*
+- **B1**: Member-role refactor — Citizen-default; non-Sovereign roles unfilled at genesis. Founder fills Sovereign + Citizen only. **SHIPPED (V2-1).**
+- **B2**: Hestia-LCT-as-Sovereign integration — `hub init` accepts existing Hestia LCT; deprecate anonymous-Sovereign pattern. **SHIPPED (V2-7):** `hub init --sovereign-hestia` + RemoteSigner/HestiaCallbackSigner; MCP + REST acts work on Hestia chapters.
+- **B3**: Sovereign Council mechanics — multi-fill at the role level; admit/retire/eject/elect event types; M-of-N signature validation. **SHIPPED (V2-9):** Council data model + propose/aggregate flow + M-of-N enforcement + admin UI.
+- **B4**: Law parser + interpreter — read signed law file; validate signatures; evaluate requests against rules. PolicyEntity role calls into this. **SHIPPED (V2-8):** YAML law parser/validator, signed law storage (`LawAmended`), evaluator (Law × R6 → Allow/Deny/Escalate), PolicyEntity gate wired into REST + MCP act handlers *and reads*, hot-reload, `hub set-law`/`get-law`/`init-law`.
+- **B5**: Storage backend abstraction — Trait + SqliteBackend + PostgresBackend impls; migration tool from file-based MVP. **SHIPPED (V2-2):** `ChapterStore`/`HubStore` trait + FileBackend + SqliteBackend (SQLCipher-encrypted) + DynamoDB backend + `hub migrate`. Postgres still on the roadmap.
+- **B6**: Multi-tenant deployment — schema-per-chapter (default) or tenant-id-column (high-density) within one Postgres deployment; one-chapter-per-process for max isolation. *Needs B5. (Still future.)*
+- **B7**: Member self-add request flow — `MemberJoinRequested` event; admin review surface; chapter-law-policy hook. **SHIPPED:** V2-12 member self-add via signed envelope, plus a member **admission queue + operator GUI** (no-restart admit/deny/re-key/remove).
+- **B8**: AI role-filler runtime — process supervision (spawning + monitoring AI agents per role); ATP accounting per AI action; T3 scoring; escalation event routing. *Needs U2+U4 and B4. (Still future.)*
+- **B9**: Admin web UI — askama server-rendered HTML; member view + admin view + Sovereign Council interface + escalation review queue. **SHIPPED (V2-16):** read-only `/admin` dashboard + write-capable operator plane (admissions + member management) on the admin port `127.0.0.1:8772`.
+- **B10**: HTTPS + caddy convention — reverse-proxy pattern; well-known URI for discovery. **PARTLY SHIPPED:** the `GET /.well-known/web4-hub.json` discovery endpoint ships; the HTTPS/reverse-proxy convention is still future.
+- **B11**: Cloud deployment artifacts — helm chart for k8s + terraform modules for AWS/GCP/Azure. Platform-agnostic via clean storage + reverse-proxy abstractions. *Needs B5+B10. (Still future.)*
 
 ### Track L — Law primitives (shared between hub + community)
 
@@ -245,30 +248,44 @@ These are demonstrations + starter implementations. Communities can swap any for
 
 Dependency-driven order, not calendar-driven. Each sprint produces a verifiable milestone.
 
-| Sprint | Track | Focus | Depends on |
-|---|---|---|---|
-| V2-1 | B | B1 — Member-role refactor (Citizen-default, others unfilled) | — |
-| V2-2 | B | B5 — Storage backend abstraction + SQLite impl + migration tool | — |
-| V2-3 | H | H1 — Hestia vault (passphrase-first; hardware optional) | — |
-| V2-4 | H | H2-H3 — Hestia member CLI + multi-hub connector | H1 |
-| V2-5 | U | U1+U2 — web4-core PRs: multi-fill RoleAssignment + DelegatedAuthority | — |
-| V2-6 | U | U3 — Law schema PR upstream | — |
-| V2-7 | B | B2 — Hestia-LCT-as-Sovereign integration | H2 + U3 |
-| V2-8 | B | B4 — Law interpreter; PolicyEntity uses it | U3 + B5 |
-| V2-9 | B | B3 — Sovereign Council mechanics | U1+U2 + B2 |
-| V2-10 | H | H4 — Hestia delegation primitives | U2 |
-| V2-11 | H | H5 — AI-variant Hestia | H1+H4 |
-| V2-12 | B | B7 — Member self-add flow | H3 + B4 + B5 |
-| V2-13 | B | B8 — AI role-filler runtime | U2+U4 + B4 + H5 |
-| V2-14 | C | C1-C4 — Reference AI role-fillers (parallel, community-led) | B8 (API) |
-| V2-15 | B | B6 — Multi-tenant deployment | B5 |
-| V2-16 | B | B9 — Admin web UI | B7 + B8 |
-| V2-17 | B | B10 — HTTPS + discovery | B9 |
-| V2-18 | B | B11 — Cloud deployment artifacts | B5 + B10 |
+| Sprint | Track | Focus | Depends on | Status |
+|---|---|---|---|---|
+| V2-1 | B | B1 — Member-role refactor (Citizen-default, others unfilled) | — | **SHIPPED** |
+| V2-2 | B | B5 — Storage backend abstraction + SQLite impl + migration tool | — | **SHIPPED** (file/SQLite/DynamoDB + `hub migrate`) |
+| V2-3 | H | H1 — Hestia vault (passphrase-first; hardware optional) | — | Hestia track |
+| V2-4 | H | H2-H3 — Hestia member CLI + multi-hub connector | H1 | Hestia track |
+| V2-5 | U | U1+U2 — web4-core PRs: multi-fill RoleAssignment + DelegatedAuthority | — | web4-core track |
+| V2-6 | U | U3 — Law schema PR upstream | — | web4-core track |
+| V2-7 | B | B2 — Hestia-LCT-as-Sovereign integration | H2 + U3 | **SHIPPED** |
+| V2-8 | B | B4 — Law interpreter; PolicyEntity uses it | U3 + B5 | **SHIPPED** (gates writes *and* reads) |
+| V2-9 | B | B3 — Sovereign Council mechanics | U1+U2 + B2 | **SHIPPED** (M-of-N propose/sign/threshold) |
+| V2-10 | H | H4 — Hestia delegation primitives | U2 | Hestia track |
+| V2-11 | H | H5 — AI-variant Hestia | H1+H4 | Hestia track |
+| V2-12 | B | B7 — Member self-add flow | H3 + B4 + B5 | **SHIPPED** (+ admission queue/operator GUI) |
+| V2-13 | B | B8 — AI role-filler runtime | U2+U4 + B4 + H5 | future |
+| V2-14 | C | C1-C4 — Reference AI role-fillers (parallel, community-led) | B8 (API) | future (community-led) |
+| V2-15 | B | B6 — Multi-tenant deployment | B5 | future |
+| V2-16 | B | B9 — Admin web UI | B7 + B8 | **SHIPPED** (`/admin` + operator plane) |
+| V2-17 | B | B10 — HTTPS + discovery | B9 | partly (`.well-known` shipped) |
+| V2-18 | B | B11 — Cloud deployment artifacts | B5 + B10 | future |
 
 V2 done when V2-18 ships. That's the "deployable as production community infrastructure" target. V3 is whatever V2 didn't address — likely federation specifics, advanced AI role coordination, performance work at >1M scale.
 
 This is **not** a calendar plan. It's a dependency-graph order. Pace is set by how fast each piece can be done well, not by a roadmap.
+
+---
+
+## Shipped beyond the original plan
+
+Several subsystems were not in the original track structure above but have since shipped. Recorded here so the architecture stays honest about current state.
+
+- **Hub encrypt-at-rest enclosure.** The hub now protects its own keys without requiring an external Hestia: Sovereign identity encrypted at rest, `hub seal-identity` (migrate a plaintext identity in place), unlock-first boot into a degraded **locked shell** (tier-0 surface, no stored passphrase), runtime ignition via an unlock seam (incl. a tier-2 **M-of-N witnessed** unlock grant) and `rotate-passphrase`. SQLCipher-encrypted state + encrypted ledger complete it. (Updates Commitment #8.)
+- **Sealed channels + discovery.** Sealed member↔hub E2E channel; paired member↔member channels (ECDH + ChaCha20-Poly1305, forward secrecy via ephemeral session keys); `find_members` (hub gates, membot engine); `request_intro`/`list_intros`/`respond_intro` (the consent half of discovery); external→citizen bootstrap (`request_citizenship`) over the channel. PolicyEntity gates channel reads with MRH-style result bounding.
+- **EUDI / `did:web4`.** OID4VCI issuer (membership SD-JWT-VCs) + OID4VP verifier, with a RemoteSigner issuer, and `did:web4` identifiers. Society-scale verifiable credentials.
+- **Constellation attestation.** Hub-side verify + challenge/present channel tools.
+- **Member admission queue + operator plane.** Self-add via signed envelope plus a no-restart operator GUI (admit/deny/re-key/remove) on the operator plane (`127.0.0.1:8772`). (Realizes B7 + B9.)
+- **ReferencedAct + hub→citizen notifications.** Acts can reference prior acts; the hub notifies citizens. (Phase-0 Gap A.)
+- **Open-core plugin seam.** The generic `hub-plugin` seam — canonical `gate → handle → scope` dispatch path — is promoted to open core (public). Advanced role-fillers can plug in behind it.
 
 ---
 
@@ -301,13 +318,15 @@ This is **not** a calendar plan. It's a dependency-graph order. Pace is set by h
 
 ## Implications for MVP — what to revisit before V2 starts
 
-Three MVP artifacts conflict with the new commitments and should be flagged for V2-1 cleanup:
+> **RESOLVED.** All three MVP conflicts below have been addressed.
 
-1. **`hub gen-lct ./sovereign.json`** — generates an anonymous chapter-specific LCT. This was MVP-pragmatic. V2 deprecates it in favor of Hestia-as-Sovereign. The CLI keeps the command for testing + non-Hestia use cases but adds a clear "for production, use Hestia LCT" note.
-2. **`Society::bootstrap` filling all 7 roles with founder** — this was the path of least resistance for MVP. V2-1 changes it to Sovereign + Citizen only; other roles unfilled until law specifies otherwise.
-3. **Daemon hardcodes Sovereign-signs-everything** — MVP shortcut. V2-8 changes it: PolicyEntity (reading the law) decides whether a request is authorized before any signing happens.
+Three MVP artifacts conflicted with the new commitments and were flagged for cleanup:
 
-These are clean migration points, not breaking changes. MVP chapters can run as-is; V2 chapters use the new flow.
+1. **`hub gen-lct ./sovereign.json`** — generated an anonymous chapter-specific LCT. **RESOLVED:** Hestia-as-Sovereign (`hub init --sovereign-hestia`) shipped (V2-7), and the Sovereign identity is now encrypted at rest behind the fail-closed vault rather than sitting in a plaintext JSON file.
+2. **`Society::bootstrap` filling all 7 roles with founder** — **RESOLVED (V2-1):** founder fills Sovereign + Citizen only; other roles unfilled until law specifies otherwise.
+3. **Daemon hardcodes Sovereign-signs-everything** — **RESOLVED (V2-8):** the PolicyEntity, reading the signed law, decides whether a request is authorized (Allow/Deny/Escalate) before any signing happens — on writes *and* reads.
+
+These were clean migration points, not breaking changes. MVP chapters can still run as-is; V2 chapters use the new flow.
 
 ---
 

--- a/hub/membox/README.md
+++ b/hub/membox/README.md
@@ -1,6 +1,12 @@
 # Hub member discovery — `find_members`
 
 > The hub is the front door; **membot is the engine.**
+>
+> **The cart is a pure index — no member PII at rest.** It stores embeddings
+> keyed to opaque member LCTs and nothing else. Names and profiles live once, in
+> the hub's authoritative encrypted registry, and the hub re-attaches them at
+> query time. Member prose exists only in RAM during embedding; it is never
+> persisted.
 
 Semantic member discovery for a Web4 hub. A member asks *"who can help me with
 X?"* over the E2E channel; the hub gates + scopes the request and composes
@@ -17,9 +23,9 @@ rerank).
 
 | File | Role |
 |------|------|
-| `ingest.py` | Reads hub members → free-form prose passages → embeds (pinned **nomic-embed-text-v1.5**) → writes a `.cart.npz` + a passage-index-aligned `members.json` (forward-compat tags). |
-| `sidecar.py` | Long-lived localhost HTTP service. Mounts the cart + holds the model once. `POST /find_members {query, top_k, temperature}` → ranked `{member_lct, name, score, tags}`. `GET /health`. |
-| `test_ingest.py` | Passage/tag contract tests (no model load). |
+| `ingest.py` | Reads hub members → builds free-form prose passages → embeds (pinned **nomic-embed-text-v1.5**) → writes a `.cart.npz` whose stored "text" is the **opaque member LCT** (not the prose) + a passage-index-aligned `members.json` holding only `{member_lct, profile_version}`. The prose is used to compute embeddings in RAM and discarded. |
+| `sidecar.py` | Long-lived localhost HTTP service. Mounts the cart + holds the model once. `POST /find_members {query, top_k, temperature}` → ranked `{member_lct, score}` (plus the echoed `temperature`) — no name, no tags. `GET /health` → `{ok, cart, n_members, fingerprint}`. |
+| `test_ingest.py` | Passage/index contract tests (no model load). |
 
 The Rust hub-side `find_members` channel tool (in `hub-daemon/src/rest.rs`)
 calls the sidecar over localhost, gated by chapter law (`read:find_members`) and
@@ -29,12 +35,17 @@ forthcoming Walk-as-MCP (register-and-gate, not reimplement).
 ## Locked v1 contract (the three adds)
 
 1. **Model pinned** to `nomic-ai/nomic-embed-text-v1.5` (free via `cartridge_builder`).
-2. **Forward-compat tags** per member (`member_lct`, `profile_version`,
-   `last_pair_purpose`) so V3 trust feedback slots in without re-imprinting.
+2. **Pure index, no PII at rest** — the cart stores the opaque `member_lct` as
+   each passage's text; `members.json` carries only `{member_lct, profile_version}`
+   (`profile_version` is a one-way sha256 prefix of the passage, so it changes
+   exactly when a member's profile changes, without storing the content). The
+   `find_members` response is just `{member_lct, score}`; the hub enriches it
+   with name/profile from its encrypted registry.
 3. **Temperature knob from day one** — accepted at the API boundary now;
    precision-only until membot exposes settle-noise in search (then wired through).
 
-Passage shape: `{Name}. {free-form skills/interests prose}. Recent pair purposes: {…}.`
+Passage shape (RAM only, fed to the embedder and discarded): `{Name}. {free-form
+skills/interests prose}.`
 Tuning: `top_k` 10–15, keyword rerank ~0.05/hit, hippocampus-walk off (single-passage profiles).
 
 ## Operate


### PR DESCRIPTION
Staleness/incompleteness audit of all 13 public hub docs + systematic fix. The docs predated the vault/unlock-first rewrite, the PolicyEntity law engine, member admission + operator GUI, EUDI, sealed channels, and the plugin seam. Audited each doc against ground-truth code (CLI/MCP/REST surface) via parallel subagents, then fixed staleness + filled gaps. **Docs only — no code changed** (verified). Code fences balanced; commands re-verified against main.rs/rest.rs/store.rs/law.rs/signer.rs. +1138/-311 across 13 files.