### PR TITLE
hub: idempotence guards for pairing + council add

### DIFF
--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -599,6 +599,12 @@ async fn run_council(sub: CouncilCommand) -> Result<()> {
                 anyhow::bail!("--pubkey must be 32 bytes (got {})", decoded.len());
             }
             let mut session = HubSession::open(&hub_dir).await?;
+            // Idempotency: don't double-admit an existing holder (the projection
+            // would absorb it as a set-insert, but the ledger would carry a
+            // redundant CouncilMemberAdded).
+            if session.state().council_holders.contains(&member_lct_id) {
+                anyhow::bail!("{} is already a Sovereign Council holder", member_lct_id);
+            }
             let entry = session.add_council_member(member_lct_id, pubkey, name.clone()).await?;
             println!("Council member added.");
             println!("  Member LCT:   {}", member_lct_id);

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -3542,6 +3542,23 @@ async fn submit_pair_request(
             String::from("self-pair (initiator == counterparty) is not allowed")
         ));
     }
+    // Idempotency / no-duplicate: refuse if a Pending or Active pair between
+    // these two LCTs already exists (either direction). Without this, repeated
+    // pair_requests pile up parallel live pairs for the same relationship.
+    let dup = projected.pairs.values().any(|p| {
+        matches!(p.status, PairStatus::Pending | PairStatus::Active)
+            && p.includes(envelope.signer_lct_id)
+            && p.includes(payload.counterparty_lct_id)
+    });
+    if dup {
+        return Err(ApiError {
+            status: StatusCode::CONFLICT,
+            message: format!(
+                "a pending or active pair with {} already exists",
+                payload.counterparty_lct_id
+            ),
+        });
+    }
 
     let pair_id = Uuid::new_v4();
     let event = HubEvent::PairingRequested {


### PR DESCRIPTION
The two request-level gaps from the idempotence review: `submit_pair_request` now refuses (409) a duplicate Pending/Active pair between the same two LCTs (either direction); `council add` (CLI) bails if the LCT is already a holder. Projection was already idempotent; these close the request layer. Build + 29/155 tests green.