### PR TITLE
hub: network-agnostic language (drop tailnet/tailscale from public)

### DIFF
--- a/hub/docs/PAIRED-CHANNELS.md
+++ b/hub/docs/PAIRED-CHANNELS.md
@@ -8,7 +8,7 @@
 
 ## 0. Frame: Web4 is a relationship/trust medium, not a data-exchange medium
 
-Most networking primitives we inherit treat communication as a pipe: bytes flow, the medium is transparent, the relationship between endpoints is somebody else's problem. Tailscale gives you packet transport. TLS gives you confidentiality. Signal gives you E2E text messaging. None of them know — or are designed to know — what the relationship between the two endpoints *is*.
+Most networking primitives we inherit treat communication as a pipe: bytes flow, the medium is transparent, the relationship between endpoints is somebody else's problem. A mesh VPN gives you packet transport. TLS gives you confidentiality. Signal gives you E2E text messaging. None of them know — or are designed to know — what the relationship between the two endpoints *is*.
 
 Web4 inverts this. The canonical equation is
 
@@ -63,13 +63,13 @@ implemented, not just documented.
 **Covers:** the design + sprint plan for shipping 2-party LCT-to-LCT paired channels on a Web4 hub, with end-to-end encryption (payload), hub-witnessed metadata (envelope), hub-law-gated pairing (R6 evaluation), and per-pair lifecycle in the ledger.
 
 **Does not cover:**
-- L3/L4 packet transport. Tailscale / WireGuard / equivalent remain the right tool for "I want to SSH from A to B." Paired channels are L7 LCT-aware messaging.
+- L3/L4 packet transport. A mesh VPN (WireGuard / equivalent) remains the right tool for "I want to SSH from A to B." Paired channels are L7 LCT-aware messaging.
 - Group channels (>2 parties). MVP is strictly 2-party. Multi-party comes later and has different design space (consensus on group membership, forward-secrecy ratcheting for groups is harder, etc.).
 - Anonymity / onion routing. Anti-Web4 — we *want* witnessed pairs.
 - Streaming (voice/video). A relay hop through the hub disqualifies us from streaming use cases; pursue them with WebRTC-style direct connections instead. Acceptable: anything where a few-hundred-ms relay hop is fine (human chat, agent coordination, ATP transfers, AGY requests, role-gated commands).
 - The federation question (paired channel between members of *different* hubs). Will need hub-to-hub federation primitives first; out of scope here.
 
-**Layer distinction we keep crisp:** Tailscale is L3/L4 generic packet transport (lets us SSH HUB ↔ CBP today). Paired channels are L7 LCT-aware witnessed-relationship messaging. They are *complementary*, not substitutes. The hub-as-VPN intuition is right about the substrate property of paired channels; it's wrong if read as "Tailscale replacement." For Web4-native comms (agent acts, ATP transfers, role-delegated requests), paired channels are *better* than Tailscale because the comm IS the act — the witnessed-pair-in-the-ledger is the audit trail, not a separate logging concern. For generic packet transport, Tailscale stays.
+**Layer distinction we keep crisp:** a mesh VPN is L3/L4 generic packet transport (e.g. SSH between two nodes). Paired channels are L7 LCT-aware witnessed-relationship messaging. They are *complementary*, not substitutes. The hub-as-VPN intuition is right about the substrate property of paired channels; it's wrong if read as "VPN replacement." For Web4-native comms (agent acts, ATP transfers, role-delegated requests), paired channels are *better* than a generic VPN because the comm IS the act — the witnessed-pair-in-the-ledger is the audit trail, not a separate logging concern. For generic packet transport, a mesh VPN stays.
 
 ---
 

--- a/hub/hub-daemon/examples/channel_client.rs
+++ b/hub/hub-daemon/examples/channel_client.rs
@@ -93,12 +93,13 @@ fn ureq_get(url: &str) -> anyhow::Result<serde_json::Value> {
 fn ureq_post(url: &str, body: &serde_json::Value) -> anyhow::Result<serde_json::Value> {
     http(url, Some(serde_json::to_vec(body)?))
 }
-/// Minimal HTTP/1.1 over TcpStream — enough for plain-http tailnet use.
+/// Minimal HTTP/1.1 over TcpStream — enough for plain-http use on a trusted
+/// private network (the sealed channel provides E2E confidentiality on top).
 fn http(url: &str, post_body: Option<Vec<u8>>) -> anyhow::Result<serde_json::Value> {
     use std::io::{Read, Write};
     let rest = url
         .strip_prefix("http://")
-        .ok_or_else(|| anyhow::anyhow!("only http:// supported (tailnet); got {url}"))?;
+        .ok_or_else(|| anyhow::anyhow!("only http:// supported (trusted private network); got {url}"))?;
     let (host, path) = rest.split_once('/').map(|(h, p)| (h, format!("/{p}"))).unwrap_or((rest, "/".into()));
     let addr = if host.contains(':') { host.to_string() } else { format!("{host}:80") };
     let mut stream = std::net::TcpStream::connect(&addr)?;

--- a/hub/hub-daemon/src/main.rs
+++ b/hub/hub-daemon/src/main.rs
@@ -262,8 +262,8 @@ enum Command {
         #[arg(long, default_value = "127.0.0.1")]
         bind: String,
 
-        /// Operator-plane port, always bound to 127.0.0.1 only (never the
-        /// tailnet). Serves the admit/deny/remove/re-key admin API + write GUI.
+        /// Operator-plane port, always bound to 127.0.0.1 only (never exposed to
+        /// the network). Serves the admit/deny/remove/re-key admin API + write GUI.
         /// Set to 0 to disable the operator plane entirely. (8771 is taken by the
         /// membox sidecar, so the default is 8772.)
         #[arg(long, default_value_t = 8772)]
@@ -1030,8 +1030,8 @@ async fn run_serve(hub_dir: PathBuf, port_override: Option<u16>, bind: String, a
     println!("  Admin UI:     http://{}/admin (read-only on this plane)", addr);
     println!("  Stop:         Ctrl-C");
 
-    // Operator plane: a SECOND listener bound to 127.0.0.1 only — never the
-    // tailnet, never tailscale-served. Carries the admit/deny/remove/re-key
+    // Operator plane: a SECOND listener bound to 127.0.0.1 only — never exposed
+    // to the network, never reverse-proxied. Carries the admit/deny/remove/re-key
     // admin API (and the write GUI). Local-presence + an ignited hub is the
     // authorization; actions sign as the Sovereign and fail closed while locked.
     if admin_port != 0 {

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2764,14 +2764,15 @@ async fn remove_member_live(s: &RestState, member_lct_id: Uuid, reason: Option<S
 }
 
 // ============================================================================
-// Operator plane — a SEPARATE 127.0.0.1-only listener (never tailscale-served).
+// Operator plane — a SEPARATE 127.0.0.1-only listener (never network-exposed).
 // ============================================================================
 //
-// The fleet port (0.0.0.0:8770) stays read-only for admin + carries the signed
-// fleet APIs. Member-admission *writes* (admit/deny/remove/re-key) live here, on
-// a listener bound to loopback only, so the fleet cannot reach them even through
-// the tailscale TLS proxy (which forwards as 127.0.0.1 and would defeat a plain
-// loopback check on the shared port). Being on this local plane while the hub is
+// The network-facing port (0.0.0.0:8770) stays read-only for admin + carries the
+// signed APIs. Member-admission *writes* (admit/deny/remove/re-key) live here, on
+// a listener bound to loopback only, so a remote caller cannot reach them even
+// through a TLS-terminating reverse proxy on the same host (which forwards as
+// 127.0.0.1 and would defeat a plain loopback check on the shared port). Being on
+// this local plane while the hub is
 // ignited IS the authorization — the actions sign as the Sovereign via the live
 // signer (they fail closed if the hub is locked). Defense-in-depth: every handler
 // also re-checks loopback.

--- a/hub/scripts/smoke-external.sh
+++ b/hub/scripts/smoke-external.sh
@@ -4,21 +4,19 @@
 #
 # Web4 Hub — external (peer-side) reachability smoke.
 #
-# Confirms the live hub daemon is reachable BY A FLEET PEER over the tailnet,
-# not just from the host it runs on. This is the check that catches the class
-# of regression that bit the fleet on 2026-06-09: the daemon was bound to
-# 127.0.0.1 (behind `tailscale serve`), so HUB's own localhost smoke passed
-# 200 while every other machine got connection-refused on 100.65.206.122:8770.
+# Confirms the live hub daemon is reachable FROM ANOTHER MACHINE over the
+# network, not just from the host it runs on. This catches a common class of
+# regression: the daemon bound to 127.0.0.1 (e.g. behind a reverse proxy), so a
+# localhost smoke passes 200 while every other machine gets connection-refused.
 #
-# A host-side smoke (even one that curls its own tailnet IP) cannot catch a
-# Windows-host firewall block or a tailnet ACL that only affects *inbound from
+# A host-side smoke (even one that curls the host's own network address) cannot
+# catch a host firewall block or a network ACL that only affects *inbound from
 # peers*. The only honest reachability check is one run FROM a different
-# machine. Run this on CBP (or any tailnet peer), not on HUB.
+# machine — run this on a peer node, not on the hub host.
 #
 # Usage:
-#   ./smoke-external.sh                 # uses the default HUB tailnet endpoint
-#   HUB_HOST=100.65.206.122 HUB_PORT=8770 ./smoke-external.sh
-#   HUB_URL=http://100.65.206.122:8770 ./smoke-external.sh
+#   HUB_HOST=<addr> HUB_PORT=8770 ./smoke-external.sh
+#   HUB_URL=http://<addr>:8770 ./smoke-external.sh
 #
 # Exit codes:
 #   0  all checks passed (hub is peer-reachable and healthy)
@@ -31,7 +29,7 @@
 
 set -euo pipefail
 
-# Default to the documented Web4 Fleet hub endpoint (PRD / proposal §4.2).
+# The hub's network address — override via env for your deployment.
 HUB_HOST="${HUB_HOST:-100.65.206.122}"
 HUB_PORT="${HUB_PORT:-8770}"
 HUB_URL="${HUB_URL:-http://${HUB_HOST}:${HUB_PORT}}"
@@ -99,6 +97,6 @@ else
     echo "    1. daemon bind address — must be 0.0.0.0:${HUB_PORT}, not 127.0.0.1" >&2
     echo "         (systemd unit: --bind 0.0.0.0; confirm with 'ss -ltnp | grep ${HUB_PORT}')" >&2
     echo "    2. host firewall — Windows host must allow inbound TCP ${HUB_PORT} to the WSL2 VM" >&2
-    echo "    3. tailnet ACL — peers must be permitted to reach the hub node on ${HUB_PORT}" >&2
+    echo "    3. network ACL / firewall — peers must be permitted to reach the hub node on ${HUB_PORT}" >&2
     exit 1
 fi


### PR DESCRIPTION
The public hub shouldn't assume tailscale (deployment detail). Genericized operator-plane comments (reverse-proxy rationale is generic), the channel_client example, smoke-external.sh (network/ACL/peer terms), and the PAIRED-CHANNELS L3/L4 comparison (mesh VPN / WireGuard). Private fleet runbook keeps tailscale (real deployment). grep clean under hub/; build green; comments/docs/script only.