### PR TITLE
feat(ontology): promote role-extension.{md,ttl} to web4-standard (Phase-0, CBP green-light)

### DIFF
--- a/web4-standard/ontology/role-extension-schema.md
+++ b/web4-standard/ontology/role-extension-schema.md
@@ -1,0 +1,263 @@
+---
+date: 2026-07-08
+from: Legion (web4-core/schema owner)
+status: Phase-0 PROMOTED to web4-standard/ontology/ on CBP green-light (forum/cbp-to-legion-hub-phase0-2.3-witness-green-light-2026-07-08.md; concord: forum/cbp-to-legion-hub-phase0-concord-ratified-2026-07-08.md). role:driftMark enum is PROVISIONAL pending HUB naming confirmation (CBP condition (a)).
+thread: hestia-role-orchestration
+framework: R6
+covers: Legion's three green-lit drafts — (1) role_extension RDF schema, (2) 3-level law-composition spec, (3) hestia-string → Role-LCT migration
+grounds-against:
+  - web4-core::role::{SocietyRole, RoleAssignment, RoleEvent}     (deployed)
+  - web4-core::lct::EntityType::Role                              (deployed)
+  - hestia::policy::{PolicyConfig, PolicyRule, PolicyMatch, PolicyDecision, PolicyEvaluation, fold_strictest}  (deployed)
+  - hestia::reputation CONSTELLATION_ROLES + per-(instance,role) trust (deployed, #18/#22/#24)
+canon-companion: ./role-extension.ttl (Turtle vocabulary, 90 triples, rdflib-clean; promoted alongside this doc)
+---
+
+# Phase-0 schema drafts — Hestia role-entity orchestration
+
+This document turns the ratified concord into three concrete drafts Legion owns. It is written
+against **what is already deployed**, not a blank slate: `EntityType::Role`, `SocietyRole` +
+`base_mandatory()`, `RoleAssignment`/`RoleEvent`, and hestia's `fold_strictest` policy engine all
+exist. The Phase-0 work is the **law extension attached to a role LCT** and the **third fold level**,
+not the entity or the fold operator.
+
+Two-layer naming is used throughout, as adopted:
+
+- **SocietyRole** — governance *function* (`web4-core::role::SocietyRole`): the 7 base-mandatory
+  (+ Witness/Auditor context-mandatory). Fills R6 elements. This is what Hestia must *hold* before it
+  may orchestrate.
+- **orchestration Role-entity** — a *staffed capacity* the sovereign defines/staffs/launches:
+  `EntityType::Role` + `SocietyRole::Custom("…")`, e.g. `mesh-worker`. Operates **under** the
+  SocietyRoles' law. This is the thing dp asked to "define, staff, assign an agent to."
+
+A `role_extension` (draft 1) attaches to an **orchestration Role-entity's** LCT. It is folded under
+society + constellation law (draft 2). Migration (draft 3) lifts today's hestia constellation-role
+strings into orchestration Role-entities carrying such extensions.
+
+---
+
+## Draft 1 — the `role_extension` document schema
+
+### 1.1 What it is
+
+A `role_extension` is the machine-readable law attached to an orchestration Role-entity's LCT. It has
+exactly three parts, each RDF-typed (Turtle vocabulary in the companion `.ttl`):
+
+| part | question it answers | folds as |
+|---|---|---|
+| **affordances** | what MAY this role's occupant do? | a set of `PolicyRule`s + a default verdict (tightening-only overlay) |
+| **responsibilities** | what MUST the occupant do, and on what cadence? | duty/cadence/reporting obligations (checked by the Witness daemon, not the launcher) |
+| **scope / MRH** | over what resources does the grant range? | repos / machines / channels / data classes / ATP budget |
+
+Bound to the role LCT (`RoleAssignment.role_lct_id`), **never** to the occupant. When the occupant
+rotates (`RoleEvent::FillerAdded`/`FillerEjected`), the extension is unchanged — authority binds to
+the role, per `role.rs`'s stated principle.
+
+### 1.2 Affordances are typed so a flag-set is machine-checkable
+
+The load-bearing requirement (the `--dangerously-skip-permissions` case): an affordance is not free
+text. It is a typed grant the launcher can check a concrete launch invocation against **before**
+spawning. Affordance types:
+
+- `ToolAffordance` — permits a tool/category (maps to `PolicyMatch.tools` / `.categories`).
+- `ChannelAffordance` — permits a mesh channel / hub endpoint.
+- `RepoAffordance` — permits a repo (+ optional path glob, + read vs write-class).
+- `WriteClassAffordance` — permits a write-class (`commit`, `push`, `merge`, `delete`, `outward-send`).
+- `CliFlagAffordance` — permits a specific launcher flag. **`--dangerously-skip-permissions` is
+  exactly a `CliFlagAffordance` whose absence in the extension means the launcher MUST refuse to pass
+  the flag.** A flag the occupant tries to use but the role does not afford = fail-closed refusal,
+  not a warning.
+
+Machine-check contract (launcher side, deployed pattern HST-004 generalizes):
+`launch_request.flags ⊆ role_extension.cli_flag_affordances` AND every requested tool/repo/write-class
+is covered — else the launch is denied at spawn time, before the R6 act is even attempted.
+
+### 1.3 Affordances tighten, never grant (monotone)
+
+An affordance in a `role_extension` can only ever be *at most* as broad as what constellation +
+society law already allow — it **removes** capability, never adds it. This is not enforced by trusting
+the document; it is enforced by the fold (§Draft 2): the extension enters `fold_strictest` as the
+*role* overlay, and `fold_strictest` provably cannot loosen the base. A `role_extension` that
+*appears* to grant something the parent denies is not honored — the fold discards it. So the schema
+carries affordances as **the permit surface the role claims**; the fold is what makes the claim safe.
+
+---
+
+## Draft 2 — 3-level law composition
+
+### 2.1 Topology (fixed by the concord)
+
+Today hestia folds 2 levels: `constellation_base ∧ role_overlay` via `fold_strictest`. Phase-0 adds
+the **society** level:
+
+```
+effective_law = society  ∧  constellation  ∧  role_extension
+              = fold_strictest( fold_strictest(society, constellation), role_extension )
+```
+
+`fold_strictest` is associative and strictest-wins (`Allow` < `Warn` < `Deny`, ties break toward
+`enforced` — `types.rs:158`), so the 3-level fold is just the existing operator applied twice. **No new
+fold math.** The society level is populated, not invented.
+
+### 2.2 Eval-time is the invariant; write-time is an additive linter
+
+Ratified. The **load-bearing guarantee is the eval-time strictest-wins fold**, run locally at the
+moment of acting (every launch and every write-class act), because law is continuous-at-act — parent
+law moves under a once-valid extension.
+
+Write-time schema-rejection is an **additive authoring linter**, explicitly **not a proof**: it
+certifies an extension against a *snapshot* of parent law at authoring time. A green lint is not a
+promise the role keeps launching. It is labeled best-effort-at-authoring and nothing downstream may
+treat it as an enforcement guarantee.
+
+### 2.3 Eval-time denial distinguishes its cause — via a persisted authoring-validity witness
+
+Per CBP's §2 addition, an eval-time denial MUST carry a distinguishable cause, because different
+situations all surface as "role denied here":
+
+- **(a) `author:violation`** — the extension exceeds parent law → **author error.** The operator wrote
+  a bad role.
+- **(b) `drift:parent-tightened`** — the extension was valid when authored, but society/constellation
+  law later tightened under it → **silent role-rot, not the author's fault.** Fail-closed, but the mark
+  says *the law moved*, not *you wrote this wrong*.
+
+**The fold alone cannot tell (a) from (b)** (CBP's load-bearing catch, folded in here). Both present
+identically at eval-time — the *role overlay* is permissive (`Allow`/looser) and the **base** (society ∧
+constellation) produces the deny; `fold_strictest` chose the base over the role. That shape is the same
+whether the extension *never* was valid (a) or *once* was (b). The eval-time fold holds only the
+**current** parent law, so it cannot know whether the extension was **ever** valid. The discriminator is
+**history**, and it lives in exactly one place: the write-time linter's recorded verdict.
+
+So the write-time linter (the thing §2.2/§4 correctly demote to "not an enforcement proof") has one
+residual, load-bearing job: **being the durable record of "was this ever valid."** Its persisted output
+is the *attribution anchor*. The schema therefore persists an authoring-validity witness on every
+extension (TTL: `role:authoredUnder` + `role:lintVerdict`):
+
+- `role:authoredUnder` — the parent-law version/snapshot the linter checked against at authoring time.
+- `role:lintVerdict` — `pass | fail` against that snapshot.
+
+Eval-time attribution then **reads** the witness rather than re-deriving from the fold:
+
+| `role:lintVerdict` | meaning | `role:driftMark` on an eval-time deny |
+|---|---|---|
+| `fail` | exceeded parent even when written | **`author:violation`** |
+| `pass` | valid when written, parent later moved | **`drift:parent-tightened`** |
+| *absent* | no witness (offline / linter skipped / pre-migration string-role) | **`drift:unattributed`** |
+
+**(c) `drift:unattributed`** is the third state CBP's asks add: an extension with no witness has no
+attributable history, so it is **denied, cause unknown** — never silently mislabeled as (a) or (b).
+Fail-closed on the deny, honest on the cause. `role:driftMark`'s range is therefore the **three** values
+`author:violation | drift:parent-tightened | drift:unattributed`.
+
+Proposed surface unchanged: the mark rides in `PolicyEvaluation.constraints` for the audit trail,
+honoring the fail-closed-plus-warn default and §4's mark-don't-punish posture. This keeps §2.2's
+"best-effort at authoring" label honest — the linter is not a proof, but its *persisted* verdict is what
+lets an eval-time denial carry a truthful cause instead of a guess. Neither the fold math (§2.1) nor the
+topology (§2.4) changes: one durable field-pair and one extra marker value make §2.3's promise
+("distinguishable cause") actually deliverable rather than same-shaped-at-the-fold.
+
+### 2.4 Society law arrives as a served document, folded locally (pinned by Q2 + Q4)
+
+The society level does **not** arrive via a live hub fold at launch. That would make the hub a
+mandatory launch dependency, violating Q2 (hub must not be a mandatory launch dependency; ≥1
+non-launching witness; fail-closed). So:
+
+> **Society law arrives as a served document the sovereign folds locally**, cached under the same
+> staleness discipline as observe-only law (Q4: 24h ceiling / cadence default). The 3-level fold runs
+> **locally at eval-time on cached-but-fresh law** — hub reachable or not.
+
+Two orthogonal guarantees, not to be conflated:
+
+- **law freshness** — served-doc + staleness ceiling (this section). About *composition*.
+- **act attestation** — high-consequence launches still need the live non-launching-witness
+  counter-sign (Q2). About *the launch act*.
+
+HUB owns the Law-Oracle **serving endpoint** (the `§3.2` deliverable); the **fold topology** above is
+fixed by the concord and lives on the folding (Legion/hestia) side. If cached society law is older
+than the Q4 ceiling, the fold treats the stale level as fail-closed (deny-by-default for
+high-consequence classes), not as absent.
+
+---
+
+## Draft 3 — hestia string-role → Role-LCT migration (Phase-1 audit-first mirror)
+
+### 3.1 Current state (deployed)
+
+`hestia::reputation` publishes a fixed constellation-role **string** set and already keys per-role
+trust on it:
+
+```
+role:constellation:interactive-dev
+role:constellation:mesh-worker
+role:constellation:reviewer
+role:constellation:autonomous-timer
+role:constellation:member        (DEFAULT_CONSTELLATION_ROLE)
+```
+
+Trust is already per-`(instance, role)` (#22); the `reversal` R7 signal already writes
+`(subject_instance_lct, role_lct)` un-collapsed (#24). The strings are the only thing not yet
+first-class entities.
+
+### 3.2 Migration = one orchestration Role-entity per string
+
+For each constellation string, mint one orchestration Role-entity:
+
+- `EntityType::Role` LCT via `LctBuilder` (the role's own LCT).
+- `SocietyRole::Custom("constellation:mesh-worker")` — the string becomes the entity's canonical label.
+- a `role_extension` (draft 1) whose affordances are the **lifted launcher primer** for that role:
+  the launcher's current fail-closed flag-set (`HESTIA_ROLE` + HST-004 posture) expressed as typed
+  `CliFlagAffordance`/`ToolAffordance`/`WriteClassAffordance` grants. "Primer IS law, flags ARE
+  affordances" becomes literal — the primer is *read* into the extension, one-to-one.
+
+### 3.3 Audit-first, non-destructive
+
+Phase-1 is a **mirror**, not a cutover:
+
+1. Mint the Role-entities + extensions, bound to the existing role strings as their labels.
+2. Continue keying trust on `role_lct` (already the case) — the string→LCT map means **no trust
+   history is orphaned**; a divergent string still resolves to the same role LCT (the `reputation.rs`
+   comment already anticipates this: "a divergent `mesh-worker` vs … keys on `role_lct`").
+3. Run the 3-level fold in **observe/audit mode** (`PolicyConfig.enforce = false`) alongside the live
+   2-level enforcement. Log every place the folded-in society level *would* change a verdict. That
+   divergence log is the Phase-1 deliverable — it proves the society level is correct before it is
+   allowed to deny anything.
+4. Flip `enforce = true` per role only after its audit log is clean.
+
+`DEFAULT_CONSTELLATION_ROLE` (`member`) migrates last and stays the fail-closed floor: an unmigrated
+or unknown occupant resolves to `member`'s extension, which grants the least.
+
+Migration also **stamps the authoring-validity witness** (§2.3): each lifted extension is linted against
+the migration-time parent-law version and gets `role:authoredUnder` + `role:lintVerdict` recorded. A
+pre-migration string-role that is enforced *before* it carries a witness resolves to `drift:unattributed`
+on any eval-time deny — denied, cause honestly unknown — which is the correct fail-closed posture until
+migration back-fills the witness.
+
+---
+
+## Schema REQUIREMENTS elevated from the two hardenings (concord-binding)
+
+Per the ratified concord these are no longer "satisfied by current code" — they are **explicit schema
+requirements** so HUB's surface half is bound too and cannot re-collapse the pair:
+
+- **H1 — un-collapsed reputation.** `Result` / `ReputationDelta` MUST persist
+  `(role_lct, occupant_instance_lct)` as **separate fields**, never collapsed at write time. The
+  law-defined occupant-major 70/30 split is applied **at read/fold time only** — a re-tunable
+  projection, never a lossy write. Phase-3 must be able to falsify the 70/30 split from the raw
+  stream. (Deployed in Legion's `reversal`/`ReputationDelta`; now required of any surface that writes
+  reputation, incl. HUB.)
+- **H2 — tamper-evident deferred launch-act queue.** The deferred launch-act (unanchored) queue MUST
+  reuse the **nonced append-only freshness primitive** (#16), so a suppressed entry is a detectable
+  sequence/nonce gap at anchor time. **Deferred ≠ deniable.** No bespoke sequence.
+
+---
+
+## Division of ownership (from the concord)
+
+- **Legion (this doc):** `role_extension` RDF schema, 3-level composition spec, string→LCT migration.
+- **HUB:** Witness watcher daemon, Roles UI, launcher-primer → law migration surface, and the §3.2
+  Law-Oracle **serving endpoint** (topology fixed above; HUB confirms the endpoint shape).
+
+Open for HUB react: the drift-mark set is now **three** values —
+`author:violation | drift:parent-tightened | drift:unattributed` (§2.3) — rendered in HUB's audit UI.
+Confirm that surface / naming, or name a better one. Note `drift:unattributed` needs a distinct UI
+affordance from the other two: it means *cause unknown*, not *cause known-and-benign*.

--- a/web4-standard/ontology/role-extension.ttl
+++ b/web4-standard/ontology/role-extension.ttl
@@ -1,0 +1,165 @@
+@prefix web4:  <https://web4.io/ontology#> .
+@prefix role:  <https://web4.io/ontology/role/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+# =============================================================================
+# Role-Extension Ontology — law attached to an orchestration Role-entity's LCT
+#
+# Phase-0 — promoted to canonical home on CBP green-light
+# (forum/cbp-to-legion-hub-phase0-2.3-witness-green-light-2026-07-08.md;
+#  concord: forum/cbp-to-legion-hub-phase0-concord-ratified-2026-07-08.md).
+# Prose companion: ./role-extension-schema.md
+#
+# PROVISIONAL SURFACE: the role:driftMark enum (three string values) promotes as
+# PROVISIONAL pending HUB confirmation of the audit-UI naming (CBP condition (a)).
+# A later HUB rename is a clarification of a provisional note, not a break of a
+# ratified standard. See role:driftMark below. Phase-1 may formalize the enum as a
+# controlled vocabulary (owl:oneOf / SKOS) — CBP condition (b), held for Phase-1.
+#
+# An orchestration Role-entity is EntityType::Role + SocietyRole::Custom(..) with
+# its own LCT. A role:Extension is the machine-readable law bound to that LCT.
+# It composes UNDER society + constellation law via strictest-wins fold — an
+# extension can only TIGHTEN (remove affordances), never grant.
+# =============================================================================
+
+role: a owl:Ontology ;
+    dcterms:title "Web4 Role-Extension Ontology" ;
+    dcterms:description "Schema for the law extension attached to an orchestration Role-entity LCT: affordances, responsibilities, scope/MRH." ;
+    owl:versionInfo "0.1.0-draft" .
+
+# --- Core classes ---
+
+role:Extension a rdfs:Class ;
+    rdfs:label "Role Extension" ;
+    rdfs:comment "The law bound to an orchestration Role-entity LCT. Exactly three parts: affordances, responsibilities, scope. Folds under society and constellation law as the strictest-wins role overlay." .
+
+role:Affordance a rdfs:Class ;
+    rdfs:label "Affordance" ;
+    rdfs:comment "A typed capability the role's occupant MAY exercise. Typed so a concrete launch invocation is machine-checkable against it before spawn. Tightening-only: honored by the fold iff parent law already permits it." .
+
+role:Responsibility a rdfs:Class ;
+    rdfs:label "Responsibility" ;
+    rdfs:comment "A duty the occupant MUST discharge, with cadence and reporting. Checked by the Witness daemon, not the launcher." .
+
+role:Scope a rdfs:Class ;
+    rdfs:label "Scope / MRH" ;
+    rdfs:comment "The Markov Relevancy Horizon of the grant: repos, machines, channels, data classes, ATP budget the role ranges over." .
+
+# --- Affordance subclasses (the typed permit surface) ---
+
+role:ToolAffordance a rdfs:Class ;
+    rdfs:subClassOf role:Affordance ;
+    rdfs:comment "Permits a tool or tool-category. Maps to hestia PolicyMatch.tools / .categories." .
+
+role:ChannelAffordance a rdfs:Class ;
+    rdfs:subClassOf role:Affordance ;
+    rdfs:comment "Permits a mesh channel or hub endpoint." .
+
+role:RepoAffordance a rdfs:Class ;
+    rdfs:subClassOf role:Affordance ;
+    rdfs:comment "Permits a repo, optionally narrowed by path glob and read-vs-write-class." .
+
+role:WriteClassAffordance a rdfs:Class ;
+    rdfs:subClassOf role:Affordance ;
+    rdfs:comment "Permits a write-class: commit | push | merge | delete | outward-send." .
+
+role:CliFlagAffordance a rdfs:Class ;
+    rdfs:subClassOf role:Affordance ;
+    rdfs:comment "Permits a specific launcher flag. Absence is fail-closed: the launcher MUST refuse a flag the role does not afford. --dangerously-skip-permissions is exactly this." .
+
+# --- Extension structural properties ---
+
+role:boundToRoleLct a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "The Role-entity LCT this extension governs (RoleAssignment.role_lct_id). Authority binds here, NEVER to the occupant; unchanged across occupant rotation." .
+
+role:hasAffordance a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range role:Affordance .
+
+role:hasResponsibility a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range role:Responsibility .
+
+role:hasScope a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range role:Scope .
+
+role:defaultVerdict a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range xsd:string ;
+    rdfs:comment "allow | warn | deny — the overlay's verdict when no affordance matches. Fail-closed roles default to deny." .
+
+# --- Affordance detail properties ---
+
+role:permits a rdf:Property ;
+    rdfs:domain role:Affordance ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The concrete grant token (tool name, channel id, repo, write-class, or flag)." .
+
+role:pathGlob a rdf:Property ;
+    rdfs:domain role:RepoAffordance ;
+    rdfs:range xsd:string .
+
+role:writeClass a rdf:Property ;
+    rdfs:domain role:RepoAffordance ;
+    rdfs:range xsd:string ;
+    rdfs:comment "read | commit | push | merge | delete." .
+
+# --- Responsibility detail properties ---
+
+role:cadence a rdf:Property ;
+    rdfs:domain role:Responsibility ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Cron-like or event trigger describing how often the duty is due." .
+
+role:reportsTo a rdf:Property ;
+    rdfs:domain role:Responsibility ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "The Witness/Auditor role LCT that attests discharge of this duty." .
+
+# --- Scope detail properties ---
+
+role:atpBudget a rdf:Property ;
+    rdfs:domain role:Scope ;
+    rdfs:range xsd:decimal ;
+    rdfs:comment "ATP ceiling the role may spend per period. Enforced by Treasurer at act time." .
+
+role:rangesOver a rdf:Property ;
+    rdfs:domain role:Scope ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "A resource (repo, machine, channel, data class) inside the role's MRH." .
+
+# --- Composition / fold properties (eval-time invariant) ---
+
+role:foldsUnder a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "The parent law level (society or constellation) this extension composes under via strictest-wins fold. Extension can only tighten." .
+
+# --- Authoring-validity witness (the write-time linter's DURABLE output) ---
+# The eval-time fold holds only CURRENT parent law, so it cannot tell 'was ever
+# valid' from 'never valid' — both surface as (overlay-permissive, base-denies).
+# The discriminator is history. These two properties persist the write-time
+# linter's verdict so an eval-time denial can carry a TRUTHFUL cause. Write-time
+# is still not an enforcement proof (eval-time is the invariant); this is its
+# residual, load-bearing job.
+
+role:authoredUnder a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "The parent-law version/snapshot the write-time linter checked this extension against at authoring time. The attribution anchor: paired with role:lintVerdict it records whether the extension was EVER valid." .
+
+role:lintVerdict a rdf:Property ;
+    rdfs:domain role:Extension ;
+    rdfs:range xsd:string ;
+    rdfs:comment "'pass' | 'fail' — the write-time linter's recorded verdict against role:authoredUnder. pass ⟹ a later eval-time deny is drift:parent-tightened; fail ⟹ author:violation; absent ⟹ drift:unattributed. Persisted, not throwaway." .
+
+role:driftMark a rdf:Property ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Eval-time denial cause, read from the authoring-validity witness (role:authoredUnder + role:lintVerdict), NOT re-derived from the fold alone (the fold cannot tell these apart — all three present as overlay-permissive/base-denies). One of three: 'author:violation' (lintVerdict=fail — extension exceeded parent even at authoring — author error) | 'drift:parent-tightened' (lintVerdict=pass — once-valid extension, parent later tightened — silent role-rot, not the author's fault) | 'drift:unattributed' (no witness — offline/linter-skipped/pre-migration string-role — denied, cause unknown; fail-closed on the deny, honest on the cause). Emitted into PolicyEvaluation.constraints. STABILITY: these three enum strings are PROVISIONAL pending HUB confirmation of the audit-UI naming (CBP condition (a), 2026-07-08); a HUB rename is a clarification, not a standard break. drift:unattributed requires a DISTINCT UI affordance from the other two — cause-unknown, not cause-known-benign." .


### PR DESCRIPTION
## What

Promotes the `hestia-role-orchestration` Phase-0 vocabulary from `shared-context/specs/hestia-role-orchestration/` to its canonical home `web4-standard/ontology/`:

- `role-extension.ttl` — **90 triples, `rdflib` parse clean**.
- `role-extension-schema.md` — prose companion.

## Why now

CBP ground-truthed the delivery (re-parsed the TTL, checked each property) and gave a **green-light** to promote — see `shared-context/forum/cbp-to-legion-hub-phase0-2.3-witness-green-light-2026-07-08.md` (thread `hestia-role-orchestration`). The §2.3 witness fix that closed CBP's load-bearing catch is baked into the ontology comment where it can't be lost.

## What the vocabulary carries

- **Typed affordance surface** — `CliFlag/Tool/Repo/Channel/WriteClass`. `--dangerously-skip-permissions` is a `CliFlagAffordance` whose absence is fail-closed refusal.
- **3-level strictest-wins fold** — `society ∧ constellation ∧ role_extension` = existing `fold_strictest` applied twice. No new fold math.
- **Authoring-validity witness** — `role:authoredUnder` + `role:lintVerdict` persist the write-time linter's verdict so an eval-time deny carries a truthful cause (`author:violation | drift:parent-tightened | drift:unattributed`) the fold alone cannot derive — all three present identically at the fold.

## CBP condition (a) — carried on this PR (does not block it)

The `role:driftMark` three-value enum promotes as **PROVISIONAL** pending HUB confirmation of the audit-UI naming. A later HUB rename is then a clarification of a provisional note, not a break of a ratified standard. Recorded in the TTL header + on `role:driftMark`'s comment + schema front-matter. CBP condition (b) — formalize as a controlled vocabulary (`owl:oneOf`/SKOS) — held for Phase-1.

## Gate

A mesh green-light is **not** a merge. This PR runs the normal human gate + hub-track ritual. Eval-time strictest-wins fold remains the invariant; topology and fold math are unmoved from the reviewed draft.

## Still owed by HUB (not blocking this PR)

1. §3.2 Law-Oracle serving-endpoint shape.
2. Confirm/name the three drift markers — `drift:unattributed` needs a **distinct** UI affordance (cause-unknown ≠ cause-known-benign). HUB's marker confirmation is what lifts the provisional note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)