### PR TITLE
remediate(C122): apply C118-N2 to core-spec/t3-v3-tensors.md (C82→C83→C121→C122)

### DIFF
--- a/docs/audits/C122-t3-v3-tensors-remediation-2026-07-01.md
+++ b/docs/audits/C122-t3-v3-tensors-remediation-2026-07-01.md
@@ -1,0 +1,64 @@
+# C122 Remediation: `t3-v3-tensors.md` — apply C118-N2
+
+**Date**: 2026-07-01
+**Author**: Autonomous session (Legion, web4 track) — REMEDIATION turn, slot `000036`
+**Document**: `web4-standard/core-spec/t3-v3-tensors.md`
+**Lineage**: C13 → C42 → **C43** (PR #299) → C82 → **C83** (PR #374, `25d36bb0`) → C121 (3rd delta AUDIT, PR #425, `59b21d5e`) → **C122** (this remediation).
+**Finding applied**: **C118-N2** (raised at atp-adp C118, `C118-atp-adp-cycle-2nd-delta-2026-06-29.md`; CONFIRMED live at t3-v3 C121 §B.3, `C121-t3-v3-tensors-3rd-delta-2026-06-30.md`).
+**Type**: Single citation-precision cell edit. Autonomous-in-file. Spec-only.
+
+---
+
+## The defect (C118-N2, as confirmed at C121)
+
+`t3-v3-tensors.md` §10.2 protocol-invariants table, the **ATP conservation** row (L640, post-C83).
+
+The C83 F2 remediation reworded this row's "Related context" cell to **primary-anchor on atp-adp §6.3** ("Transfer Fees") while **quoting**:
+- the supply equation `total supply = ATP + ADP`, and
+- the per-transfer form `initial == final + fees`.
+
+Neither quoted element lives in §6.3. Verified against the **live** `atp-adp-cycle.md` (frozen in the relevant sections; C119 `e99b419e` touched only §4.2/§7.1):
+
+| Quoted element | True home section | Live evidence |
+|----------------|-------------------|---------------|
+| `total supply = ATP + ADP` (supply equation) | **§3.1 / §3.2** | §3.1 "Pool Architecture" (header L219; `total_supply` L227); §3.2 "Pool Management" (header L248; `total_supply == sum(...)` invariant L266) |
+| `initial == final + fees` (per-transfer invariant) | **§2.4** | §2.4 "Slashing (ATP Destruction)" (header L170; the string at L214, scoping ATP→ADP transfers) |
+| "preserving total supply" (looser, via fee-recycling) | **§6.3** | §6.3 "Transfer Fees" (header L593; fee-recycling "total supply" L605) — this is the *only* claim §6.3 actually supports |
+
+So the cell primary-anchored §6.3 (which supports only the loosest claim) while quoting strings from §2.4 and §3.1/§3.2 — an anchor/quote mismatch **introduced by C83's own F2 reword** (a [[feedback_remediation_introduced_regression]] instance; caught by the atp-adp sibling audit reading t3-v3's outbound citation, not by t3-v3's own delta — cf. [[feedback_snapshot_presence_guard]]).
+
+**Severity**: LOW (citation precision). The invariant text itself was already correct — total supply is conserved, transfers preserve it, slashing is the deliberate exception. **Owner**: t3-v3 (atp-adp is read-only here). C118 correctly routed this flag-only to the t3-v3 track; C121 confirmed it live and routed it to this remediation turn.
+
+## The fix
+
+The "Related context" cell now routes each element to its true home:
+
+**Before** (L640):
+```
+| ATP conservation | total supply = ATP + ADP (transfers preserve total supply; the per-transfer form is `initial == final + fees`) | [`atp-adp-cycle.md`](atp-adp-cycle.md) §6.3 (§2.4 Slashing is the deliberate exception) | — |
+```
+
+**After**:
+```
+| ATP conservation | total supply = ATP + ADP (transfers preserve total supply; the per-transfer form is `initial == final + fees`) | [`atp-adp-cycle.md`](atp-adp-cycle.md) §3.1/§3.2 (supply equation `total supply = ATP + ADP`), §2.4 (per-transfer invariant `initial == final + fees`; Slashing is the deliberate exception), §6.3 (fee-recycling preserves total supply) | — |
+```
+
+Only the "Related context" column changed. The Parameter, Value, and Test-vector columns are byte-identical. The invariant statement (Value column) is untouched — this is precision, not a normative change.
+
+## Verification
+
+- Each cited anchor confirmed present in the live `atp-adp-cycle.md` at the line noted in the table above (grep-verified this session, not from memory — the C56 remediation discipline).
+- No change to `atp-adp-cycle.md` (read-only sibling; not the defect site).
+- No change to SDK / test-vectors / ontology.
+- No operator-gated carry touched (D1 ontology-vocab, D3/M4 Valuation range, F1 minimal-vs-neutral, L3 t3v3-010 label, X4-structural, attach-strategy all remain open and untouched).
+- No corpus-wide MUST sweep (C120→C121 signal: the MUST-vs-reference-impl class is doc-specific; N2 was a citation, not a missing carve-out — nothing to sweep).
+
+## Disposition
+
+- **C118-N2**: **CLOSED** by this edit.
+- t3-v3 remediation debt after this turn: **none** autonomous. Remaining open items are operator/SDK-gated carries (see carries.md).
+- Next t3-v3 AUDIT turn (rotation advances t3-v3 → reputation-computation) should verify this cell held and re-read it vs the then-live atp-adp sections.
+
+---
+
+*Remediation complete. One spec-only cell re-anchor; invariant text unchanged; every anchor verified live.*

--- a/web4-standard/core-spec/t3-v3-tensors.md
+++ b/web4-standard/core-spec/t3-v3-tensors.md
@@ -637,7 +637,7 @@ constitute the complete normative definition.
 | 6D-to-3D bridge formula | primary×0.6 + secondary×(0.4/3) | [§2.5](#25-bridging-flat-6-dimensional-trust-schemas-into-the-3-roots) | t3v3-008 |
 | V3 calculation | valuation=(earned/expected)×satisfaction; veracity=(verified/total)×confidence; validity=1.0 if transferred else 0.0 | §3.3 | t3v3-014 |
 | Operational health formula | t3_composite×0.4 + v3_composite×0.3 + energy_ratio×0.3 (note: test vector t3v3-010 labels this "coherence" — this is **not** identity coherence C×S×Phi×R from the whitepaper; it measures operational health) | — | t3v3-010 |
-| ATP conservation | total supply = ATP + ADP (transfers preserve total supply; the per-transfer form is `initial == final + fees`) | [`atp-adp-cycle.md`](atp-adp-cycle.md) §6.3 (§2.4 Slashing is the deliberate exception) | — |
+| ATP conservation | total supply = ATP + ADP (transfers preserve total supply; the per-transfer form is `initial == final + fees`) | [`atp-adp-cycle.md`](atp-adp-cycle.md) §3.1/§3.2 (supply equation `total supply = ATP + ADP`), §2.4 (per-transfer invariant `initial == final + fees`; Slashing is the deliberate exception), §6.3 (fee-recycling preserves total supply) | — |
 
 > **V3 Valuation range** is deliberately omitted from the table above: its
 > classification is the unresolved 3-way divergence flagged in the §3.1 open


### PR DESCRIPTION
## Summary

t3-v3 **REMEDIATION** turn (paired with the C121 AUDIT, PR #425). Applies **C118-N2** — a citation-precision defect raised at the atp-adp C118 audit and confirmed live at t3-v3 C121 §B.3.

**Defect**: the §10.2 protocol-invariants "ATP conservation" row (L640) primary-anchored its "Related context" citation on atp-adp **§6.3** (Transfer Fees) while *quoting* strings that live elsewhere:
- `total supply = ATP + ADP` (supply equation) → actually atp-adp **§3.1/§3.2**
- `initial == final + fees` (per-transfer invariant) → actually atp-adp **§2.4**
- §6.3 supports only the looser "preserving total supply" via fee-recycling.

This anchor/quote mismatch was **introduced by C83's own F2 reword** (a remediation-introduced regression; surfaced by the atp-adp sibling audit reading t3-v3's outbound citation, not by t3-v3's own delta).

**Fix**: one "Related context" cell re-anchored — §3.1/§3.2 for the supply equation, §2.4 for the per-transfer invariant + slashing exception, §6.3 for fee-recycling. **Invariant text (Value column) unchanged** — it was already correct; this is precision, not a normative change.

## Verification
- Every anchor grep-verified against the **live** atp-adp-cycle.md this session (§2.4 L170/L214, §3.1 L219/L227, §3.2 L248/L266, §6.3 L593/L605).
- Diff = 1 file, 1 line; Parameter/Value/Test-vector columns byte-identical.
- No change to atp-adp / SDK / vectors / ontology. No operator-gated carry touched. No corpus-wide sweep (C120→C121 signal: this class is doc-specific).

## Governance
v2 protocol; policy review **APPROVED** (independently re-verified the defect and anchors). Audit doc: `docs/audits/C122-t3-v3-tensors-remediation-2026-07-01.md`.

Closes **C118-N2**. t3-v3 now carries no autonomous remediation debt; rotation advances t3-v3 → reputation-computation for the next AUDIT turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)