### PR TITLE
hub §5.3 v1: reputation projection — witness + fold ReputationDelta (role-contextualized)

### DIFF
--- a/hub/hub-daemon/src/admin.rs
+++ b/hub/hub-daemon/src/admin.rs
@@ -729,6 +729,15 @@ fn event_summary(event: &HubEvent) -> String {
                 html_escape(&act.substance.uri),
             )
         }
+        HubEvent::ReputationRecorded { delta } => format!(
+            "📊 reputation Δ for {} <span class=\"muted\">in role</span> {} \
+             <span class=\"muted\">(ΔT3 {:+.3}, ΔV3 {:+.3}) — {}</span>",
+            html_escape(&delta.subject_lct),
+            html_escape(&delta.role_lct),
+            delta.net_trust_change(),
+            delta.net_value_change(),
+            html_escape(&delta.reason),
+        ),
         HubEvent::MemberJoinRequested { member_lct_id, name, .. } => format!(
             "🚪 join requested by {} {} <span class=\"muted\">[escalated → review]</span>",
             short(member_lct_id),

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2103,6 +2103,52 @@ async fn dispatch_channel(
                 "truncated": total > limit.unwrap_or(total),
             }))
         }
+        // R7 reputation READ — the (subject, role) trust/value tensors accrued on
+        // this society's ledger. Role-contextualized (RFC #403): pass `role_lct` to
+        // scope to one role-pairing, or omit for all of the subject's role reps.
+        "reputation" => {
+            let Some(subject) = inner.args.get("subject_lct").and_then(|v| v.as_str()) else {
+                return Err(ApiError::bad_request("reputation requires 'subject_lct'".to_string()));
+            };
+            let role_filter = inner.args.get("role_lct").and_then(|v| v.as_str());
+            let mut out: Vec<serde_json::Value> = state.reputation.iter()
+                .filter(|((subj, role), _)| subj == subject && role_filter.is_none_or(|r| r == role))
+                .map(|((subj, role), rep)| serde_json::json!({
+                    "subject_lct": subj,
+                    "role_lct": role,
+                    "t3": rep.t3,
+                    "v3": rep.v3,
+                    "observations": rep.observations,
+                    "last_updated": rep.last_updated,
+                }))
+                .collect();
+            let total = out.len();
+            if let Some(n) = limit { out.truncate(n); }
+            Ok(serde_json::json!({
+                "reputation": out,
+                "total": total,
+                "truncated": total > limit.unwrap_or(total),
+            }))
+        }
+        // R7 reputation RECORD (Sovereign-only in v1) — witness a pre-computed
+        // `ReputationDelta` so it folds into the projection. The delta is produced by
+        // `web4_core::r6::compute_reputation` (factors × society-law weights); the hub
+        // records + applies it, it does NOT invent the scoring math.
+        "record_reputation" => {
+            if role != "sovereign" {
+                return Err(ApiError {
+                    status: StatusCode::FORBIDDEN,
+                    message: "record_reputation is Sovereign-only (v1)".to_string(),
+                });
+            }
+            let delta: web4_core::r6::ReputationDelta = inner.args.get("delta")
+                .cloned()
+                .and_then(|v| serde_json::from_value(v).ok())
+                .ok_or_else(|| ApiError::bad_request(
+                    "record_reputation requires 'delta' (a ReputationDelta)".to_string()))?;
+            let index = witness_event(s, HubEvent::ReputationRecorded { delta }).await?;
+            Ok(serde_json::json!({ "recorded": true, "entry_index": index }))
+        }
         "list_members" => {
             let all: Vec<&hub_lib::state::Member> = state.members.values().collect();
             let total = all.len();

--- a/hub/hub-lib/src/events.rs
+++ b/hub/hub-lib/src/events.rs
@@ -400,6 +400,14 @@ pub enum HubEvent {
     /// envelope (the daemon's `SealedNotice`), never duplicated onto this
     /// witnessed record — its integrity is bound instead by `content_hash`.
     ReferencedAct { act: Act },
+
+    /// R7 reputation back-propagation: a role-contextualized trust/value delta
+    /// recorded on the ledger — the *witnessed* half of reputation. The delta is
+    /// computed elsewhere (`web4_core::r6::compute_reputation` from factors ×
+    /// society-law weights); the hub records + applies it, never invents the math.
+    /// Reputation is NEVER global — the delta's `(subject_lct, role_lct)` scopes
+    /// it to an MRH role-pairing link (RFC #403).
+    ReputationRecorded { delta: web4_core::r6::ReputationDelta },
 }
 
 /// Why a pair ended. Captures audit-relevant intent so V3 trust
@@ -455,6 +463,7 @@ impl HubEvent {
             Self::VaultUnlockAttested { .. } => "vault_unlock_attested",
             Self::VaultUnlockResolved { .. } => "vault_unlock_resolved",
             Self::ReferencedAct { .. } => "referenced_act",
+            Self::ReputationRecorded { .. } => "reputation_recorded",
         }
     }
 }

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -83,8 +83,56 @@ pub struct HubState {
     /// (`admission_repeat_limit`/`admission_review_limit`), not here.
     pub admission: BTreeMap<Uuid, AdmissionStanding>,
 
+    /// Role-contextualized reputation, keyed by `(subject_lct, role_lct)` — the
+    /// projected side of R7 back-propagation. Reputation is NEVER global; it lives
+    /// on the MRH role-pairing link (RFC #403). Folded from `ReputationRecorded`.
+    pub reputation: BTreeMap<(String, String), RoleReputation>,
+
     /// Last seen index from the ledger (for cache invalidation in future).
     pub last_index: u64,
+}
+
+/// Accumulated role-contextualized reputation for one `(subject, role)` pairing.
+/// Folded from `ReputationRecorded` deltas via `T3/V3::apply_delta` — the hub
+/// applies the math but never invents it (weights are a society-law hook).
+#[derive(Clone, Debug, Serialize)]
+pub struct RoleReputation {
+    pub t3: web4_core::t3::T3,
+    pub v3: web4_core::v3::V3,
+    pub observations: u32,
+    pub last_updated: DateTime<Utc>,
+}
+
+impl RoleReputation {
+    fn new(ts: DateTime<Utc>) -> Self {
+        Self {
+            t3: web4_core::t3::T3::default(),
+            v3: web4_core::v3::V3::default(),
+            observations: 0,
+            last_updated: ts,
+        }
+    }
+}
+
+/// Map a `ReputationDelta` dimension name to the typed T3 dimension.
+fn trust_dim(s: &str) -> Option<web4_core::t3::TrustDimension> {
+    use web4_core::t3::TrustDimension::*;
+    match s {
+        "talent" => Some(Talent),
+        "training" => Some(Training),
+        "temperament" => Some(Temperament),
+        _ => None,
+    }
+}
+/// Map a `ReputationDelta` dimension name to the typed V3 dimension.
+fn value_dim(s: &str) -> Option<web4_core::v3::ValueDimension> {
+    use web4_core::v3::ValueDimension::*;
+    match s {
+        "valuation" => Some(Valuation),
+        "veracity" => Some(Veracity),
+        "validity" => Some(Validity),
+        _ => None,
+    }
 }
 
 /// Abuse-resistance counters for one applicant LCT (see [`HubState::admission`]).
@@ -464,6 +512,27 @@ impl HubState {
                 // charter.json / hub-law.yaml instead. Future sprints surface
                 // them here too.
             }
+            // R7 reputation: fold the delta into the (subject, role) tensors. The
+            // hub applies the delta (via T3/V3::apply_delta); the *weights* that
+            // produced it are a society-law hook, computed by the recorder.
+            HubEvent::ReputationRecorded { delta } => {
+                let rep = self
+                    .reputation
+                    .entry((delta.subject_lct.clone(), delta.role_lct.clone()))
+                    .or_insert_with(|| RoleReputation::new(ts));
+                for (dim, td) in &delta.t3_delta {
+                    if let Some(d) = trust_dim(dim) {
+                        rep.t3.apply_delta(d, td.change);
+                    }
+                }
+                for (dim, td) in &delta.v3_delta {
+                    if let Some(d) = value_dim(dim) {
+                        rep.v3.apply_delta(d, td.change);
+                    }
+                }
+                rep.observations += 1;
+                rep.last_updated = ts;
+            }
             HubEvent::CouncilMemberAdded { member_lct_id, member_pubkey_hex, member_name, .. } => {
                 self.council_holders.insert(*member_lct_id);
                 self.council_pubkeys.insert(*member_lct_id, member_pubkey_hex.clone());
@@ -650,6 +719,48 @@ mod tests {
         let state = HubState::project(&ledger);
         assert_eq!(state.member_count(), 1);
         assert!(state.members.contains_key(&sov.lct.id));
+    }
+
+    #[tokio::test]
+    async fn reputation_recorded_folds_into_role_pairing() {
+        use std::collections::HashMap;
+        use web4_core::t3::{T3, TrustDimension};
+        let sov = IdentityFile::generate(EntityType::Human);
+        let kp = sov.keypair().unwrap();
+        let subject = Uuid::new_v4().to_string();
+        let mut t3_delta = HashMap::new();
+        t3_delta.insert("temperament".to_string(),
+            web4_core::r6::TensorDelta { change: 0.2, from_value: 0.0, to_value: 0.2 });
+        let delta = web4_core::r6::ReputationDelta {
+            subject_lct: subject.clone(),
+            role_lct: "citizen".to_string(),
+            action_type: "handoff".into(),
+            action_target: "hub".into(),
+            action_id: "act-1".into(),
+            rule_triggered: "on_time".into(),
+            reason: "delivered on time".into(),
+            t3_delta,
+            v3_delta: HashMap::new(),
+            contributing_factors: vec![],
+            witnesses: vec![],
+            timestamp: Utc::now(),
+        };
+        let (_tmp, ledger) = make_ledger_with(vec![
+            (sov.lct.id, &kp, HubEvent::Genesis {
+                hub_name: "Test".into(), charter_hash: "sha256:0".into(),
+                founding_sovereign_lct_id: sov.lct.id, created_at: Utc::now(),
+            }),
+            (sov.lct.id, &kp, HubEvent::ReputationRecorded { delta }),
+        ]).await;
+        let state = HubState::project(&ledger);
+        let rep = state.reputation.get(&(subject.clone(), "citizen".to_string()))
+            .expect("reputation projected for the (subject, citizen) role-pairing");
+        assert_eq!(rep.observations, 1);
+        let before = T3::default().score(TrustDimension::Temperament);
+        assert!(rep.t3.score(TrustDimension::Temperament) >= before, "temperament folded up");
+        // Role-contextualized: a different role for the SAME subject is a distinct
+        // pairing (no global reputation) — nothing there.
+        assert!(state.reputation.get(&(subject, "treasurer".to_string())).is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Roadmap §5.3, phase 1 — co-owned with Legion** (the society-scale instance of the reputation loop Legion closed at constellation scale in hestia 629d849; RFC #403 normative over both).

Wires the hub into web4-core's **existing** R7 engine — the hub **records + applies** deltas, it does **not** invent tensor math.

- **`HubEvent::ReputationRecorded { delta: r6::ReputationDelta }`** — the witnessed half of reputation on the ledger.
- **`HubState.reputation: BTreeMap<(subject_lct, role_lct), RoleReputation>`** — role-contextualized per RFC #403 (**no global reputation**; keyed on the MRH role-pairing link). `apply()` folds `t3_delta`/`v3_delta` via `T3/V3::apply_delta`.
- **Channel tools:** `record_reputation` (Sovereign-only in v1 — witness a pre-computed `ReputationDelta`) and `reputation` (read a subject's per-role tensors, `role_lct`-scopable, tier-gated + read-scoped). Exhaustive admin `event_summary` arm added.

**Boundary per your answers:** scoring **weights live in society law** (reputation-comp §336, via `rules`), not the engine — the hub folds the delta someone computed via `compute_reputation`; `admission.min_trust_score` is the reading side of that same law surface. Built against current `main` (#425/#427/#428, treated as stable).

**Test:** `reputation_recorded_folds_into_role_pairing` (fold + role-contextualization). **34 daemon + 158 lib green.**

**v2 follow-ups:** compute-from-factors + law-weight lookup on record; wire `min_trust_score` + `find_members` ranking to read the projection; auto-derive deltas from `referenced_act` R7 outcomes.

@Legion — review against #403 + the hestia warn/deny reference; I'll keep you honest on the hub-law hook. Not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)