### PR TITLE
hub(robustness): bound the mailbox + fix HubState serialization landmine

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -722,6 +722,15 @@ async fn witness_event(s: &RestState, event: HubEvent) -> Result<u64, ApiError> 
 /// by the caller (e.g. the `referenced_act` dispatch). `from` rides the envelope
 /// in the clear so the recipient can address a reply. Best-effort: dropped if the
 /// recipient has no pinned pubkey / the seal fails.
+/// Per-member mailbox size cap. A member can't flood a peer's mailbox (or the
+/// hub's memory) without bound; at the cap the oldest notice is dropped to make
+/// room (ring semantics — the most recent N always survive).
+const MAX_NOTICES_PER_MEMBER: usize = 1000;
+/// Notice retention. Notices older than this are pruned on enqueue and on drain,
+/// so a mailbox that's touched (or polled) doesn't accumulate stale entries. A
+/// fully-idle mailbox is bounded instead by [`MAX_NOTICES_PER_MEMBER`].
+const NOTICE_TTL_SECS: i64 = 7 * 24 * 3600;
+
 async fn queue_sealed_notice(
     s: &RestState, recipient: Uuid, from: Uuid, kind: &str, pointer_uri: &str, body: &[u8],
 ) {
@@ -746,13 +755,24 @@ async fn queue_sealed_notice(
         Ok(c) => c,
         Err(e) => { tracing::warn!("queue_sealed_notice: seal failed: {e}"); return; }
     };
-    s.notifications.lock().await.entry(recipient).or_default().push(SealedNotice {
+    let now = Utc::now();
+    let cutoff = now - chrono::Duration::seconds(NOTICE_TTL_SECS);
+    let mut mailbox = s.notifications.lock().await;
+    let queue = mailbox.entry(recipient).or_default();
+    queue.retain(|n| n.queued_at >= cutoff); // TTL prune
+    while queue.len() >= MAX_NOTICES_PER_MEMBER {
+        queue.remove(0); // at cap: drop oldest to make room
+        tracing::warn!(
+            "mailbox for {recipient} at cap ({MAX_NOTICES_PER_MEMBER}); dropped oldest notice"
+        );
+    }
+    queue.push(SealedNotice {
         pair_id,
         from,
         sealed,
         kind: kind.to_string(),
         pointer_uri: pointer_uri.to_string(),
-        queued_at: Utc::now(),
+        queued_at: now,
     });
 }
 
@@ -2366,7 +2386,9 @@ async fn dispatch_channel(
         "notifications" => {
             // A citizen drains their pending sealed notices (the delivery floor; push to a
             // registered LCT-MCP endpoint is the future optimization on the same queue).
-            let notices = s.notifications.lock().await.remove(&caller_lct_id).unwrap_or_default();
+            let cutoff = Utc::now() - chrono::Duration::seconds(NOTICE_TTL_SECS);
+            let mut notices = s.notifications.lock().await.remove(&caller_lct_id).unwrap_or_default();
+            notices.retain(|n| n.queued_at >= cutoff); // don't deliver expired notices
             Ok(serde_json::json!({ "total": notices.len(), "notifications": notices }))
         }
         "referenced_act" => {
@@ -4764,6 +4786,37 @@ mod channel_e2e_tests {
             caller_lct_id: member_lct, pair_id: pid2, sealed: sealed2, caller_pubkey_hex: None,
         })).await;
         assert!(res.is_err(), "stale issued_at must be rejected as out-of-window");
+    }
+
+    #[tokio::test]
+    async fn mailbox_is_capped_and_drops_oldest() {
+        // Flood protection: a member's mailbox can't grow without bound. Past the
+        // cap the oldest notices are dropped (ring), so the newest survive.
+        let (_tmp, state) = fresh_rest_state(None).await;
+        let hub_pub = state.signer.public_key().unwrap();
+        let member = KeyPair::generate();
+        let member_lct = Uuid::new_v4();
+        let pid = Uuid::new_v4();
+        let sealed = seal_req(&member, &hub_pub, pid, "request_citizenship",
+            serde_json::json!({ "name": "Flooded" }));
+        channel_request(State(state.clone()), Path(state.hub_id), Json(ChannelRequest {
+            caller_lct_id: member_lct, pair_id: pid, sealed,
+            caller_pubkey_hex: Some(member.verifying_key().to_hex()),
+        })).await.expect("pinned");
+
+        let overflow = super::MAX_NOTICES_PER_MEMBER + 5;
+        for i in 0..overflow {
+            super::queue_sealed_notice(
+                &state, member_lct, member_lct, "handoff",
+                &format!("pr/{i}"), b"body",
+            ).await;
+        }
+        let mailbox = state.notifications.lock().await;
+        let queue = mailbox.get(&member_lct).expect("mailbox exists");
+        assert_eq!(queue.len(), super::MAX_NOTICES_PER_MEMBER, "capped at the max");
+        // The first 5 (oldest) were dropped; the newest is the last enqueued.
+        assert_eq!(queue.first().unwrap().pointer_uri, "pr/5", "oldest dropped");
+        assert_eq!(queue.last().unwrap().pointer_uri, format!("pr/{}", overflow - 1));
     }
 
     #[tokio::test]

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -86,6 +86,12 @@ pub struct HubState {
     /// Role-contextualized reputation, keyed by `(subject_lct, role_lct)` — the
     /// projected side of R7 back-propagation. Reputation is NEVER global; it lives
     /// on the MRH role-pairing link (RFC #403). Folded from `ReputationRecorded`.
+    ///
+    /// Serialized as a JSON **array** of entries, not a map: JSON object keys
+    /// must be strings, and a tuple key would make `serde_json::to_string(&state)`
+    /// fail at runtime. The array form (`{subject_lct, role_lct, …}`) keeps the
+    /// whole `HubState` safely serializable.
+    #[serde(serialize_with = "serialize_reputation")]
     pub reputation: BTreeMap<(String, String), RoleReputation>,
 
     /// Last seen index from the ledger (for cache invalidation in future).
@@ -112,6 +118,37 @@ impl RoleReputation {
             last_updated: ts,
         }
     }
+}
+
+/// Serialize the tuple-keyed reputation map as a JSON array of flattened
+/// entries. JSON object keys must be strings, so a `(String, String)`-keyed map
+/// can't serialize as an object — emitting a sequence keeps the whole
+/// [`HubState`] serializable (and is friendlier to consumers than a joined
+/// string key).
+fn serialize_reputation<S>(
+    map: &BTreeMap<(String, String), RoleReputation>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::ser::SerializeSeq;
+    #[derive(Serialize)]
+    struct Entry<'a> {
+        subject_lct: &'a str,
+        role_lct: &'a str,
+        #[serde(flatten)]
+        reputation: &'a RoleReputation,
+    }
+    let mut seq = serializer.serialize_seq(Some(map.len()))?;
+    for ((subject_lct, role_lct), reputation) in map {
+        seq.serialize_element(&Entry {
+            subject_lct,
+            role_lct,
+            reputation,
+        })?;
+    }
+    seq.end()
 }
 
 /// Map a `ReputationDelta` dimension name to the typed T3 dimension.
@@ -761,6 +798,42 @@ mod tests {
         // Role-contextualized: a different role for the SAME subject is a distinct
         // pairing (no global reputation) — nothing there.
         assert!(state.reputation.get(&(subject, "treasurer".to_string())).is_none());
+    }
+
+    #[tokio::test]
+    async fn hub_state_with_reputation_serializes_as_array() {
+        // Guards the tuple-key landmine: a `(String, String)`-keyed map can't be a
+        // JSON object, so without the custom serializer `to_string(&state)` would
+        // fail at runtime. It must succeed and emit reputation as an array.
+        use std::collections::HashMap;
+        let sov = IdentityFile::generate(EntityType::Human);
+        let kp = sov.keypair().unwrap();
+        let subject = Uuid::new_v4().to_string();
+        let mut t3_delta = HashMap::new();
+        t3_delta.insert("talent".to_string(),
+            web4_core::r6::TensorDelta { change: 0.1, from_value: 0.0, to_value: 0.1 });
+        let delta = web4_core::r6::ReputationDelta {
+            subject_lct: subject.clone(),
+            role_lct: "citizen".to_string(),
+            action_type: "handoff".into(), action_target: "hub".into(), action_id: "a".into(),
+            rule_triggered: "r".into(), reason: "x".into(),
+            t3_delta, v3_delta: HashMap::new(),
+            contributing_factors: vec![], witnesses: vec![], timestamp: Utc::now(),
+        };
+        let (_tmp, ledger) = make_ledger_with(vec![
+            (sov.lct.id, &kp, HubEvent::Genesis {
+                hub_name: "Test".into(), charter_hash: "sha256:0".into(),
+                founding_sovereign_lct_id: sov.lct.id, created_at: Utc::now(),
+            }),
+            (sov.lct.id, &kp, HubEvent::ReputationRecorded { delta }),
+        ]).await;
+        let state = HubState::project(&ledger);
+        let json = serde_json::to_value(&state).expect("HubState must serialize");
+        let arr = json["reputation"].as_array().expect("reputation is a JSON array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["subject_lct"], serde_json::json!(subject));
+        assert_eq!(arr[0]["role_lct"], serde_json::json!("citizen"));
+        assert_eq!(arr[0]["observations"], serde_json::json!(1));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two independent hardening fixes surfaced in a full hub/hestia architecture review.

## 1. Mailbox bounds (flood + staleness)
The per-member sealed-notice mailbox (`RestState.notifications`) was **unbounded**: any member could `referenced_act{to:Peer}` into a peer's mailbox without limit (memory-growth DoS), and notices never expired.

- **Size cap** (`MAX_NOTICES_PER_MEMBER = 1000`): at the cap the oldest notice is dropped (ring semantics — the most recent N survive), with a `warn` log.
- **TTL** (7 days): expired notices pruned on enqueue *and* on drain, so an active/polled mailbox sheds stale entries; a fully-idle mailbox is bounded by the size cap.

Durability across restart (persisting the mailbox) is a larger follow-up — this is the in-memory bound, not persistence.

## 2. HubState serialization landmine
`HubState` derives `Serialize` but now holds `reputation: BTreeMap<(String, String), RoleReputation>` (from #430). **JSON object keys must be strings**, so `serde_json::to_string(&state)` would fail at runtime the moment anyone serialized the whole struct. Nothing does today (only fields are re-packed) — but it's a trap. Added a `#[serde(serialize_with)]` that emits reputation as a JSON **array** of `{subject_lct, role_lct, …}` entries, keeping the tuple key internally and the whole struct safely serializable.

## Tests
- `mailbox_is_capped_and_drops_oldest` — cap holds at 1000, oldest evicted, newest kept.
- `hub_state_with_reputation_serializes_as_array` — `to_value(&state)` succeeds and emits an array (would have failed before).
- **35 daemon + 159 lib tests green.**

Independent of #431 (channel replay); both branch off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)