### PR TITLE
docs: refresh STATUS + web4-core README + hub status (0.2/0.3 line)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Web4 Implementation Status
 
-**Last Updated**: June 15, 2026
+**Last Updated**: July 9, 2026
 
 ---
 
@@ -28,20 +28,22 @@ The strongest single external validation: a 2026-05-13 three-round Kimi 2.6 cros
 
 ---
 
-## Published artifacts (current: v0.1.1, 2026-04-28)
+## Published artifacts (current: v0.2.0)
 
 | Package | Registry | Version | Install |
 |---|---|---|---|
-| **web4-core** (Rust) | [crates.io](https://crates.io/crates/web4-core) | 0.1.1 | `cargo add web4-core` |
-| **web4-core** (Python) | [PyPI](https://pypi.org/project/web4-core/) | 0.1.1 | `pip install web4-core` |
-| **web4-trust-core** (Rust) | [crates.io](https://crates.io/crates/web4-trust-core) | 0.1.1 | `cargo add web4-trust-core` |
-| **web4-trust** (Python) | [PyPI](https://pypi.org/project/web4-trust/) | 0.1.1 | `pip install web4-trust` |
+| **web4-core** (Rust) | [crates.io](https://crates.io/crates/web4-core) | 0.2.0 | `cargo add web4-core` |
+| **web4-core** (Python) | [PyPI](https://pypi.org/project/web4-core/) | 0.2.0 | `pip install web4-core` |
+| **web4-trust-core** (Rust) | [crates.io](https://crates.io/crates/web4-trust-core) | 0.2.0 | `cargo add web4-trust-core` |
+| **web4-trust** (Python) | [PyPI](https://pypi.org/project/web4-trust/) | 0.2.0 | `pip install web4-trust` |
 
-> v0.1.0 yanked from crates.io: the Python `web4-core` wheel shipped without `__init__.py`, so `import web4_core` returned an empty module. Fixed in v0.1.1; v0.1.0 PyPI artifacts remain installable but `web4-trust`'s docstring also incorrectly described tensors as "6-dimensional" (canonical: 3 root dims, fractally extensible via `web4:subDimensionOf`). Use v0.1.1.
+> **`web4-core` 0.3.0 is queued** — the repo has moved well past the published 0.2.0 (role entities, canonical T3/V3, the Act primitive, EUDI/OID4VC, the vault). Use the latest published (0.2.0) until 0.3.0 lands.
+>
+> *Historical:* v0.1.0 was yanked (Python wheel shipped without `__init__.py`); fixed in 0.1.1. Use the latest.
 
 All AGPL-3.0-or-later. Patent grant terms: [PATENTS.md](PATENTS.md). Commercial licensing: contact Metalinxx Inc. via the [project repository](https://github.com/dp-web4/web4).
 
-`web4-core` provides LCT (Linked Context Token) primitives + T3/V3 trust tensors + identity coherence + ledger anchoring (`InMemoryLedger`, `LocalLedger`). `web4-trust-core` adds trust persistence and witnessing primitives. The Python wheels are PyO3-built bindings over the same Rust core.
+`web4-core` provides LCT (Linked Context Token) primitives + T3/V3 trust tensors (canonical, since 0.2) + identity coherence + ledger anchoring (`InMemoryLedger`, `LocalLedger`). As of the 0.2/0.3 line it also carries the **Act** primitive (witnessed action grammar) + `ReputationDelta`, **role entities** (`RoleEntity`/`RoleExtension`/`RoleRegistry`, LCT issuance), the **EUDI/W3C-DID stack** (`did` / `sd_jwt_vc` / `oid4vc`), and the recursive **vault**. `web4-trust-core` adds trust persistence, witnessing, and decay. The Python wheels are PyO3-built bindings over the same Rust core.
 
 ---
 
@@ -52,8 +54,9 @@ All AGPL-3.0-or-later. Patent grant terms: [PATENTS.md](PATENTS.md). Commercial 
 | **Spec corpus** (LCT, T3/V3, MRH, ATP/ADP, R6/R7) | Stable | [`web4-standard/core-spec/`](web4-standard/core-spec/) |
 | **Inter-society protocol spec** (genesis, first-contact, federation, secession) | v0.1.2 DRAFT, 2026-05-13 | [`web4-standard/core-spec/inter-society-protocol.md`](web4-standard/core-spec/inter-society-protocol.md) |
 | **Society roles spec** (7 base-mandatory + context-mandatory + optional) | v0.1.0 DRAFT, 2026-05-13 | [`web4-standard/core-spec/society-roles.md`](web4-standard/core-spec/society-roles.md) |
-| **`web4-core`** | **Published v0.1.1** (crates.io + PyPI). LCT, T3/V3, Coherence, Ledger trait + 2 backends (InMemory, Local file). 52 unit tests + 4 doctests. | [`web4-core/`](web4-core/) |
-| **`web4-trust-core`** | **Published v0.1.1** (crates.io + PyPI). Trust storage, witnessing, decay. | [`web4-trust-core/`](web4-trust-core/) |
+| **`web4-core`** | **Published v0.2.0** (crates.io + PyPI); **0.3.0 queued**. LCT, canonical T3/V3, Coherence, Ledger + 2 backends, plus **Act**, **role entities**, the **EUDI/DID stack**, and the **vault**. 164 tests. | [`web4-core/`](web4-core/) |
+| **`web4-trust-core`** | **Published v0.2.0** (crates.io + PyPI). Trust storage, witnessing, decay. | [`web4-trust-core/`](web4-trust-core/) |
+| **Community Hub** (`web4/hub`) | Runnable single-binary Web4 society server: signed law + witnessed hash-chained ledger, sealed member↔hub channel, admission/council, EUDI issuer/verifier. Hardened this cycle (external security review: MCP-writes→loopback operator plane, council-gate-before-persist, pluggable operator-auth token, freshness enforcement, production profile, law-integrity fail-closed) + a `hub up` turnkey deploy kit. | [`hub/`](hub/) |
 | **Runnable proof of presence** | `python identity_bootstrap.py` — bootstraps a host LCT (keypair on disk, hash-chained `LocalLedger`, public `lct.json` sidecar); `--verify` re-checks the chain on re-run. ~30 sec. | [`web4-core/python/examples/identity_bootstrap.py`](web4-core/python/examples/identity_bootstrap.py) |
 | **Cross-language interop demo** | Python mints an LCT to a hash-chained ledger; a Rust binary reads the same `ledger.jsonl` and verifies chain integrity + anchor proof. The on-disk format is the contract. | [`web4-core/examples/cross_language_verify/`](web4-core/examples/cross_language_verify/) |
 | **Reference Python SDK** | 2,627 tests, mypy --strict clean (not yet on PyPI separately) | [`web4-standard/implementation/`](web4-standard/implementation/) |

--- a/hub/README.md
+++ b/hub/README.md
@@ -33,6 +33,14 @@ We don't mandate the policy. We insist that whatever the policy is, is followed 
 | 5 | Docker package + first-chapter demo scripts | ✓ (Docker untested on dev machine; first operator with Docker should report) |
 | 6 | Pilot-organizer docs + polish | ✓ |
 
+**Post-MVP hardening (2026-07).** A full external security review (GPT-5.5 Pro, 3 passes) drove a
+hardening cycle, all landed: MCP write tools moved off the public listener onto the loopback operator
+plane; `assign_role` gates council/law *before* persisting; **pluggable operator-auth** (`HUB_OPERATOR_AUTH=token`);
+sealed-channel **freshness enforcement** on write tools; **`HUB_PROFILE=production`** refusing unsafe
+defaults; law-integrity **fail-closed** on mismatch; issuer URLs from `HUB_PUBLIC_BASE_URL` not the Host
+header; unlock-verifier timeout. Plus the **`hub up`** turnkey deploy kit (see *Deployment models*) and
+the start of role-based launch orchestration (roles as LCT entities).
+
 ## Deployment models (in process)
 
 > **Status: in process.** The hub runs today as a single binary + config file (see [Quick start](#quick-start)). The map below is the target set of turnkey deployment postures — and the `hub up` installer that selects them — so an operator with no IT background can stand a hub up in one command.

--- a/web4-core/README.md
+++ b/web4-core/README.md
@@ -16,6 +16,10 @@ This crate provides the cryptographic and semantic primitives — Linked Context
 - **V3 (Value Tensor)** — 3 root dimensions (Valuation / Veracity / Validity). Same fractal RDF pattern as T3.
 - **Coherence** — Identity coherence scoring `C × S × Φ × R` (Continuity × Stability × Phi × Reachability). Multiplicative — a low score in any factor limits the whole.
 - **Crypto** — Ed25519 signing/verification, SHA-256 hashing.
+- **Act** — the witnessed action grammar (`Act`, `ActAddress`, `SubstanceRef`, `ConsequenceClass`) + `ReputationDelta` — how a witnessed act and its reputation effect are expressed.
+- **Role entities** — roles as first-class LCT entities (`RoleEntity`, `RoleExtension`, `RoleRegistry`) with LCT issuance and monotone-tightening law composition — the substrate for role-based orchestration.
+- **EUDI / W3C-DID interop** — an LCT resolves as a `did:web4` DID Document and is expressible as an IETF **SD-JWT-VC** credential over **OpenID4VCI / OpenID4VP** (`did`, `sd_jwt_vc`, `oid4vc`).
+- **Vault** — a recursive, memory-only-unlock encrypted store (`vault`): no plaintext at rest, per-item locking, fresh-launch naivety.
 
 ## Quick start
 


### PR DESCRIPTION
Audit of the status/readme .md files — several were weeks stale:

- **STATUS.md** (was 2026-06-15; claimed web4-core **0.1.1**, 52 tests): re-dated; all four published packages **0.1.1 → 0.2.0** (verified against crates.io + PyPI), **0.3.0 queued** note; web4-core feature list updated (Act, role entities, EUDI, vault); 164 tests; **added the Community Hub** as a working artifact (it was entirely absent) with its hardening + `hub up` summary.
- **web4-core/README.md** (was 2026-06-08; missing the 0.2/0.3 primitives): added Act, role entities, EUDI/DID, vault to *What's in here* — matters for the crate we're publishing at 0.3.0 (#494).
- **hub/README.md**: a *Post-MVP hardening (2026-07)* note under Current status — the security-review cycle + `hub up` + role orchestration.

Docs-only; verified all version claims against the live registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)