### PR TITLE
hub(security): anti-replay guard for the sealed channel

### DIFF
--- a/hub/hub-daemon/examples/channel_client.rs
+++ b/hub/hub-daemon/examples/channel_client.rs
@@ -63,9 +63,17 @@ fn main() -> anyhow::Result<()> {
     let hub_pub = PublicKey::from_bytes(&pk_arr)?;
     eprintln!("hub {hub_id} @ {base} (pubkey {}…)", &hub_pub_hex[..16]);
 
-    // 2. Seal {tool, args} with a fresh pair_id.
+    // 2. Seal {tool, args} with a fresh pair_id. The nonce + issued_at let the
+    //    hub reject replays with a bounded seen-set (freshness window closes the
+    //    gap a TTL alone would leave); both are inside the sealed blob, so AEAD
+    //    authenticates them.
     let pair_id = Uuid::new_v4();
-    let inner = serde_json::json!({ "tool": tool, "args": tool_args });
+    let inner = serde_json::json!({
+        "tool": tool,
+        "args": tool_args,
+        "nonce": Uuid::new_v4().to_string(),
+        "issued_at": chrono::Utc::now().to_rfc3339(),
+    });
     let sealed = pair_channel::seal(&me, &hub_pub, pair_id, &serde_json::to_vec(&inner)?)?;
 
     // 3. POST the channel request.

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -35,7 +35,7 @@ use axum::{
     Router,
 };
 use std::net::SocketAddr;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -45,6 +45,7 @@ use uuid::Uuid;
 use hub_lib::hub::{HubPaths, SovereignMode};
 use hub_lib::law::HubLawExt;
 use hub_lib::envelope::{verify_envelope, Challenge, MapResolver, NonceStore, PublicKeyResolver, SignedEnvelope, VerifyError};
+use hub_lib::replay::ReplayGuard;
 use hub_lib::events::HubEvent;
 use hub_lib::identity::IdentityFile;
 use hub_lib::init::load_society;
@@ -105,6 +106,10 @@ pub struct RestState {
     pub signer: Arc<SwappableSigner>,
     pub ledger: Arc<Mutex<HubLedger>>,
     pub nonces: Arc<NonceStore>,
+    /// Anti-replay seen-set for sealed channel requests (see [`ReplayGuard`]).
+    /// AEAD authenticates the sealer but not freshness; this rejects captured
+    /// `{pair_id, sealed}` re-submissions that would double-witness write acts.
+    pub replay: Arc<ReplayGuard>,
     /// Public-key resolver for envelope signature verification.
     /// Wrapped in RwLock so the V2-12 join endpoint can extend it
     /// at runtime as new members are admitted.
@@ -329,6 +334,7 @@ impl RestState {
             signer: Arc::new(SwappableSigner::new(signer)),
             ledger,
             nonces: Arc::new(NonceStore::new()),
+            replay: Arc::new(ReplayGuard::new()),
             resolver: Arc::new(tokio::sync::RwLock::new(resolver)),
             law,
             constellations: Arc::new(hub_lib::constellation::ConstellationGate::new()),
@@ -404,6 +410,7 @@ impl RestState {
             signer: Arc::new(SwappableSigner::new(signer)),
             ledger: placeholder_ledger,
             nonces: Arc::new(NonceStore::new()),
+            replay: Arc::new(ReplayGuard::new()),
             resolver: Arc::new(tokio::sync::RwLock::new(MapResolver::new())),
             law,
             constellations: Arc::new(hub_lib::constellation::ConstellationGate::new()),
@@ -1204,6 +1211,9 @@ impl ApiError {
     fn internal(e: anyhow::Error) -> Self {
         Self { status: StatusCode::INTERNAL_SERVER_ERROR, message: format!("{:#}", e) }
     }
+    fn conflict(msg: impl Into<String>) -> Self {
+        Self { status: StatusCode::CONFLICT, message: msg.into() }
+    }
 }
 
 /// The hub's vault is locked: refuse citizen-tier+ work, 503. Tier-0 (no-LCT)
@@ -1921,6 +1931,16 @@ struct ChannelInner {
     tool: String,
     #[serde(default)]
     args: serde_json::Value,
+    /// Anti-replay nonce, fresh per request. Optional for back-compat: when
+    /// present it keys the replay guard directly; when absent the guard falls
+    /// back to the sealed-blob hash (still rejects byte-identical replays).
+    #[serde(default)]
+    nonce: Option<String>,
+    /// Client send time. Optional for back-compat: when present, requests
+    /// outside the freshness window are rejected, which makes the TTL-bounded
+    /// replay set complete (a replay can't outlive the window it's checked in).
+    #[serde(default)]
+    issued_at: Option<DateTime<Utc>>,
 }
 
 async fn channel_request(
@@ -1964,6 +1984,38 @@ async fn channel_request(
         ))?;
     let inner: ChannelInner = serde_json::from_slice(&plaintext)
         .map_err(|e| ApiError::bad_request(format!("malformed channel request: {e}")))?;
+
+    // Anti-replay. AEAD authenticated the sealer but proves possession, not
+    // freshness: a captured `{pair_id, sealed}` POST decrypts identically on
+    // re-submission, which would double-witness a write act (referenced_act,
+    // record_reputation, …) and inflate the ledger + any reputation folded
+    // from it. Freshness-gate when the client dates the request, then dedup on
+    // its nonce (or, for older clients, the sealed-blob hash). Keys are
+    // namespaced by caller so a nonce value can't collide across members.
+    // Reads are idempotent so this is harmless for them; the seal is randomized
+    // per call, so a legitimate re-invocation is a new key, never a false reject.
+    let now = Utc::now();
+    const CHANNEL_FRESHNESS_SECS: i64 = 120;
+    if let Some(issued) = inner.issued_at {
+        if (now - issued).num_seconds().abs() > CHANNEL_FRESHNESS_SECS {
+            return Err(ApiError::bad_request(
+                "channel request outside freshness window (replay or clock skew)".to_string(),
+            ));
+        }
+    }
+    let replay_key = match &inner.nonce {
+        Some(n) => format!("{}:n:{n}", req.caller_lct_id),
+        None => format!(
+            "{}:h:{}",
+            req.caller_lct_id,
+            web4_core::crypto::sha256_hex(req.sealed.as_bytes())
+        ),
+    };
+    if !s.replay.check_and_record(&replay_key, now) {
+        return Err(ApiError::conflict(
+            "channel request replay rejected (already processed)".to_string(),
+        ));
+    }
 
     // Authz + dispatch on the decrypted request.
     let response = dispatch_channel(&s, req.caller_lct_id, req.pair_id, req.caller_pubkey_hex.clone(), inner).await?;
@@ -4630,6 +4682,88 @@ mod channel_e2e_tests {
         assert_eq!(out3["notifications"][0]["pointer_uri"], serde_json::json!("pr/423#thread=t1"));
         assert_eq!(out3["notifications"][0]["from"], serde_json::json!(member_lct),
             "sender LCT rides the envelope in the clear so the recipient can reply");
+    }
+
+    #[tokio::test]
+    async fn channel_replay_is_rejected_and_does_not_double_witness() {
+        // Capture-and-replay: re-POSTing the identical sealed bytes must be
+        // rejected, or a write act would be witnessed twice. Uses the back-compat
+        // hash path (seal_req sends no nonce/issued_at).
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let hub_pub = state.signer.public_key().unwrap();
+        let member = KeyPair::generate();
+        let member_lct = Uuid::new_v4();
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&member, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Replayer" }));
+        channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid, sealed,
+            caller_pubkey_hex: Some(member.verifying_key().to_hex()),
+        })).await.expect("admitted + pinned");
+
+        // Emit a referenced_act to self, then replay the EXACT same bytes.
+        let pid2 = Uuid::new_v4();
+        let sealed2 = seal_req(&member, &hub_pub, pid2, "referenced_act", serde_json::json!({
+            "to": { "to": "peer", "lct_id": member_lct },
+            "kind": "handoff",
+            "pointer_uri": "pr/999#thread=t1",
+        }));
+        let mk = || ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid2, sealed: sealed2.clone(), caller_pubkey_hex: None,
+        };
+        channel_request(State(state.clone()), Path(state.hub_id), Json(mk()))
+            .await.expect("first submission recorded");
+        let replay = channel_request(State(state.clone()), Path(state.hub_id), Json(mk())).await;
+        assert!(replay.is_err(), "identical re-POST must be rejected as a replay");
+
+        // The act was witnessed exactly once: the mailbox holds one notice.
+        let pid3 = Uuid::new_v4();
+        let sealed3 = seal_req(&member, &hub_pub, pid3, "notifications", serde_json::json!({}));
+        let resp3 = channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid3, sealed: sealed3, caller_pubkey_hex: None,
+        })).await.expect("drain");
+        let out3 = open_resp(&member, &hub_pub, pid3, &resp3.0.sealed);
+        assert_eq!(out3["total"], serde_json::json!(1),
+            "replay must not double-witness — exactly one notice");
+
+        // A genuinely new invocation (fresh seal) is NOT blocked.
+        let pid4 = Uuid::new_v4();
+        let sealed4 = seal_req(&member, &hub_pub, pid4, "presence", serde_json::json!({}));
+        channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid4, sealed: sealed4, caller_pubkey_hex: None,
+        })).await.expect("a fresh request with new sealed bytes is accepted");
+    }
+
+    #[tokio::test]
+    async fn channel_stale_issued_at_is_rejected() {
+        // A client-dated request outside the freshness window is refused — this is
+        // what bounds the replay set so a deferred replay can't outlive it.
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let hub_pub = state.signer.public_key().unwrap();
+        let member = KeyPair::generate();
+        let member_lct = Uuid::new_v4();
+        // Pin first (fresh request_citizenship, no issued_at → accepted).
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&member, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Timely" }));
+        channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid, sealed,
+            caller_pubkey_hex: Some(member.verifying_key().to_hex()),
+        })).await.expect("pinned");
+
+        // Seal a presence read stamped 10 minutes in the past.
+        let pid2 = Uuid::new_v4();
+        let stale = (Utc::now() - chrono::Duration::seconds(600)).to_rfc3339();
+        let inner = serde_json::json!({
+            "tool": "presence", "args": {},
+            "nonce": Uuid::new_v4().to_string(), "issued_at": stale,
+        });
+        let sealed2 = pair_channel::seal(&member, &hub_pub, pid2, &serde_json::to_vec(&inner).unwrap())
+            .unwrap().to_base64();
+        let res = channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid2, sealed: sealed2, caller_pubkey_hex: None,
+        })).await;
+        assert!(res.is_err(), "stale issued_at must be rejected as out-of-window");
     }
 
     #[tokio::test]

--- a/hub/hub-lib/src/lib.rs
+++ b/hub/hub-lib/src/lib.rs
@@ -33,6 +33,7 @@ pub mod law;
 pub mod ledger;
 pub mod pair_message;
 pub mod proposal;
+pub mod replay;
 pub mod session;
 
 #[cfg(feature = "dynamodb")]

--- a/hub/hub-lib/src/replay.rs
+++ b/hub/hub-lib/src/replay.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Metalinxx Inc.
+
+//! Anti-replay guard for the sealed channel.
+//!
+//! The sealed channel authenticates via AEAD — only the holder of the pinned
+//! key could have sealed a request. But AEAD proves *possession*, not
+//! *freshness*: a captured `{pair_id, sealed}` POST decrypts identically on
+//! re-submission. Without a seen-set, an observer positioned to capture the
+//! ciphertext (a compromised relay, host-log access, or — in the open-community
+//! future — any peer) can replay a captured **write** act (`referenced_act`,
+//! `record_reputation`, `request_citizenship`, …) to double-witness it,
+//! inflating the ledger and any reputation folded from it.
+//!
+//! This guard records a per-request key with a TTL and rejects a repeat within
+//! the window. The key is an explicit client nonce when supplied, else the hash
+//! of the sealed blob (so it works for every existing client with no wire
+//! change). Paired with the caller-supplied `issued_at` freshness check in the
+//! channel handler, the bounded TTL is *complete*: a replay must arrive inside
+//! the freshness window to reach the set at all. Clients that don't yet send
+//! `issued_at` still get burst-replay protection for the TTL duration.
+//!
+//! In-memory, per-process. Multi-replica hubs will want shared state — the same
+//! caveat that already applies to [`crate::envelope::NonceStore`].
+
+use chrono::{DateTime, Duration, Utc};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Default seen-key retention. Must be >= the channel freshness window so an
+/// in-window replay is always still recorded when the duplicate arrives.
+pub const DEFAULT_REPLAY_TTL_SECONDS: i64 = 300;
+
+/// Flood backstop: hard cap on retained keys. A burst of *unique* requests
+/// (each fresh, so none are replays) can't grow the map without bound between
+/// prunes. On overflow we prune expired entries first, then evict the oldest.
+const MAX_KEYS: usize = 100_000;
+
+/// Records recently-seen channel-request keys to reject exact replays.
+pub struct ReplayGuard {
+    seen: Mutex<HashMap<String, DateTime<Utc>>>,
+    ttl: Duration,
+}
+
+impl ReplayGuard {
+    pub fn new() -> Self {
+        Self::with_ttl(DEFAULT_REPLAY_TTL_SECONDS)
+    }
+
+    pub fn with_ttl(ttl_seconds: i64) -> Self {
+        Self {
+            seen: Mutex::new(HashMap::new()),
+            ttl: Duration::seconds(ttl_seconds),
+        }
+    }
+
+    /// Record `key` as seen at `now`. Returns `true` if it was fresh (accept),
+    /// `false` if the same key was already seen within the TTL (replay → reject).
+    ///
+    /// The freshness comparison is explicit (`now - first < ttl`), so a stale
+    /// leftover entry never false-rejects even if it hasn't been pruned yet;
+    /// pruning is purely a memory concern and runs only when the map is full,
+    /// keeping the hot path O(1) amortized.
+    pub fn check_and_record(&self, key: &str, now: DateTime<Utc>) -> bool {
+        let mut seen = self.seen.lock().expect("replay guard poisoned");
+        if let Some(&first) = seen.get(key) {
+            if now - first < self.ttl {
+                return false; // replay within the window
+            }
+            // Stale entry for the same key — fall through and overwrite it.
+        }
+        if seen.len() >= MAX_KEYS {
+            let ttl = self.ttl;
+            seen.retain(|_, &mut t| now - t < ttl);
+            if seen.len() >= MAX_KEYS {
+                // Still full: a genuine flood of in-window unique keys. Evict
+                // the oldest to bound memory (worst case: an attacker can age
+                // out a real entry, re-opening a narrow replay window — an
+                // acceptable trade against unbounded growth).
+                if let Some(oldest) = seen.iter().min_by_key(|(_, &t)| t).map(|(k, _)| k.clone()) {
+                    seen.remove(&oldest);
+                }
+            }
+        }
+        seen.insert(key.to_string(), now);
+        true
+    }
+
+    pub fn len(&self) -> usize {
+        self.seen.lock().expect("replay guard poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for ReplayGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_key_accepted_replay_rejected() {
+        let g = ReplayGuard::new();
+        let now = Utc::now();
+        assert!(
+            g.check_and_record("caller:h:abc", now),
+            "first sighting = accept"
+        );
+        assert!(
+            !g.check_and_record("caller:h:abc", now),
+            "exact replay = reject"
+        );
+        assert!(
+            g.check_and_record("caller:h:def", now),
+            "distinct key = accept"
+        );
+    }
+
+    #[test]
+    fn key_reusable_after_ttl_expires() {
+        let g = ReplayGuard::with_ttl(60);
+        let t0 = Utc::now();
+        assert!(g.check_and_record("k", t0));
+        // Same key just past the TTL is no longer a replay (freshness gate in the
+        // handler is what actually prevents deferred replay; this just frees memory).
+        let later = t0 + Duration::seconds(61);
+        assert!(
+            g.check_and_record("k", later),
+            "past TTL the key is free again"
+        );
+    }
+
+    #[test]
+    fn caller_namespacing_keeps_nonces_independent() {
+        let g = ReplayGuard::new();
+        let now = Utc::now();
+        assert!(g.check_and_record("alice:n:1", now));
+        // Same nonce value under a different caller prefix must not collide.
+        assert!(g.check_and_record("bob:n:1", now));
+    }
+}


### PR DESCRIPTION
## What & why

The sealed channel authenticates with AEAD (only the pinned-key holder can seal), but AEAD proves **possession, not freshness**. A captured `{pair_id, sealed}` POST decrypts identically on re-submission, so with no seen-set an observer able to capture the ciphertext (a compromised relay, host-log access, or — in the open-community future — any peer) can **replay a write act** (`referenced_act`, `record_reputation`, `request_citizenship`, …) to double-witness it, inflating the ledger and any reputation folded from it.

This surfaced in a full hub/hestia architecture review as the highest-severity open seam. It's the integrity floor under the §5.3 reputation projection (#430) and the whole witnessing story.

## Fix (hub-side, backward compatible)

- **`hub_lib::replay::ReplayGuard`** — TTL-bounded (default 300s), caller-namespaced seen-set. Hot path is O(1) amortized (prune only at a hard `MAX_KEYS` cap; oldest-eviction flood backstop). Explicit `now - first < ttl` check so a not-yet-pruned stale entry never false-rejects.
- **`channel_request`** dedups every request on an explicit client `nonce` when present, else the **sealed-blob hash** (works for all existing clients, no wire change). A replay → `409 Conflict`.
- Optional **`nonce` + `issued_at`** on `ChannelInner` (serde-default). When the client dates the request, a **±120s freshness gate** makes the TTL-bounded set *complete* — a deferred replay can't outlive the window it's checked in. Clients that don't send them still get burst-replay protection for the TTL.
- Reference client (`examples/channel_client`) now emits both fields.

Reads are idempotent (replay is harmless), and the per-call random seal means a legitimate re-invocation is always a fresh key — never a false reject. Only byte-identical captured replays are refused.

## Tests
- 3 `ReplayGuard` unit tests (accept/reject, TTL reuse, caller namespacing).
- `channel_replay_is_rejected_and_does_not_double_witness` — after a replay the mailbox still holds exactly **one** notice (proves no double-witness), and a fresh-sealed re-invocation is still accepted.
- `channel_stale_issued_at_is_rejected`.
- **36 daemon + 161 lib tests green.**

## Follow-ups (noted, not in this PR)
- Shared seen-set for multi-replica hubs (same caveat as `NonceStore`).
- Idempotency-response cache so a legit retry gets the original result rather than a 409.
- Add `nonce`/`issued_at` to hestia's `HubChannel` client — **coordinating with Legion** (cross-repo).

## Review note
Touches shared channel substrate + the reputation integrity path, so tagging for review rather than self-merge (per the open co-owned-PR governance question). Reviewers: correctness of the freshness/dedup logic and the back-compat fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)