### PR TITLE
remediate(C124): apply C123 to core-spec/reputation-computation.md (C85→C123→C124)

### DIFF
--- a/docs/audits/C124-reputation-computation-remediation-2026-07-01.md
+++ b/docs/audits/C124-reputation-computation-remediation-2026-07-01.md
@@ -1,0 +1,109 @@
+# C124: reputation-computation.md — Remediation (applies C123)
+
+**Date**: 2026-07-01
+**Author**: Autonomous session (legion-web4-20260701-120002), LEAD
+**Turn type**: REMEDIATION (alternation after C123 AUDIT)
+**Document**: `web4-standard/core-spec/reputation-computation.md`
+**Applies**: `docs/audits/C123-reputation-computation-3rd-delta-2026-07-01.md` (PR #428, `748326db`)
+**Lineage**: C13/C15 → C44 (#304) → C45 (#305) → C84 → C85 (#376 `15be0743`) → C123 (#428) → **C124** (this remediation)
+**Direction**: spec→SDK convergence only. NO SDK / test-vector / `.ttl` mutation.
+
+---
+
+## Scope
+
+Applied the **2 autonomous-actionable** findings from C123. The remaining C123 items
+(X-1 schema reshape, X-2 §10 staleness, NEW-1-SDK-face, r7-§1.7-stale-factor,
+SDK-6/N2 record-only) are **route-only / cross-track** and were NOT touched this turn.
+
+Both edits were re-verified against SDK source **this session** before applying:
+- `ReputationRule.matches()` (`reputation.py` L90–115): checks 4 recognized keys
+  (`action_type`, `result_status`, `quality_threshold`, `min_atp_stake`), then
+  `return True` — unrecognized keys silently ignored ⇒ **fail-OPEN**. Confirmed.
+- Negative-age clamps present at `reputation.py` L442 (`current()` `age_days`) and
+  L476 (`inactivity_decay()` `days_inactive`), both `max(0.0, …)`. Confirmed.
+- git provenance: none of `fail-closed` / `unrecognized condition` /
+  `Trigger Condition Semantics` exist in `15be0743^` — NEW-1's offending clause is
+  **C85 remediation-introduced** (a [[feedback_remediation_introduced_regression]]
+  catch, the pattern's 8th C-series confirmation). Confirmed.
+
+---
+
+## Applied
+
+### NEW-1 (MED) — §4 "Trigger Condition Semantics" fail-closed SHOULD ⊥ SDK fail-OPEN
+
+**Before** (§4 L295–296, added by C85):
+> Implementations MAY define additional conditions; an unrecognized condition
+> SHOULD cause the rule not to match (fail-closed) rather than be ignored.
+
+**After**:
+> Implementations MAY define additional conditions. The reference SDK
+> (`reputation.py` `ReputationRule.matches()`) evaluates only the recognized
+> conditions above and **ignores** any it does not recognize (**fail-open**): a
+> rule matches when all recognized conditions pass, regardless of extra keys.
+> An implementation MAY instead treat an unrecognized condition as fail-closed
+> (cause the rule not to match); this is a stricter local choice and is **not
+> currently required** for conformance.
+
+**Rationale**: the C85 clause asserted a normative SHOULD that the reference
+implementation does the exact opposite of. A conformant implementation following
+the old text would reject rules the SDK accepts. The rewrite converges the spec to
+the SDK's actual dispatch behavior (the established SDK→spec direction) and demotes
+fail-closed to an optional, non-required local choice — removing the false
+conformance claim **without silently changing SDK behavior via a spec edit**.
+Whether the SDK *should* be tightened to fail-closed (the more defensible design
+against malformed/adversarial rules) remains **NEW-1-SDK-face**, routed to the
+operator; NOT self-applied.
+
+Orphan check: `grep` for `fail-closed`/`unrecognized`/`ignored` confirmed the clause
+appears ONLY at §4 — no summary/checklist restatement survives as an orphan.
+
+### N1 (LOW) — §7 age pseudocode missing SDK's `max(0.0, …)` clamp
+
+**Before**:
+- L652 `age_days = (now() - delta.timestamp).total_seconds() / 86400.0  # fractional days (SDK parity)`
+- L703 `days_inactive = (now() - last_action_timestamp).total_seconds() / 86400.0`
+
+**After** (now L657 / L708 after §4 grew):
+- `age_days = max(0.0, (now() - delta.timestamp).total_seconds() / 86400.0)  # fractional days, floored at 0 for clock skew (SDK parity)`
+- `days_inactive = max(0.0, (now() - last_action_timestamp).total_seconds() / 86400.0)  # floored at 0 for clock skew (SDK parity)`
+
+**Rationale**: exact parity with SDK `current()` L442 / `inactivity_decay()` L476, which
+floor age at 0.0 to neutralize future-dated timestamps (clock skew). The pre-existing
+value clamps `max(0.0, min(1.0, …))` at L374/L388/L668/L733 are unrelated and untouched.
+
+---
+
+## NOT applied (route-only — carried forward)
+
+| ID | Disposition |
+|---|---|
+| **X-1** (MED, cross-track) | reputation-schema reshape: mcp §7.3 flat `trust_dimension_updates` ⊥ r7 §1.7 / this doc's `t3_delta`+`v3_delta` split. Belongs to the operator's mcp B2/B6 bundle. STILL OPEN. |
+| **X-2** (LOW, cross-track) | §10 "Future Evolution" stale vs mcp §7.5 normative; rides X-1. STILL OPEN. |
+| **NEW-1-SDK-face** | whether SDK `matches()` should be tightened to fail-closed — SDK-behavioral/security operator decision. Routed. |
+| **r7-§1.7-stale-factor** (LOW) | r7-framework §1.7 example still carries the pre-INT-1 `accuracy_threshold_exceeded` factor; belongs to a future r7 audit turn (routed outbound). |
+| **SDK-6/B-I5**, **N2** | record-only (§6 witness SDK gap; SDK write-back side-effect). Unchanged. |
+
+---
+
+## Verification
+
+- `grep max(0.0` → both new §7 clamps present (L657, L708); 4 pre-existing value clamps intact.
+- `grep fail-open/fail-closed` → 2 hits, both in the single rewritten §4 paragraph; no orphan.
+- Spec-only change; no SDK/vector/.ttl touched (`git diff --stat` = 1 spec file + this record).
+- Markdown structure intact (table + paragraph render unchanged around §4; §7 code block valid).
+
+**Result**: reputation-computation.md §4 no longer contradicts the reference SDK on
+unrecognized trigger conditions, and §7 age pseudocode matches the SDK's clock-skew
+flooring. reputation-computation is now at **zero autonomous spec-vs-SDK debt**; the
+only remaining items are cross-track/operator carries (X-1, X-2, NEW-1-SDK-face,
+r7-stale-factor) and record-only notes.
+
+---
+
+*C124 closes the two autonomous findings C123 opened. The NEW-1 catch — a prior
+remediation's own added prose over-reaching into a false conformance SHOULD — is the
+8th C-series confirmation of the remediation-introduced-regression pattern: always
+git-check net-new prose against `<remediation-commit>^` and re-test it against the
+SDK/canonical it claims to mirror.*

--- a/web4-standard/core-spec/reputation-computation.md
+++ b/web4-standard/core-spec/reputation-computation.md
@@ -292,8 +292,13 @@ matches only when **all** stated conditions hold). The conditions in common use:
 | `quality_threshold` | Matches **iff** `output.quality >= threshold`. A missing quality value is treated as `0.0`, so the threshold fails. |
 | `min_atp_stake` | Matches **iff** the action's staked ATP `>= min_atp_stake`. Lets rules apply only above a minimum economic commitment. |
 
-Implementations MAY define additional conditions; an unrecognized condition
-SHOULD cause the rule not to match (fail-closed) rather than be ignored.
+Implementations MAY define additional conditions. The reference SDK
+(`reputation.py` `ReputationRule.matches()`) evaluates only the recognized
+conditions above and **ignores** any it does not recognize (**fail-open**): a
+rule matches when all recognized conditions pass, regardless of extra keys.
+An implementation MAY instead treat an unrecognized condition as fail-closed
+(cause the rule not to match); this is a stricter local choice and is **not
+currently required** for conformance.
 
 ### Rule Categories
 
@@ -649,7 +654,7 @@ def compute_current_reputation(entity_lct, role_lct, dimension, time_horizon_day
     weight_sum = 0.0
 
     for delta in deltas:
-        age_days = (now() - delta.timestamp).total_seconds() / 86400.0  # fractional days (SDK parity)
+        age_days = max(0.0, (now() - delta.timestamp).total_seconds() / 86400.0)  # fractional days, floored at 0 for clock skew (SDK parity)
         recency_weight = math.exp(-age_days / 30.0)  # exp decay, 30-day time constant (1/e; ≈20.8-day half-life)
 
         weighted_sum += delta.change * recency_weight
@@ -700,7 +705,7 @@ def apply_reputation_decay(entity_lct, role_lct, last_action_timestamp):
     in role B decays only in role B. The SDK (`reputation.py`
     `inactivity_decay(entity_lct, role_lct)`) keys decay state the same way.
     """
-    days_inactive = (now() - last_action_timestamp).total_seconds() / 86400.0
+    days_inactive = max(0.0, (now() - last_action_timestamp).total_seconds() / 86400.0)  # floored at 0 for clock skew (SDK parity)
 
     if days_inactive < 30:
         return 0.0  # No decay within 30 days


### PR DESCRIPTION
## C124 — REMEDIATION turn (applies C123 audit PR #428)

Alternation after the C123 3rd-delta AUDIT. Applies the **2 autonomous-actionable** findings to `web4-standard/core-spec/reputation-computation.md`. Both spec-only, **spec→SDK convergence**; NO SDK / test-vector / `.ttl` change.

### NEW-1 (MED) — §4 fail-closed SHOULD ⊥ SDK fail-OPEN `matches()`
The C85 remediation itself added a "Trigger Condition Semantics" subsection whose closing clause asserted *"an unrecognized condition SHOULD cause the rule not to match (fail-closed) rather than be ignored"* — the **exact opposite** of the reference SDK `ReputationRule.matches()` (`reputation.py` L90–115), which inspects 4 recognized keys and returns `True` when they pass, **silently ignoring** unrecognized keys (fail-OPEN). A conformant implementation following the old text would reject rules the SDK accepts.

Rewrote §4 to describe the SDK's actual fail-open behavior and demote fail-closed to an optional, non-required local choice — removing the false conformance claim without silently changing SDK behavior via a spec edit.

- **git-verified provenance**: `fail-closed` / `Trigger Condition Semantics` are absent in `15be0743^` → the clause is **C85 remediation-introduced** (8th C-series confirmation of the remediation-introduced-regression pattern). C84's SDK-5 never asked for fail-closed conformance.
- Whether the SDK *should* be tightened to fail-closed = **NEW-1-SDK-face**, routed to the operator (SDK-behavioral/security decision); NOT self-applied.

### N1 (LOW) — §7 age pseudocode missing SDK clamp
Added `max(0.0, …)` to §7 `age_days` and `days_inactive` for exact parity with SDK `current()` (L442) / `inactivity_decay()` (L476), which floor age at 0.0 to neutralize future-dated timestamps (clock skew).

### Verification
- Both findings re-verified against SDK source this session before applying.
- Orphan check: fail-closed language existed only at §4 (no summary restatement survives).
- `git diff --stat` = 1 spec file + 1 audit record (`docs/audits/C124-...md`). Pre-existing value clamps `max(0.0,min(1.0,…))` untouched.

### NOT applied (route-only / cross-track — carried forward)
X-1 (reputation-schema reshape, mcp B2/B6 bundle), X-2 (§10 Future-Evolution stale vs mcp §7.5), NEW-1-SDK-face, r7-§1.7-stale-factor (future r7 audit turn), SDK-6/N2 (record-only).

### Governance
v2 protocol followed: propose → **policy review APPROVED** → execute → document. Session log: `private-context/autonomous-sessions/legion-web4-20260701-120002-session.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)