### PR TITLE
hub: operator sets admission limits by amending hub law (inspectable)

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -785,6 +785,15 @@ function addMember(){
 function grantReview(id){ if(confirm('Grant this review? Clears the applicant’s auto-block so they can apply again.')) hubAct('/admin/api/reviews/'+id+'/grant'); }
 function refuseReview(id){ const reason=prompt('Refuse review — reason (optional):'); if(reason!==null) hubAct('/admin/api/reviews/'+id+'/refuse',{reason:reason||null}); }
 function admissionReset(){ const lct=prompt('Admission-reset which LCT id? (clears denial + review standing)'); if(!lct) return; const reason=prompt('Reason (optional):'); if(reason!==null) hubAct('/admin/api/members/'+lct.trim()+'/admission-reset',{reason:reason||null}); }
+function setLimits(){
+  const rt=document.getElementById('lim-repeat').value.trim();
+  const rv=document.getElementById('lim-review').value.trim();
+  const body={};
+  if(rt!=='') body.repeat_limit=parseInt(rt,10);
+  if(rv!=='') body.review_limit=parseInt(rv,10);
+  if(Object.keys(body).length===0){ alert('Enter at least one limit to set.'); return; }
+  if(confirm('Write these admission limits to hub law? (witnessed amendment)')) hubAct('/admin/api/admission-limits',body);
+}
 </script>"#;
 
 pub(crate) async fn joins_page(State(s): State<RestState>) -> Result<Html<String>, AdminError> {
@@ -801,8 +810,39 @@ pub(crate) async fn joins_page(State(s): State<RestState>) -> Result<Html<String
     });
     let pending = joins.iter().filter(|j| j.status == JoinStatus::Pending).count();
 
+    // Admission policy (the repair-path limits) — effective values from hub law,
+    // or code defaults if unset. Setting them writes hub law (witnessed).
+    let (repeat_limit, review_limit, src) = match s.law.read().await.as_ref() {
+        Some(l) => {
+            let in_law = l.admission.as_ref()
+                .map(|a| a.repeat_limit.is_some() || a.review_limit.is_some())
+                .unwrap_or(false);
+            (l.admission_repeat_limit(), l.admission_review_limit(),
+             if in_law { "from hub law" } else { "default (not yet in law)" })
+        }
+        None => (
+            hub_lib::law::DEFAULT_ADMISSION_REPEAT_LIMIT,
+            hub_lib::law::DEFAULT_ADMISSION_REVIEW_LIMIT,
+            "default (no law set)",
+        ),
+    };
+
     let mut body = String::from(OPERATOR_BANNER);
-    body.push_str("<h2>Admission queue</h2>");
+    body.push_str("<h2>Admission policy</h2>");
+    body.push_str(&format!(
+        "<p class=\"muted\">Retries before auto-block: <b>{repeat_limit}</b> · denial-reviews (appeals) \
+         before terminal: <b>{review_limit}</b> &nbsp;<span class=\"pill\">{src}</span>. \
+         Setting these <b>amends hub law</b> (witnessed, inspectable) — the single source of truth.</p>"
+    ));
+    body.push_str(&format!(
+        "<div style=\"display:grid;grid-template-columns:max-content 1fr;gap:0.4rem 0.6rem;max-width:520px;align-items:center;\">\
+         <label>Retries (repeat_limit)</label><input id=\"lim-repeat\" type=\"number\" min=\"1\" placeholder=\"{repeat_limit}\" style=\"padding:0.3rem;width:6rem;\">\
+         <label>Appeals (review_limit)</label><input id=\"lim-review\" type=\"number\" min=\"0\" placeholder=\"{review_limit}\" style=\"padding:0.3rem;width:6rem;\">\
+         <span></span><span><button onclick=\"setLimits()\">Write to hub law</button></span>\
+         </div>"
+    ));
+
+    body.push_str("<h2 style=\"margin-top:1.5rem\">Admission queue</h2>");
     body.push_str(&format!(
         "<p class=\"muted\">{} pending · {} total. Law-<code>Allow</code> joins are auto-admitted and never queue; \
          only law-<code>Escalate</code> requests land here.</p>",

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2960,8 +2960,58 @@ async fn admin_admission_reset(
     Ok(Json(serde_json::json!({ "reset": true, "entry_index": entry_index })))
 }
 
+#[derive(Deserialize)]
+struct AdmissionLimitsBody {
+    #[serde(default)]
+    repeat_limit: Option<u32>,
+    #[serde(default)]
+    review_limit: Option<u32>,
+}
+
+/// `POST /admin/api/admission-limits` — set the admission repeat/review limits by
+/// **amending chapter law** (law is the single inspectable source of truth — the
+/// operator's choice is written there, witnessed via LawAmended, not a side
+/// config). Requires a base law to exist (`hub init-law`).
+async fn admin_set_admission_limits(
+    State(s): State<RestState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(body): Json<AdmissionLimitsBody>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_loopback(&peer)?;
+    let mut law = s.law.read().await.clone().ok_or_else(|| ApiError::bad_request(
+        "no hub law set — run `hub init-law` first, then set admission limits".to_string(),
+    ))?;
+    {
+        let adm = law.admission.get_or_insert_with(Default::default);
+        if let Some(r) = body.repeat_limit { adm.repeat_limit = Some(r); }
+        if let Some(r) = body.review_limit { adm.review_limit = Some(r); }
+    }
+    let yaml = serde_yaml::to_string(&law)
+        .map_err(|e| ApiError::internal(anyhow::anyhow!("serializing law: {e}")))?;
+    // Sanity: the amended law must still parse + validate.
+    hub_lib::law::Law::parse_and_validate(&yaml)
+        .map_err(|e| ApiError::internal(anyhow::anyhow!("amended law invalid: {e}")))?;
+    {
+        let mut ledger = s.ledger.lock().await;
+        ledger.store_mut().write_law(&yaml).await.map_err(ApiError::internal)?;
+    }
+    let entry_index = witness_event(&s, HubEvent::LawAmended {
+        new_law_sha256: hub_lib::law::Law::sha256_hex_of(&yaml),
+        amended_by: s.sovereign_lct_id,
+        version: law.version.clone(),
+        diff_summary: Some("admission limits set via operator plane".to_string()),
+    }).await?;
+    let (repeat_limit, review_limit) = (law.admission_repeat_limit(), law.admission_review_limit());
+    *s.law.write().await = Some(law);
+    Ok(Json(serde_json::json!({
+        "updated": true, "entry_index": entry_index,
+        "repeat_limit": repeat_limit, "review_limit": review_limit,
+    })))
+}
+
 pub fn admin_api_router(state: RestState) -> Router {
     Router::new()
+        .route("/admin/api/admission-limits", post(admin_set_admission_limits))
         .route("/admin/api/joins", get(admin_list_joins))
         .route("/admin/api/joins/:request_id/admit", post(admin_admit_join))
         .route("/admin/api/joins/:request_id/deny", post(admin_deny_join))
@@ -4768,6 +4818,56 @@ norms:
         assert!(html.contains("Denial reviews"), "review queue section");
         assert!(html.contains("grantReview(") && html.contains("refuseReview("), "review buttons wired");
         assert!(html.contains("admissionReset("), "admission-reset control wired");
+        // The admission-policy (limits) section + law-writing form render too.
+        assert!(html.contains("Admission policy"), "policy section");
+        assert!(html.contains("setLimits(") && html.contains("Write to hub law"), "limits form wired to law");
+    }
+
+    #[tokio::test]
+    async fn operator_sets_admission_limits_by_amending_law() {
+        const BASE_LAW: &str = r#"
+version: "1.0.0"
+norms:
+  - id: ADMISSION-REQUIRES-SOVEREIGN
+    selector: r6.request.action
+    operator: "=="
+    value: member_join_request
+    decision: escalate
+    priority: 100
+"#;
+        let (_tmp, state) = fresh_rest_state(Some(BASE_LAW)).await;
+        let loop_addr: SocketAddr = "127.0.0.1:5555".parse().unwrap();
+        let remote: SocketAddr = "10.0.0.9:5555".parse().unwrap();
+
+        // Defaults until set (no admission section in the base law).
+        assert_eq!(state.law.read().await.as_ref().unwrap().admission_review_limit(), 1);
+
+        // Remote caller rejected.
+        assert_eq!(
+            admin_set_admission_limits(State(state.clone()), ConnectInfo(remote),
+                Json(AdmissionLimitsBody { repeat_limit: Some(5), review_limit: Some(2) }))
+                .await.err().unwrap().status,
+            StatusCode::FORBIDDEN,
+        );
+        // Operator sets them → written to law (live + witnessed).
+        admin_set_admission_limits(State(state.clone()), ConnectInfo(loop_addr),
+            Json(AdmissionLimitsBody { repeat_limit: Some(5), review_limit: Some(2) }))
+            .await.unwrap();
+        let law = state.law.read().await.clone().unwrap();
+        assert_eq!(law.admission_repeat_limit(), 5);
+        assert_eq!(law.admission_review_limit(), 2);
+        assert!(law.admission.as_ref().unwrap().repeat_limit == Some(5), "persisted in the law's admission section");
+        // A LawAmended was witnessed.
+        let amended = {
+            let l = state.ledger.lock().await;
+            l.entries().iter().any(|e| e.event.kind() == "law_amended")
+        };
+        assert!(amended, "the change is witnessed as a LawAmended");
+        // And it round-trips through the on-disk store (re-projects to the same values).
+        let persisted = state.open_store().await.unwrap().read_law().await.unwrap().unwrap();
+        let reparsed = hub_lib::law::Law::parse_and_validate(&persisted).unwrap();
+        assert_eq!(reparsed.admission_repeat_limit(), 5);
+        assert_eq!(reparsed.admission_review_limit(), 2);
     }
 
     #[tokio::test]

--- a/hub/hub-lib/src/law.rs
+++ b/hub/hub-lib/src/law.rs
@@ -142,7 +142,7 @@ pub struct EscalationTrigger {
     pub description: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AdmissionPolicy {
     #[serde(default)]
     pub open: bool,


### PR DESCRIPTION
Closes the gap you flagged — the admission retry/appeal policy lived only as code defaults, invisible in the law. Adds POST /admin/api/admission-limits (loopback) that amends hub law (write_law + witnessed LawAmended + live reload), an operator GUI 'Admission policy' section showing effective retries/appeals + a form to write them, and surfaces the effective values (default vs from-law). Law stays the single inspectable source of truth. 31 daemon + 155 lib green (law write/persist/witness/round-trip test).