### PR TITLE
sec(hub): test harness seals nonce+issued_at on channel requests (H-007 Phase-1)

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -5125,7 +5125,16 @@ mod channel_e2e_tests {
         tool: &str,
         args: serde_json::Value,
     ) -> String {
-        let inner = serde_json::json!({ "tool": tool, "args": args });
+        // H-007 Phase 1: the test harness seals what a real client (channel_client)
+        // does — nonce + issued_at on the ChannelInner — so the ~35 harness channel
+        // calls stay green once Phase-2 enforcement requires freshness on write
+        // tools. Behaviorally a no-op today (the hub tolerates both fields).
+        let inner = serde_json::json!({
+            "tool": tool,
+            "args": args,
+            "nonce": Uuid::new_v4().to_string(),
+            "issued_at": chrono::Utc::now().to_rfc3339(),
+        });
         let pt = serde_json::to_vec(&inner).unwrap();
         pair_channel::seal(applicant, hub_pub, pair_id, &pt)
             .unwrap()


### PR DESCRIPTION
HUB's **Phase-1 half** of the H-007/H-008 mesh-freshness rollout (coordination thread `sec-mesh-freshness`).

The ~35 harness channel calls (via `seal_req`) sealed a bare `{tool, args}` — no ChannelInner freshness — so a prototyped H-007 enforcement 400'd 23 of them. `seal_req` now seals `{tool, args, nonce, issued_at}` exactly like the `channel_client` reference, so the harness stays green once Phase-2 enforcement lands. **Behaviorally a no-op today** (the hub tolerates both fields).

Sequencing: Legion's half is hestia#15 (`channel_query` freshness). **Phase-2 (hub enforcement) flips only after both sides post 'Phase-1 shipped'** — not in this PR. Full suite green (49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)