### PR TITLE
hub: plane-aware admin nav (no dead operator links on the fleet plane)

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -64,20 +64,29 @@ const STYLE: &str = r#"
 </style>
 "#;
 
-fn layout(hub_name: &str, title: &str, body: &str) -> Html<String> {
-    // Joins/Manage are operator-plane pages (127.0.0.1 only); on the read-only
-    // fleet plane they 404, which is the honest signal that admin writes aren't there.
-    let nav = r#"<nav>
+fn layout(s: &RestState, title: &str, body: &str) -> Html<String> {
+    let hub_name = &s.hub_name;
+    // The Joins/Manage write pages exist ONLY on the loopback operator plane.
+    // Show their nav links there; omit them on the read-only fleet plane so we
+    // don't advertise links that would 404.
+    let operator_nav = if s.operator_plane {
+        r#"
+      <a href="/admin/joins">Joins ⚙</a>
+      <a href="/admin/manage">Manage ⚙</a>"#
+    } else {
+        ""
+    };
+    let nav = format!(
+        r#"<nav>
       <a href="/admin">Overview</a>
       <a href="/admin/members">Members</a>
       <a href="/admin/roles">Roles</a>
       <a href="/admin/ledger">Ledger</a>
       <a href="/admin/law">Law</a>
       <a href="/admin/council">Council</a>
-      <a href="/admin/pairs">Pairs</a>
-      <a href="/admin/joins">Joins ⚙</a>
-      <a href="/admin/manage">Manage ⚙</a>
-    </nav>"#;
+      <a href="/admin/pairs">Pairs</a>{operator_nav}
+    </nav>"#
+    );
     Html(format!(
         "<!doctype html><html><head><meta charset=\"utf-8\">\
          <title>{title} — {hub_name}</title>{STYLE}</head>\
@@ -181,10 +190,10 @@ async fn overview(State(s): State<RestState>) -> Result<Html<String>, AdminError
     body.push_str("<h2>Recent acts (last 20)</h2>");
     body.push_str(&render_ledger_table(&last_20));
 
-    Ok(layout(&s.hub_name, "Overview", &body))
+    Ok(layout(&s, "Overview", &body))
 }
 
-async fn members(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
+pub(crate) async fn members(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
     let ledger = s.ledger.lock().await;
     let projected = HubState::project(&*ledger);
     drop(ledger);
@@ -217,7 +226,7 @@ async fn members(State(s): State<RestState>) -> Result<Html<String>, AdminError>
         body.push_str("</tbody></table>");
     }
 
-    Ok(layout(&s.hub_name, "Members", &body))
+    Ok(layout(&s, "Members", &body))
 }
 
 async fn roles(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -285,7 +294,7 @@ async fn roles(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
         body.push_str("</tbody></table>");
     }
 
-    Ok(layout(&s.hub_name, "Roles", &body))
+    Ok(layout(&s, "Roles", &body))
 }
 
 async fn ledger_list(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -298,7 +307,7 @@ async fn ledger_list(State(s): State<RestState>) -> Result<Html<String>, AdminEr
         entries.len(),
         render_ledger_table(&entries),
     );
-    Ok(layout(&s.hub_name, "Ledger", &body))
+    Ok(layout(&s, "Ledger", &body))
 }
 
 async fn ledger_detail(
@@ -347,7 +356,7 @@ async fn ledger_detail(
         html_escape(&entry.signature),
         html_escape(&event_json),
     );
-    Ok(layout(&s.hub_name, &format!("Entry #{}", index), &body))
+    Ok(layout(&s, &format!("Entry #{}", index), &body))
 }
 
 async fn council(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -410,7 +419,7 @@ async fn council(State(s): State<RestState>) -> Result<Html<String>, AdminError>
         body.push_str("</tbody></table>");
     }
 
-    Ok(layout(&s.hub_name, "Council", &body))
+    Ok(layout(&s, "Council", &body))
 }
 
 async fn pairs(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -483,7 +492,7 @@ async fn pairs(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
         );
     }
 
-    Ok(layout(&s.hub_name, "Pairs", &body))
+    Ok(layout(&s, "Pairs", &body))
 }
 
 async fn law(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -518,7 +527,7 @@ async fn law(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
             body.push_str("</pre>");
         }
     }
-    Ok(layout(&s.hub_name, "Law", &body))
+    Ok(layout(&s, "Law", &body))
 }
 
 // ---------- shared bits ----------
@@ -818,7 +827,7 @@ pub(crate) async fn joins_page(State(s): State<RestState>) -> Result<Html<String
         body.push_str("</tbody></table>");
     }
     body.push_str(OPERATOR_JS);
-    Ok(layout(&s.hub_name, "Admission queue", &body))
+    Ok(layout(&s, "Admission queue", &body))
 }
 
 pub(crate) async fn manage_page(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -868,7 +877,7 @@ pub(crate) async fn manage_page(State(s): State<RestState>) -> Result<Html<Strin
         body.push_str("</tbody></table>");
     }
     body.push_str(OPERATOR_JS);
-    Ok(layout(&s.hub_name, "Manage members", &body))
+    Ok(layout(&s, "Manage members", &body))
 }
 
 /// Operator-plane GUI pages (admit/deny + member management). Mounted ONLY on

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -1002,7 +1002,8 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String, a
     let admin_state = rest_state.clone();
     let gate_state = rest_state.clone();
     // Operator plane (separate 127.0.0.1-only listener) shares the same RestState.
-    let operator_state = rest_state.clone();
+    let mut operator_state = rest_state.clone();
+    operator_state.operator_plane = true; // this clone serves the write pages → show their nav links
     let operator_gate = rest_state.clone();
     let app = mcp_router(mcp_state)
         .merge(rest_router(rest_state))

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -89,6 +89,11 @@ pub struct RestState {
     pub paths: HubPaths,
     pub hub_id: Uuid,
     pub hub_name: String,
+    /// True only for the loopback-only operator-plane listener (the one that
+    /// serves the write pages). Plain bool (not shared): set on the cloned
+    /// RestState handed to the operator app, so the admin nav can show the
+    /// write-page links (`/admin/joins`, `/admin/manage`) only where they exist.
+    pub operator_plane: bool,
     pub sovereign_lct_id: Uuid,
     /// The signer abstraction, behind a `SwappableSigner` so the hub can be
     /// promoted **locked → unlocked at runtime** (the unlock slot swaps the
@@ -338,6 +343,7 @@ impl RestState {
                 },
             )),
             notifications: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            operator_plane: false,
         })
     }
 
@@ -399,6 +405,7 @@ impl RestState {
             protected: Arc::new(Mutex::new(None)),
             store_key: Arc::new(tokio::sync::RwLock::new(None)),
             notifications: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            operator_plane: false,
         })
     }
 
@@ -4279,6 +4286,21 @@ norms:
 
         // Removing a non-member errors.
         assert!(remove_member_live(&state, Uuid::new_v4(), None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn admin_nav_is_plane_aware() {
+        let (_tmp, mut state) = fresh_rest_state(None).await;
+        // Fleet plane (default): the read-only dashboard must NOT advertise the
+        // operator-only write pages (they'd 404 there).
+        let html = crate::admin::members(State(state.clone())).await.unwrap().0;
+        assert!(!html.contains("/admin/joins"), "fleet nav must not link operator pages");
+        assert!(!html.contains("/admin/manage"), "fleet nav must not link operator pages");
+        // Operator plane: the same page DOES surface the write-page nav links.
+        state.operator_plane = true;
+        let html = crate::admin::members(State(state.clone())).await.unwrap().0;
+        assert!(html.contains("/admin/joins") && html.contains("/admin/manage"),
+            "operator nav links the write pages");
     }
 
     #[tokio::test]


### PR DESCRIPTION
The admin nav advertised the operator write pages (Joins/Manage) on both listeners, but they exist only on the loopback operator plane (8772) → dead 404 links on the read-only fleet plane (8770). Adds a per-listener `operator_plane` flag (set on the operator state clone) and renders those nav links only there. 28 daemon tests (new: admin_nav_is_plane_aware).