### PR TITLE
identity-p1: publish constellation role enum + provenance-strength fold

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2239,6 +2239,9 @@ fn temporal_delta(
     web4_core::r6::ReputationDelta {
         subject_lct: ob.subject_lct.clone(),
         role_lct: ob.role_lct.clone(),
+        // Hub-internal obligation-outcome delta: the hub does not hardware-attest
+        // the subject's sovereign here, so it stays at the fail-closed default.
+        sovereign_strength: web4_core::r6::SovereignStrength::default(),
         action_type: action_kind.to_string(),
         action_target: "hub".to_string(),
         action_id: action_id.to_string(),
@@ -2354,6 +2357,7 @@ async fn dispatch_channel(
                     "t3": rep.t3,
                     "v3": rep.v3,
                     "observations": rep.observations,
+                    "sovereign_strength": rep.sovereign_strength,
                     "last_updated": rep.last_updated,
                 }))
                 .collect();

--- a/hub/hub-lib/src/law.rs
+++ b/hub/hub-lib/src/law.rs
@@ -50,6 +50,52 @@ fn is_known_role(role: &str) -> bool {
     KNOWN_ROLES.contains(&role.to_lowercase().as_str())
 }
 
+/// The canonical **constellation session-capacity** role vocabulary — the
+/// `role_lct` a constellation orchestrator (e.g. hestia, claude-code) acts under
+/// for per-`(instance, role)` reputation (RFC #403 role dimension; #430 fold).
+///
+/// This is a **distinct namespace** from [`KNOWN_ROLES`] (the Web4 *society*
+/// roles — sovereign/administrator/…): a society role types delegation/admission/
+/// ATP authority, whereas a constellation role scopes an instance's reputation to
+/// the capacity it is acting in. Both are role vocabularies; they do not overlap.
+///
+/// Published per thread `identity-p1-cospec` (HUB Concern 2): self-declared roles
+/// fragment the fold exactly like `plugin_id` does one level up (`mesh-worker` vs
+/// `mesh_worker`). Members validate their declared role at connect against this
+/// set and **fail closed to [`DEFAULT_CONSTELLATION_ROLE`]** on any unknown value
+/// — never minting a novel role subject. See [`normalize_constellation_role`].
+pub const KNOWN_CONSTELLATION_ROLES: &[&str] = &[
+    "role:constellation:interactive-dev", // a human-driven session
+    "role:constellation:mesh-worker",     // a hub-mesh-fired autonomous session
+    "role:constellation:reviewer",        // a review/verify session
+    "role:constellation:autonomous-timer", // a scheduled/cron session
+    "role:constellation:member",          // the fail-closed default capacity
+];
+
+/// The fail-closed default constellation role: an unknown/unstated capacity folds
+/// here rather than fragmenting reputation onto a freely-minted role subject.
+/// Matches hestia's v1 `V1_CONSTELLATION_ROLE` placeholder.
+pub const DEFAULT_CONSTELLATION_ROLE: &str = "role:constellation:member";
+
+/// Whether `role` is a published constellation session-capacity role.
+/// Case-sensitive: the vocabulary is canonical lowercase `role:constellation:*`.
+pub fn is_known_constellation_role(role: &str) -> bool {
+    KNOWN_CONSTELLATION_ROLES.contains(&role)
+}
+
+/// Validate a self-declared constellation role at connect, failing closed to
+/// [`DEFAULT_CONSTELLATION_ROLE`] on any unpublished value. This is the hub's
+/// half of the HUB Concern 2 contract: a member calls this with the role it
+/// declared, stamps the returned canonical string as its `role_lct`, and thereby
+/// cannot fragment the fold with a typo'd or novel capacity.
+pub fn normalize_constellation_role(declared: &str) -> &'static str {
+    KNOWN_CONSTELLATION_ROLES
+        .iter()
+        .find(|&&r| r == declared)
+        .copied()
+        .unwrap_or(DEFAULT_CONSTELLATION_ROLE)
+}
+
 /// Default admission repeat limit: denials before an applicant is auto-blocked.
 pub const DEFAULT_ADMISSION_REPEAT_LIMIT: u32 = 3;
 /// Default admission review limit: denial-review requests before the terminal
@@ -377,6 +423,41 @@ impl HubLawExt for Law {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn constellation_roles_are_a_separate_namespace_from_society_roles() {
+        // The two vocabularies must not overlap: a society role is never a valid
+        // constellation role and vice-versa (they type different things).
+        for r in KNOWN_CONSTELLATION_ROLES {
+            assert!(!is_known_role(r), "'{r}' leaked into the society role set");
+        }
+        for r in KNOWN_ROLES {
+            assert!(
+                !is_known_constellation_role(r),
+                "society role '{r}' is not a constellation role"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_constellation_role_fails_closed_to_default() {
+        // The HUB Concern 2 contract: typos/novel capacities do NOT fragment the
+        // fold — they collapse to the published default.
+        assert_eq!(
+            normalize_constellation_role("role:constellation:mesh_worker"), // underscore typo
+            DEFAULT_CONSTELLATION_ROLE
+        );
+        assert_eq!(
+            normalize_constellation_role("role:constellation:whatever-i-want"),
+            DEFAULT_CONSTELLATION_ROLE
+        );
+        // A published capacity passes through unchanged.
+        assert_eq!(
+            normalize_constellation_role("role:constellation:mesh-worker"),
+            "role:constellation:mesh-worker"
+        );
+        assert!(is_known_constellation_role(DEFAULT_CONSTELLATION_ROLE));
+    }
 
     /// The canonical example from hub-law-schema.md §1.
     const EXAMPLE_LAW: &str = r#"

--- a/hub/hub-lib/src/state.rs
+++ b/hub/hub-lib/src/state.rs
@@ -125,6 +125,13 @@ pub struct RoleReputation {
     pub v3: web4_core::v3::V3,
     pub observations: u32,
     pub last_updated: DateTime<Utc>,
+    /// Attestation strength of this folded `(subject, role)` bucket — the
+    /// **weakest** sovereign strength of any delta that fed it (HUB Concern 1,
+    /// thread `identity-p1-cospec`). `placeholder` ⇒ member-attested, not
+    /// hub-verified: the subject's `instance_lct` derives from a placeholder
+    /// sovereign and cannot be cryptographically bound. Only a bucket fed
+    /// **exclusively** by hardware-sovereign deltas reports `hardware`.
+    pub sovereign_strength: web4_core::r6::SovereignStrength,
 }
 
 impl RoleReputation {
@@ -134,6 +141,9 @@ impl RoleReputation {
             v3: web4_core::v3::V3::default(),
             observations: 0,
             last_updated: ts,
+            // Neutral bucket, no deltas folded yet → strongest possible; the
+            // first (and every) delta can only weaken it via `min` below.
+            sovereign_strength: web4_core::r6::SovereignStrength::Hardware,
         }
     }
 }
@@ -598,6 +608,11 @@ impl HubState {
                         rep.v3.apply_delta(d, td.change);
                     }
                 }
+                // Fail-closed provenance: the bucket is only as strong as the
+                // weakest delta that fed it. A placeholder-attested delta pins the
+                // bucket to `placeholder` and no later hardware delta can upgrade
+                // the placeholder-era observations back to `hardware`.
+                rep.sovereign_strength = rep.sovereign_strength.min(delta.sovereign_strength);
                 rep.observations += 1;
                 rep.last_updated = ts;
             }
@@ -827,6 +842,7 @@ mod tests {
         let delta = web4_core::r6::ReputationDelta {
             subject_lct: subject.clone(),
             role_lct: "citizen".to_string(),
+            sovereign_strength: web4_core::r6::SovereignStrength::Hardware,
             action_type: "handoff".into(),
             action_target: "hub".into(),
             action_id: "act-1".into(),
@@ -854,6 +870,51 @@ mod tests {
         // Role-contextualized: a different role for the SAME subject is a distinct
         // pairing (no global reputation) — nothing there.
         assert!(state.reputation.get(&(subject, "treasurer".to_string())).is_none());
+        // Single hardware-attested delta → the bucket reports `hardware`.
+        assert_eq!(rep.sovereign_strength, web4_core::r6::SovereignStrength::Hardware);
+    }
+
+    #[tokio::test]
+    async fn fold_pins_bucket_to_weakest_sovereign_strength() {
+        // HUB Concern 2 (identity-p1-cospec): a placeholder-attested delta pins the
+        // (subject, role) bucket to `placeholder`, and a later hardware delta must
+        // NOT upgrade the placeholder-era observations back to `hardware`.
+        use std::collections::HashMap;
+        use web4_core::r6::{ReputationDelta, SovereignStrength, TensorDelta};
+        let sov = IdentityFile::generate(EntityType::Human);
+        let kp = sov.keypair().unwrap();
+        let subject = Uuid::new_v4().to_string();
+        let mk = |strength: SovereignStrength, id: &str| {
+            let mut t3 = HashMap::new();
+            t3.insert("temperament".to_string(),
+                TensorDelta { change: 0.1, from_value: 0.0, to_value: 0.1 });
+            ReputationDelta {
+                subject_lct: subject.clone(),
+                role_lct: "role:constellation:mesh-worker".to_string(),
+                sovereign_strength: strength,
+                action_type: "act".into(), action_target: "hub".into(), action_id: id.into(),
+                rule_triggered: "r".into(), reason: "x".into(),
+                t3_delta: t3, v3_delta: HashMap::new(),
+                contributing_factors: vec![], witnesses: vec![], timestamp: Utc::now(),
+            }
+        };
+        let (_tmp, ledger) = make_ledger_with(vec![
+            (sov.lct.id, &kp, HubEvent::Genesis {
+                hub_name: "Test".into(), charter_hash: "sha256:0".into(),
+                founding_sovereign_lct_id: sov.lct.id, created_at: Utc::now(),
+            }),
+            // hardware first, then a placeholder delta, then hardware again.
+            (sov.lct.id, &kp, HubEvent::ReputationRecorded { delta: mk(SovereignStrength::Hardware, "a1") }),
+            (sov.lct.id, &kp, HubEvent::ReputationRecorded { delta: mk(SovereignStrength::Placeholder, "a2") }),
+            (sov.lct.id, &kp, HubEvent::ReputationRecorded { delta: mk(SovereignStrength::Hardware, "a3") }),
+        ]).await;
+        let state = HubState::project(&ledger);
+        let rep = state.reputation
+            .get(&(subject, "role:constellation:mesh-worker".to_string()))
+            .expect("bucket projected");
+        assert_eq!(rep.observations, 3);
+        assert_eq!(rep.sovereign_strength, SovereignStrength::Placeholder,
+            "one placeholder delta must pin the whole bucket to placeholder (fail-closed)");
     }
 
     #[tokio::test]
@@ -871,6 +932,7 @@ mod tests {
         let delta = web4_core::r6::ReputationDelta {
             subject_lct: subject.clone(),
             role_lct: "citizen".to_string(),
+            sovereign_strength: Default::default(),
             action_type: "handoff".into(), action_target: "hub".into(), action_id: "a".into(),
             rule_triggered: "r".into(), reason: "x".into(),
             t3_delta, v3_delta: HashMap::new(),

--- a/web4-core/src/r6.rs
+++ b/web4-core/src/r6.rs
@@ -221,6 +221,34 @@ pub struct ContributingFactor {
     pub description: String,
 }
 
+/// Attestation strength of the emitter's sovereign identity, carried on a
+/// [`ReputationDelta`] so the hub fold can qualify per-instance reputation.
+///
+/// A `subject_lct` derived from a **placeholder** sovereign (e.g. hestia's
+/// `lct:web4:hestia:sovereign:phase1-placeholder`) cannot be cryptographically
+/// bound to its claimed instance — the hub records the delta but must tag the
+/// folded bucket as **member-attested, not hub-verified**. When the hardware
+/// sovereign (TPM / P0 track) lands, the emitter flips this to `Hardware` and
+/// the instance identity becomes unforgeable. Fail-closed: absent ⇒
+/// `Placeholder` (the weakest claim), and a bucket is only as strong as the
+/// weakest delta that fed it (see `identity-p1-cospec`, HUB Concern 1).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SovereignStrength {
+    /// Member-attested only: the sovereign is a phase-1 placeholder, so the hub
+    /// cannot verify the `(instance, role)` binding. Ordered **below** `Hardware`.
+    Placeholder,
+    /// Hardware-bound sovereign (TPM): the `instance_lct` is unforgeable.
+    Hardware,
+}
+
+impl Default for SovereignStrength {
+    fn default() -> Self {
+        // Fail-closed: an unstated strength is the weakest claim.
+        SovereignStrength::Placeholder
+    }
+}
+
 /// R7's first-class reputation output — explicit trust/value delta per action.
 ///
 /// Key: reputation is ROLE-CONTEXTUALIZED. The `role_lct` field determines
@@ -231,6 +259,11 @@ pub struct ReputationDelta {
     pub subject_lct: String,
     /// WHICH ROLE CONTEXT (the MRH link, not global)
     pub role_lct: String,
+    /// Attestation strength of the emitter's sovereign (see [`SovereignStrength`]).
+    /// Backward-compatible: deltas emitted before this field existed deserialize
+    /// as `Placeholder` (the fail-closed default), never fabricating `Hardware`.
+    #[serde(default)]
+    pub sovereign_strength: SovereignStrength,
     /// What action caused the change
     pub action_type: String,
     /// Target of the action
@@ -435,6 +468,7 @@ impl R7Action {
         self.reputation = Some(ReputationDelta {
             subject_lct: self.role.actor_lct.clone(),
             role_lct: self.role.role_lct.clone(),
+            sovereign_strength: SovereignStrength::default(),
             action_type: self.request.action.clone(),
             action_target: self.request.target.clone(),
             action_id: self.action_id.clone(),


### PR DESCRIPTION
HUB's coordinated half of thread `identity-p1-cospec` (Legion ↔ HUB). Both items are from HUB's own identity-1 review recommendations; Legion asked HUB to publish them so hestia can wire against them. hestia#10 already shipped the solo half (WHO+WHY witnessed).

## Concern 2 — role vocabulary (`hub-lib/src/law.rs`)
- Publish `KNOWN_CONSTELLATION_ROLES` — the session-capacity `role_lct` set: `interactive-dev`, `mesh-worker`, `reviewer`, `autonomous-timer`, + the `role:constellation:member` fail-closed default. **Distinct namespace** from the society `KNOWN_ROLES` (sovereign/administrator/…), which type delegation/admission/ATP authority, not instance capacity.
- `normalize_constellation_role()` fails closed to the default on any unpublished value → a typo'd/novel capacity (`mesh_worker`) can't fragment the #430 fold. Members validate at connect and stamp the returned canonical string as `role_lct`.

## Concern 1 — attestation-strength provenance (`web4-core` + hub fold)
- `SovereignStrength { placeholder, hardware }` + `sovereign_strength` on `ReputationDelta`. `#[serde(default)] = placeholder` → backward-compatible + fail-closed (a pre-field/unstated delta never fabricates `hardware`).
- The fold tags each `(subject, role)` `RoleReputation` with the **weakest** strength of any delta that fed it (placeholder sticky-down): one placeholder-attested delta pins the bucket to member-attested, and no later hardware delta upgrades the placeholder-era observations. Surfaced on the `reputation` read.

## Division of labor (per thread)
- **HUB (this PR):** publish the enum + the field + fold-side tagging.
- **Legion (hestia follow-up):** validate the declared `role` at connect against the published set; emit `sovereign_strength: "placeholder"` on each delta (flips to `"hardware"` when the TPM sovereign lands).

## Tests
Namespace-disjointness, fail-closed normalization, weakest-strength fold. `web4-core` 159 + `hub-lib`/`hub-daemon` 175 pass; clippy clean.

⚠️ Not self-merging: opened from a hub-mesh-fired session. Merge is left for the hub supervisor cycle / human gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)