### PR TITLE
release(web4-core): 0.2.0 → 0.3.0 for publish

### DIFF
--- a/web4-core/Cargo.toml
+++ b/web4-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web4-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["dp-web4 <dp@metalinxx.io>"]
 description = "Web4 trust-native infrastructure core library"

--- a/web4-core/src/role.rs
+++ b/web4-core/src/role.rs
@@ -20,8 +20,6 @@
 //!
 //! Reference: `web4-standard/core-spec/society-roles.md`
 
-use crate::lct::{EntityType, Lct};
-use crate::crypto::KeyPair;
 use crate::t3::T3;
 use crate::v3::V3;
 use chrono::{DateTime, Utc};

--- a/web4-core/src/society.rs
+++ b/web4-core/src/society.rs
@@ -23,9 +23,7 @@
 //! Reference: `web4-standard/core-spec/inter-society-protocol.md`,
 //!            `web4-standard/core-spec/society-roles.md`
 
-use crate::crypto::KeyPair;
 use crate::error::{Result, Web4Error};
-use crate::lct::{EntityType, Lct};
 use crate::role::{RoleAssignment, SocietyRole};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/web4-trust-core/Cargo.toml
+++ b/web4-trust-core/Cargo.toml
@@ -43,7 +43,7 @@ getrandom = { version = "0.2", optional = true }
 # Non-optional as of P3b: EntityTrust holds `web4_core::t3::T3` / `web4_core::v3::V3`
 # internally, so the canonical engine is required for the default build (not just
 # the WASM bindings, which also re-export web4-core role/society/atp/r6 types).
-web4-core = { path = "../web4-core", version = "0.2" }
+web4-core = { path = "../web4-core", version = "0.3" }
 
 # WASM-specific uuid with JS random source
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
**crates.io `web4-core` is stale** — pinned at 0.2.0 (published 2026-05-16), but the repo has moved **18 web4-core commits** past it: role entities (#489), canonical T3/V3 (#445), `sovereign_strength` (#457), the Act primitive + time/events (#369), the vault, and the EUDI/OID4VCI/SD-JWT-VC stack. Several are breaking → 0.x minor bump **0.2.0 → 0.3.0** (0.2.0 is immutable, can't republish).

- **web4-core** → `0.3.0`; removed 4 genuinely-unused imports so the published crate packages warning-clean.
- **web4-trust-core** → its web4-core dep constraint `0.2 → 0.3` (the only crate with a version constraint; all others use web4-core by path, unaffected).

**Fleet is unaffected** (everything consumes web4-core by path) — this is purely for external crates.io adopters + credibility. Verified: web4-trust-core builds against web4-core@0.3, 164 web4-core tests green, publish dry-run packages clean. **`cargo publish` is a follow-up operator step (your crates.io token).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)