### PR TITLE
hub-plugin: scale-agnostic signer identity (enables hestia to share the seam)

### DIFF
--- a/hub/hub-plugin/src/lib.rs
+++ b/hub/hub-plugin/src/lib.rs
@@ -57,14 +57,16 @@ impl std::error::Error for PluginError {}
 #[async_trait]
 pub trait PluginCtx: Send + Sync {
     fn caller(&self) -> &Caller;
-    /// The hub's own LCT id (its signing identity).
-    fn hub_lct(&self) -> LctId;
-    /// Sign `bytes` as the hub LCT (Ed25519, 64-byte sig). Works whether the hub
-    /// holds the key (Local) or signs via a remote callback (Hestia).
+    /// The local signing identity's LCT id. Scale-agnostic: the **society** LCT
+    /// when this seam runs in a hub, the **owner** LCT when it runs in a
+    /// person-scale node (e.g. a Hestia mini-hub). The same seam, fractally.
+    fn signer_lct(&self) -> LctId;
+    /// Sign `bytes` as the signer LCT (Ed25519, 64-byte sig). Works whether the
+    /// node holds the key (Local) or signs via a remote callback (Hestia).
     fn sign(&self, bytes: &[u8]) -> Result<Vec<u8>, PluginError>;
-    /// Verify side of `sign` — the hub's public key, hex.
-    fn hub_pubkey_hex(&self) -> String;
-    /// Read-only projected hub state (members/roles/…) as opaque JSON.
+    /// Verify side of `sign` — the signer's public key, hex.
+    fn signer_pubkey_hex(&self) -> String;
+    /// Read-only projected node state (members/roles/devices/…) as opaque JSON.
     fn state(&self) -> &Value;
     /// Send an opaque **sealed** payload to a peer LCT over the paired channel
     /// and get the sealed response. Generic — enables fan-out/recursion and

--- a/hub/hub-plugin/src/tests.rs
+++ b/hub/hub-plugin/src/tests.rs
@@ -13,13 +13,13 @@ impl PluginCtx for MockCtx {
     fn caller(&self) -> &Caller {
         &self.caller
     }
-    fn hub_lct(&self) -> LctId {
+    fn signer_lct(&self) -> LctId {
         Uuid::nil()
     }
     fn sign(&self, _bytes: &[u8]) -> Result<Vec<u8>, PluginError> {
         Ok(vec![0u8; 64])
     }
-    fn hub_pubkey_hex(&self) -> String {
+    fn signer_pubkey_hex(&self) -> String {
         "00".repeat(32)
     }
     fn state(&self) -> &Value {


### PR DESCRIPTION
Renames PluginCtx::hub_lct/hub_pubkey_hex → signer_lct/signer_pubkey_hex so the generic seam is scale-agnostic (society LCT in a hub, owner LCT in a person-scale Hestia mini-hub). Enables hestia to depend on the public hub-plugin instead of forking a near-identical copy. No public consumers break (daemon doesn't impl PluginCtx yet; dev-hub impls updated in lockstep). 3 tests green. Precursor to a hestia-adoption PR (drafted separately for the Legion track) + proposal.