### PR TITLE
fix(hub-daemon): handle Decision::Warn at the six law gates (repairs #435 build break)

### DIFF
--- a/hub/hub-daemon/src/mcp.rs
+++ b/hub/hub-daemon/src/mcp.rs
@@ -398,6 +398,15 @@ async fn append_with_sovereign(
         let outcome = law.evaluate_outcome(&req);
         match outcome.decision {
             Decision::Allow => { /* proceed */ }
+            Decision::Warn => {
+                // Non-blocking flagged-allow: proceed, but surface the advisory.
+                // Structured Warn consumption (witnessing) lands with the
+                // sequenced hub-consumes step after the hestia migration.
+                tracing::warn!(
+                    "act flagged by hub law (norm: {})",
+                    outcome.winning_norm.as_deref().unwrap_or("?")
+                );
+            }
             Decision::Deny => {
                 return Err(ApiError::forbidden(format!(
                     "act denied by hub law (norm: {})",

--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -1806,6 +1806,15 @@ async fn submit_event(
         let outcome = law.evaluate_outcome(&req);
         match outcome.decision {
             Decision::Allow => { /* proceed */ }
+            Decision::Warn => {
+                // Non-blocking flagged-allow: proceed, but surface the advisory.
+                // Structured Warn consumption (witnessing) lands with the
+                // sequenced hub-consumes step after the hestia migration.
+                tracing::warn!(
+                    "act flagged by hub law (norm: {})",
+                    outcome.winning_norm.as_deref().unwrap_or("?")
+                );
+            }
             Decision::Deny => {
                 return Err(ApiError {
                     status: StatusCode::FORBIDDEN,
@@ -2653,6 +2662,10 @@ async fn request_citizenship(
             };
             match law.evaluate_outcome(&req).decision {
                 Decision::Allow => {}
+                Decision::Warn => {
+                    // Non-blocking flagged-allow: admission proceeds, flagged.
+                    tracing::warn!("member_join_request flagged by hub law (proceeding)");
+                }
                 Decision::Deny => return Err(ApiError {
                     status: StatusCode::FORBIDDEN,
                     message: "citizenship denied by hub law".to_string(),
@@ -3434,8 +3447,12 @@ async fn submit_join(
             status: StatusCode::FORBIDDEN,
             message: "membership denied by hub law".to_string(),
         }),
-        Decision::Allow => {
-            // Auto-admit, live (no restart).
+        Decision::Allow | Decision::Warn => {
+            // Auto-admit, live (no restart). Warn is a non-blocking
+            // flagged-allow: same path, with the advisory surfaced.
+            if decision == Decision::Warn {
+                tracing::warn!("member join flagged by hub law (auto-admitting)");
+            }
             let (entry_index, entry_hash) = admit_member(
                 &s, payload.member_lct_id, &payload.member_pubkey_hex, payload.name.clone(),
             ).await?;
@@ -3512,6 +3529,14 @@ async fn gate_read(s: &RestState, role: &str, tool: &str) -> Result<(), ApiError
     let outcome = read_decision(law_guard.as_ref(), role, tool);
     match outcome.decision {
         Decision::Allow => Ok(()),
+        Decision::Warn => {
+            // Non-blocking flagged-allow: the read proceeds, flagged.
+            tracing::warn!(
+                "read '{tool}' flagged by hub law (norm: {})",
+                outcome.winning_norm.as_deref().unwrap_or("?")
+            );
+            Ok(())
+        }
         Decision::Deny => Err(ApiError {
             status: StatusCode::FORBIDDEN,
             message: format!(
@@ -4136,6 +4161,10 @@ async fn submit_pair_request(
             .map_err(ApiError::internal)?;
         match law.evaluate_outcome(&req).decision {
             Decision::Allow => {}
+            Decision::Warn => {
+                // Non-blocking flagged-allow: the pairing proceeds, flagged.
+                tracing::warn!("pair_request flagged by hub law (proceeding)");
+            }
             Decision::Deny => {
                 return Err(ApiError {
                     status: StatusCode::FORBIDDEN,


### PR DESCRIPTION
## What
Follow-up to #435 (Warn variant). The variant landed spec-clean and web4-policy/hub-lib stayed green, but **hub-daemon failed to compile** (E0004 non-exhaustive match, 6 sites): the daemon matches `Decision` exhaustively at every law gate. Caught by the hub-track maintainer's post-merge staged rebuild — the live daemon was never at risk (old binary untouched, no restart).

## How
At each gate — mcp `act`, rest `act`, `member_join_request` (both paths), `gate_read`, `pair_request` — `Warn` now proceeds exactly like `Allow` (per the engine-owner eval spec: non-blocking flagged-allow) and surfaces the advisory via `tracing::warn!` with the winning norm where the outcome is in scope. In the join path the Allow/Warn arms are merged to avoid duplicating the admit block.

No gate semantics change: Deny still 403s, Escalate still 202s/queues. Behavior-neutral for the live hub — no law on disk emits `warn`. Structured Warn consumption (witnessing the advisory) still lands with the sequenced hub-consumes step after the hestia migration, per hub-to-legion-sequence-locked-warn-mesh-reputation-2026-07-01.

## Verification
- `cargo build --release` green (was 6 x E0004 on main).
- Tests: 38 hub-daemon + 163 hub-lib + 3 hub-plugin + 7 web4-policy pass, incl. the charter/payload hash-canary family (no serialization drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)