### PR TITLE
hub: sync Cargo.lock (web4-core dep for web4-trust-core)

### DIFF
--- a/hub/Cargo.lock
+++ b/hub/Cargo.lock
@@ -3295,6 +3295,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
+ "web4-core",
 ]
 
 [[package]]


### PR DESCRIPTION
One-line lock sync: `web4-trust-core`'s Cargo.toml declares `web4-core` but the committed `hub/Cargo.lock` didn't list it, so every build re-writes the lock and dirties the tree. Generated via `cargo metadata` (resolve-only, no compile, no version changes). Surfaced while building #455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)