### PR TITLE
remediate(C128): complete presence schema-README gap ledger (C127-1 autonomous facet)

### DIFF
--- a/web4-standard/schemas/presence-protocol/README.md
+++ b/web4-standard/schemas/presence-protocol/README.md
@@ -41,11 +41,28 @@ schemas/presence-protocol/
       hestia_query_policy.schema.json
 ```
 
-Note: the `hestia://society/state` resource body and the §5.2
-`R6Action` struct have no JSON Schema yet (the former is an ad-hoc
-stats object bound directly by conformance vector P0-009; the latter
-is a documentary type catalog with no wire carrier — see
-presence-protocol.md §8).
+Note: four spec-referenced artifacts have no JSON Schema in this tree
+yet — a known-gap ledger, not a permanent exemption:
+
+- The `hestia://society/state` resource body — an ad-hoc stats object
+  bound directly by conformance vector P0-009, not a §5 struct.
+- The §5.2 `R6Action` struct — a documentary type catalog with no wire
+  carrier (see presence-protocol.md §8).
+- The `Session` struct (§5.1), returned by the `hestia://session/own`
+  resource. The `hestia_connect` output schema binds only the four-field
+  connect reply (`sessionId`, `softLct`, `assignedRole`,
+  `protocolVersion`), not the full eight-field Session record the
+  resource read returns.
+- The `VaultEntry` struct (§5.7), returned by the `hestia://vault/{name}`
+  resource. `hestia_vault_get` returns `{value, approvalToken}`, not a
+  `VaultEntry`, so no tool-output schema covers it.
+
+The last two are the only `camelCase` §5-typed resource bodies reached
+*solely* through `resources/read` — unlike `witness/recent`→`WitnessEntry`
+and `society/trust`→`TrustState`, which ride the `query_history` /
+`record_outcome` tool-output schemas — so they also have no conformance
+vector. Authoring their schemas (under `v0/common/`) and their
+`resources/read` vectors is pending.
 
 ## Validation
 


### PR DESCRIPTION
## C128 — presence-protocol REMEDIATION (autonomous facet of C127-1, LOW)

Applies the **autonomous prose facet** of C127-1, the sole net-new finding from the C127 presence-protocol 3rd-delta audit (PR #438). Lineage: C5→C38→C88→C89→C127→**C128**.

### What
The schema-README (`web4-standard/schemas/presence-protocol/README.md`) bills its JSON Schemas as the **wire-format authority**, and its "Note" enumerates the schema-less exceptions. But that list named only 2 of the 4 schema-less artifacts (`hestia://society/state`, §5.2 `R6Action`) — misleading a conformance implementer into expecting schemas that don't exist for the other two.

Extended the Note into a complete **known-gap ledger** (pending, not permanent exemption) that also names:

- **Session (§5.1)** — returned by `hestia://session/own`. `hestia_connect`'s output schema binds only the 4-field connect reply (`sessionId, softLct, assignedRole, protocolVersion`), not the full 8-field Session record the resource read returns.
- **VaultEntry (§5.7)** — returned by `hestia://vault/{name}`. `hestia_vault_get` returns `{value, approvalToken}`, not a `VaultEntry`.

These are the only `camelCase` §5-typed resource bodies reached *solely* via `resources/read` (unlike `witness/recent`→`WitnessEntry` and `society/trust`→`TrustState`, which ride the `query_history`/`record_outcome` tool-output schemas), so they also lack a conformance vector.

### Scope discipline
- **Docs-only.** No wire shape changed; no schema/vector file touched.
- **Cross-track facet routed separately, NOT self-applied**: authoring the actual `Session`/`VaultEntry` schemas under `v0/common/` + 2 `resources/read` conformance vectors — a judgment-call artifact task deferred like C88-2's `validate-presence.py`.

### Ground truth verified pre-edit
- `v0/common/` = `error_envelope`/`trust_state`/`witness_entry` only (no Session/VaultEntry schema).
- 0 conformance vectors reference `session/own` or `vault/{name}`.
- connect output schema = exactly those 4 fields; §5.1 Session = 8 fields.
- Post-edit: all 12 presence schemas + conformance JSON still parse.

### Governance
v2 protocol followed: propose → **policy review APPROVED** (first pass, ledger-framing recommendation folded in) → execute → document. Session log: `private-context/autonomous-sessions/legion-web4-20260702-120036-session.md`.

Presence-protocol now carries **zero autonomous remediation debt**. Next turn (alternation): AUDIT C129, rotation advances presence → mrh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)