### PR TITLE
fix(r6): compute_reputation takes real baselines — pre-publish API fix (rides 0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The Web4 package family currently consists of:
 - **`web4-core`** (Python + Rust crate) — core primitives, PyO3 bindings. `pip install web4-core` / `cargo add web4-core`.
 - **`web4-trust`** (Python wheel) / **`web4-trust-core`** (Rust crate + npm WASM bindings) — trust tensors and the trust ledger. `pip install web4-trust` / `cargo add web4-trust-core` / `npm install web4-trust-core`.
 
+## web4-core Unreleased (0.4.0)
+
+- **BREAKING (Rust + JS/wasm): `compute_reputation` signature** — now takes the subject's real
+  tensor baselines: `compute_reputation(quality, t3_from, v3_from, rule, reason, factors)`
+  (wasm: `computeReputation(quality, t3From, v3From, rule, reason)`). Previously `from_value`
+  was fabricated as `0.5` and `change` could exceed the clamped movement; now `from`/`to` are
+  real and `change = to − from` post-clamp. Migration: pass your subject's current T3/V3
+  averages (use `0.5, 0.5` only for genuinely neutral subjects).
+
 ## web4-core 0.3.0 — 2026-07-09 (single-package release)
 
 `web4-core` only (Rust crate + Python wheel); the trust family stays at 0.2.0. Closes the 18-commit gap accumulated since 0.2.0 (2026-05-15). 171 tests green at publish; `cargo publish --dry-run` + fresh-venv wheel install verified first. Tags: `web4-core-rust-v0.3.0`, `web4-core-py-v0.3.0`.

--- a/web4-core/src/r6.rs
+++ b/web4-core/src/r6.rs
@@ -429,9 +429,24 @@ impl R7Action {
     ///
     /// quality: 0.0 to 1.0. Below 0.5 = negative, above 0.5 = positive.
     /// This makes the action an R7 action.
+    ///
+    /// `t3_from` / `v3_from` are the subject's ACTUAL current tensor baselines
+    /// (uniform per tensor, matching this helper's uniform-shift model). They were
+    /// previously fabricated as `0.5 // placeholder`, which made every emitted
+    /// `TensorDelta.from_value` a lie for any subject not at neutral — a consumer
+    /// folding `from_value`/`to_value` (rather than `change`) reconstructed a
+    /// trajectory that never happened. Callers with per-dimension baselines should
+    /// build the delta directly (as hestia's `delta_from_change` does) — this
+    /// helper is the uniform-shift convenience.
+    ///
+    /// Clamp honesty: `change` is recomputed as `to - from` AFTER clamping, so a
+    /// subject near the ceiling books the truncated movement that actually
+    /// happened, not the nominal shift (mirrors `delta_from_change`).
     pub fn compute_reputation(
         &mut self,
         quality: f64,
+        t3_from: f64,
+        v3_from: f64,
         rule_triggered: &str,
         reason: &str,
         factors: Vec<ContributingFactor>,
@@ -441,26 +456,30 @@ impl R7Action {
 
         // T3 delta: each dimension shifts proportionally to quality
         let trust_shift = 0.05 * (quality - 0.5); // ±0.025 max per action
+        let t3_from = t3_from.clamp(0.0, 1.0);
+        let t3_to = (t3_from + trust_shift).clamp(0.0, 1.0);
         for dim in &["talent", "training", "temperament"] {
             t3_delta.insert(
                 dim.to_string(),
                 TensorDelta {
-                    change: trust_shift,
-                    from_value: 0.5, // placeholder — caller should set from actual
-                    to_value: (0.5 + trust_shift).clamp(0.0, 1.0),
+                    change: t3_to - t3_from,
+                    from_value: t3_from,
+                    to_value: t3_to,
                 },
             );
         }
 
         // V3 delta: proportional to quality offset
         let value_shift = 0.02 * (quality - 0.5);
+        let v3_from = v3_from.clamp(0.0, 1.0);
+        let v3_to = (v3_from + value_shift).clamp(0.0, 1.0);
         for dim in &["valuation", "veracity", "validity"] {
             v3_delta.insert(
                 dim.to_string(),
                 TensorDelta {
-                    change: value_shift,
-                    from_value: 0.5,
-                    to_value: (0.5 + value_shift).clamp(0.0, 1.0),
+                    change: v3_to - v3_from,
+                    from_value: v3_from,
+                    to_value: v3_to,
                 },
             );
         }
@@ -547,7 +566,7 @@ mod tests {
     #[test]
     fn test_r7_reputation() {
         let mut action = sample_action();
-        action.compute_reputation(0.8, "completion_rule", "Task completed well", vec![]);
+        action.compute_reputation(0.8, 0.5, 0.5, "completion_rule", "Task completed well", vec![]);
 
         assert!(action.is_r7());
         let rep = action.reputation.as_ref().unwrap();
@@ -557,9 +576,27 @@ mod tests {
     }
 
     #[test]
+    fn reputation_uses_real_baselines_and_clamps_honestly() {
+        // from_value was fabricated as 0.5 regardless of the subject's actual
+        // trust; now the caller's real baseline flows through, and `change` is
+        // recomputed AFTER clamping so a near-ceiling subject books the truncated
+        // movement that actually happened, not the nominal shift.
+        let mut action = sample_action();
+        action.compute_reputation(0.8, 0.99, 0.3, "rule", "near ceiling", vec![]);
+        let rep = action.reputation.as_ref().unwrap();
+        let t = &rep.t3_delta["talent"];
+        assert!((t.from_value - 0.99).abs() < 1e-12, "real baseline, not 0.5");
+        assert!((t.to_value - 1.0).abs() < 1e-12, "clamped at ceiling");
+        assert!((t.change - 0.01).abs() < 1e-9, "change = to - from post-clamp (0.01, not nominal 0.015)");
+        let v = &rep.v3_delta["veracity"];
+        assert!((v.from_value - 0.3).abs() < 1e-12);
+        assert!((v.change - 0.006).abs() < 1e-9, "v3 unclamped case: change == nominal shift");
+    }
+
+    #[test]
     fn test_r7_negative_reputation() {
         let mut action = sample_action();
-        action.compute_reputation(0.2, "failure_rule", "Task failed", vec![]);
+        action.compute_reputation(0.2, 0.5, 0.5, "failure_rule", "Task failed", vec![]);
 
         let rep = action.reputation.as_ref().unwrap();
         assert!(rep.net_trust_change() < 0.0);

--- a/web4-trust-core/src/bindings/wasm.rs
+++ b/web4-trust-core/src/bindings/wasm.rs
@@ -832,14 +832,20 @@ impl WasmR7Action {
     /// Compute reputation delta from a quality score (makes this an R7 action).
     ///
     /// quality: 0.0 to 1.0. Below 0.5 = negative, above 0.5 = positive.
+    /// t3_from / v3_from: the subject's ACTUAL current tensor baselines (0.0–1.0)
+    /// — previously fabricated as 0.5 inside web4-core, which made every emitted
+    /// from_value/to_value wrong for non-neutral subjects. Pass the real values.
     #[wasm_bindgen(js_name = computeReputation)]
     pub fn compute_reputation(
         &mut self,
         quality: f64,
+        t3_from: f64,
+        v3_from: f64,
         rule_triggered: &str,
         reason: &str,
     ) {
-        self.inner.compute_reputation(quality, rule_triggered, reason, vec![]);
+        self.inner
+            .compute_reputation(quality, t3_from, v3_from, rule_triggered, reason, vec![]);
     }
 
     /// Compute the canonical hash for chain integrity.


### PR DESCRIPTION
The 🟡 finding from the 0.3.0 publish-surface audit, fixed **pre-publish** — this is a public-API signature change, so landing it now (0.3.0 not yet on crates.io, verified `cargo search` = 0.2.0) avoids a 0.4.0 semver break later.

## Problem
`compute_reputation` stamped `from_value: 0.5 // placeholder` into every emitted `TensorDelta`. Any consumer folding `from_value`/`to_value` (rather than `change`) reconstructed a trajectory that never happened for non-neutral subjects. Second latent defect: `change` was the nominal shift even when `to_value` clamped at the ceiling — the booked movement didn't equal `to - from`.

## Fix
- `compute_reputation(quality, t3_from, v3_from, …)` — real per-tensor baselines (uniform per tensor, matching the helper's own uniform-shift model; per-dimension callers should build deltas directly as hestia's `delta_from_change` does — doc'd).
- **Clamp honesty:** `change = to - from` *after* clamping (mirrors `delta_from_change`).
- wasm binding (`web4-trust-core`) updated in lockstep — JS surface takes `t3From`/`v3From`.

## Verified
`reputation_uses_real_baselines_and_clamps_honestly` (0.99 baseline → to 1.0, change 0.01 not nominal 0.015; v3 unclamped passthrough). **168 web4-core green; web4-trust-core + hestia build in lockstep.** No production caller changes needed (hestia doesn't use the helper; hub references it only in comments).

**Sequencing:** merge before `cargo publish` runs so 0.3.0 ships the honest signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)