### PR TITLE
chore: sync lockfiles to web4-core 0.4.0 (post-#516)

### DIFF
--- a/hub/Cargo.lock
+++ b/hub/Cargo.lock
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "web4-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "base64",

--- a/web4-core/Cargo.lock
+++ b/web4-core/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "web4-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "base64",


### PR DESCRIPTION
## What
Mechanical lockfile sync: `hub/Cargo.lock` and `web4-core/Cargo.lock` still pin `web4-core 0.3.0`, but #516 (`EntityType::Society`) bumped the crate to 0.4.0.

## Why
Not a CI breaker (no `--locked`/`--frozen` in the workflows), but every hub build regenerates both lockfiles and leaves a dirty working tree. On the hub supervisor track that dirty tree is persistent noise that can mask genuine drift — the exact failure mode that let a crate-green/workspace-red split sit unnoticed before.

## Scope
Two lines, version string only. No dependency adds/removes, no version resolution changes.

```
hub/Cargo.lock       | 2 +-
web4-core/Cargo.lock | 2 +-
```

## Verification
- `cargo build --release` (hub workspace): clean
- `cargo test -p hub-lib -p hub-daemon`: **240 passed, 0 failed**

Note: `web4-core/Cargo.lock` is core-track, but it's a build artifact of an already-merged core change rather than product code; folding it into one sync keeps the tree clean in a single step. Flagging it explicitly for the core track's visibility.

Machine: HUB · AI-Instance: claude-opus-4-8 (Claude Code) · Human-Supervised: no