### PR TITLE
feat(policy): W4IP N3 Phase 2 code half — response vocabulary (parse-don't-enact)

### DIFF
--- a/hub/hub-lib/src/law.rs
+++ b/hub/hub-lib/src/law.rs
@@ -26,7 +26,7 @@ use web4_policy::PolicyExtension;
 // Re-export the generic engine surface so `crate::law::*` consumers are unchanged.
 pub use web4_policy::{
     Condition, CustomPredicate, Decision, DecisionOutcome, EscalationTrigger, Norm, Operator,
-    Procedure, R6Request,
+    Procedure, R6Request, Response, ResponseRule,
 };
 
 /// The hub's law: the generic policy engine specialized with [`HubPolicy`].
@@ -457,6 +457,37 @@ mod tests {
             "role:constellation:mesh-worker"
         );
         assert!(is_known_constellation_role(DEFAULT_CONSTELLATION_ROLE));
+    }
+
+    #[test]
+    fn hub_law_parses_response_rules_and_stays_inert() {
+        // W4IP N3 Phase 2: the hub's Law<HubPolicy> parses the `responses:` key
+        // (canonical example from hub-law-schema.md "Response vocabulary"),
+        // validates it, and the R6 gate remains blind to it (parse-don't-enact).
+        let yaml = r#"
+version: "1.0.0"
+responses:
+  - id: QUARANTINE-ON-AGENCY-OVERRIDE
+    selector: reputation.delta.category
+    operator: "=="
+    value: coercive_extractive
+    response: quarantine
+    priority: 10
+    description: "Witnessed agency-override delta -> reversible containment pending adjudication"
+"#;
+        let law = Law::parse_and_validate(yaml).expect("hub law with responses parses");
+        assert_eq!(law.responses.len(), 1);
+        assert_eq!(law.responses[0].response, Response::Quarantine);
+        assert!(!law.responses[0].response.is_kinetic());
+        // The society gate is unaffected: no norms -> default allow, and the
+        // response rule is invisible to R6 evaluation.
+        let out = law.evaluate_outcome(&R6Request {
+            role: "citizen".into(),
+            action: "member_added".into(),
+            ..Default::default()
+        });
+        assert_eq!(out.decision, Decision::Allow);
+        assert_eq!(out.winning_norm, None);
     }
 
     /// The canonical example from hub-law-schema.md §1.

--- a/web4-policy/src/lib.rs
+++ b/web4-policy/src/lib.rs
@@ -85,6 +85,13 @@ pub struct Law<E: PolicyExtension = NoExtension> {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub norms: Vec<Norm>,
 
+    /// Response rules (W4IP N3) — the second-person, post-recognition side.
+    /// Parsed and validated; NOT evaluated or enacted by this engine (see
+    /// [`ResponseRule`]). `skip_serializing_if` keeps existing signed laws
+    /// byte-identical on round-trip (wire-neutral addition).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub responses: Vec<ResponseRule>,
+
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub procedures: Vec<Procedure>,
 
@@ -117,6 +124,103 @@ pub struct Norm {
     pub priority: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+}
+
+/// A single response rule — the response side's parallel to [`Norm`]
+/// (W4IP N3, hub-law-schema.md "Response vocabulary"). Same rule anatomy,
+/// different verb field: where a norm's `decision` answers the first-person,
+/// pre-act question (*may this act I am requesting proceed?*), a response
+/// rule's `response` names the second-person, post-recognition act (*what does
+/// the society do about a target's witnessed act?*). Selectors range over
+/// recognition evidence (e.g. `reputation.delta.category`), NOT the pre-act
+/// `r6.*` namespace — deliberately disjoint vocabularies so gate rules cannot
+/// silently emit responses.
+///
+/// **Parse-don't-enact:** this engine parses and validates response rules; it
+/// does NOT evaluate or enact them. [`Law::evaluate_outcome`] never reads
+/// `responses` — every rung's enactment is individually ratified and lands as
+/// its own reviewed surface. The vocabulary exists so law can be drafted and
+/// reviewed against it before any machinery can act on it.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ResponseRule {
+    pub id: String,
+    pub selector: String,
+    pub operator: Operator,
+    pub value: serde_yaml::Value,
+    pub response: Response,
+    #[serde(default)]
+    pub priority: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// The response vocabulary (W4IP N3): the graded ladder plus the kinetic
+/// class. Every enacted response is an R7 act whose required evidence and veto
+/// scale with the rung's `ConsequenceClass` — the ladder IS S and V applied to
+/// responses. The kinetic verbs name existing scattered primitives (slash_atp,
+/// citizenship suspend/terminate, LCT revocation, CRISIS halt) so law can cite
+/// them uniformly; naming them creates no new enactment authority.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Response {
+    /// Formal, witnessed notification to the target that a recognition delta
+    /// has accrued against it. Does not interfere with the target's ability
+    /// to act. (Ratified first-rung name — `notice` is second-person by
+    /// construction; gate `warn` is first-person pre-act and stays disjoint.)
+    Notice,
+    /// Reversible containment of the target's interaction surface pending
+    /// adjudication. MUST be liftable by the same authority that imposed it —
+    /// an unliftable containment is not quarantine and belongs to the kinetic
+    /// class instead.
+    Quarantine,
+    /// Restorative: undo or compensate the violation's effects.
+    Correct,
+    /// The return path: earned restoration of standing against a rehab-bound.
+    Rehabilitate,
+    /// Kinetic: ATP stake slashing (`atp-adp-cycle.md` slash_atp).
+    Slash,
+    /// Kinetic: citizenship suspension (SOCIETY_SPECIFICATION §4.2).
+    Suspend,
+    /// Kinetic: LCT/credential revocation (LCT spec revocation record).
+    Revoke,
+    /// Kinetic: citizenship termination (SOCIETY_SPECIFICATION §4.2).
+    Terminate,
+    /// Kinetic: CRISIS motor-halt (entity-types.md "halt effectors").
+    Halt,
+}
+
+impl Response {
+    /// Whether this verb belongs to the kinetic class — responses that
+    /// interfere with the target's ability to act. Kinetic verbs are valid to
+    /// PARSE but law-inert: nothing in this crate (or its consumers, until a
+    /// rung's enactment is individually ratified) may enact them.
+    pub fn is_kinetic(self) -> bool {
+        matches!(
+            self,
+            Response::Slash
+                | Response::Suspend
+                | Response::Revoke
+                | Response::Terminate
+                | Response::Halt
+        )
+    }
+
+    /// The ladder rung's `ConsequenceClass` (referenced-acts §4), which scales
+    /// the required evidence and veto for enactment. `None` for the kinetic
+    /// class: those verbs cite primitives whose consequence semantics live
+    /// with their source specs, and per the governing invariant an
+    /// unclassified consequential surface defaults to high-consequence —
+    /// callers MUST NOT read `None` as "unclassified therefore mild".
+    pub fn consequence_class(self) -> Option<web4_core::ConsequenceClass> {
+        use web4_core::ConsequenceClass::*;
+        match self {
+            Response::Notice => Some(Reversible),
+            Response::Quarantine => Some(Reversible),
+            Response::Correct => Some(Costly),
+            Response::Rehabilitate => Some(Reversible),
+            _ => None,
+        }
+    }
 }
 
 /// The outcome of policy evaluation. `Allow` and `Warn` are non-blocking (the
@@ -234,6 +338,31 @@ impl<E: PolicyExtension> Law<E> {
             }
             if !seen_ids.insert(norm.id.clone()) {
                 return Err(anyhow!("duplicate norm id '{}'", norm.id));
+            }
+        }
+
+        // Response rules (W4IP N3): same shape rules as norms, own id
+        // namespace. Kinetic verbs are valid to parse (parse-don't-enact);
+        // there is deliberately NO verb-level rejection here.
+        let mut response_ids = HashSet::new();
+        for rule in &self.responses {
+            if rule.id.is_empty() {
+                return Err(anyhow!("response rule has empty id"));
+            }
+            if rule.selector.is_empty() {
+                return Err(anyhow!("response rule '{}' has empty selector", rule.id));
+            }
+            if rule.selector.starts_with("r6.") || rule.selector == "r6" {
+                return Err(anyhow!(
+                    "response rule '{}' selects over the pre-act r6 namespace — \
+                     response selectors range over recognition evidence \
+                     (e.g. reputation.delta.category); the vocabularies are \
+                     deliberately disjoint",
+                    rule.id
+                ));
+            }
+            if !response_ids.insert(rule.id.clone()) {
+                return Err(anyhow!("duplicate response rule id '{}'", rule.id));
             }
         }
 
@@ -727,6 +856,109 @@ norms:
         assert!(y.contains("version"));
         let back: Law = Law::from_yaml(&y).unwrap();
         assert_eq!(back.version, "1.0.0");
+    }
+
+    #[test]
+    fn responses_parse_all_nine_verbs_including_kinetic() {
+        // Parse-don't-enact: the validator MUST accept a law whose response
+        // rules use kinetic verbs (they are law-inert, not law-invalid).
+        let yaml = r#"
+version: "1.0.0"
+responses:
+  - id: NOTICE-ON-DELTA
+    selector: reputation.delta.category
+    operator: "=="
+    value: coercive_extractive
+    response: notice
+    priority: 1
+  - {id: R-QUARANTINE, selector: reputation.delta.category, operator: "==", value: x, response: quarantine}
+  - {id: R-CORRECT,    selector: reputation.delta.category, operator: "==", value: x, response: correct}
+  - {id: R-REHAB,      selector: reputation.delta.category, operator: "==", value: x, response: rehabilitate}
+  - {id: R-SLASH,      selector: reputation.delta.category, operator: "==", value: x, response: slash}
+  - {id: R-SUSPEND,    selector: reputation.delta.category, operator: "==", value: x, response: suspend}
+  - {id: R-REVOKE,     selector: reputation.delta.category, operator: "==", value: x, response: revoke}
+  - {id: R-TERMINATE,  selector: reputation.delta.category, operator: "==", value: x, response: terminate}
+  - {id: R-HALT,       selector: reputation.delta.category, operator: "==", value: x, response: halt}
+"#;
+        let law: Law = Law::parse_and_validate(yaml).unwrap();
+        assert_eq!(law.responses.len(), 9);
+        assert_eq!(law.responses[0].response, Response::Notice);
+        assert_eq!(law.responses[0].priority, 1);
+        // Ladder vs kinetic split + consequence classes (referenced-acts §4).
+        use web4_core::ConsequenceClass::*;
+        assert!(!Response::Notice.is_kinetic());
+        assert!(!Response::Quarantine.is_kinetic());
+        assert!(!Response::Correct.is_kinetic());
+        assert!(!Response::Rehabilitate.is_kinetic());
+        for k in [Response::Slash, Response::Suspend, Response::Revoke, Response::Terminate, Response::Halt] {
+            assert!(k.is_kinetic());
+            assert_eq!(k.consequence_class(), None, "kinetic class defers to source primitives");
+        }
+        assert_eq!(Response::Notice.consequence_class(), Some(Reversible));
+        assert_eq!(Response::Quarantine.consequence_class(), Some(Reversible));
+        assert_eq!(Response::Correct.consequence_class(), Some(Costly));
+        assert_eq!(Response::Rehabilitate.consequence_class(), Some(Reversible));
+    }
+
+    #[test]
+    fn responses_validation_rejects_bad_shapes() {
+        // Unknown verb fails at parse (typed enum), not at validate.
+        let bad_verb = r#"
+version: "1.0.0"
+responses:
+  - {id: R1, selector: reputation.delta.category, operator: "==", value: x, response: obliterate}
+"#;
+        assert!(Law::<NoExtension>::from_yaml(bad_verb).is_err());
+
+        // Duplicate response ids rejected.
+        let dup = r#"
+version: "1.0.0"
+responses:
+  - {id: R1, selector: reputation.delta.category, operator: "==", value: x, response: notice}
+  - {id: R1, selector: reputation.delta.category, operator: "==", value: y, response: notice}
+"#;
+        let law: Law = Law::from_yaml(dup).unwrap();
+        assert!(law.validate().is_err());
+
+        // The vocabularies are disjoint: a response selecting over the
+        // pre-act r6 namespace is exactly the first-person/second-person
+        // conflation the response side exists to prevent.
+        let conflated = r#"
+version: "1.0.0"
+responses:
+  - {id: R1, selector: r6.request.action, operator: "==", value: x, response: notice}
+"#;
+        let law: Law = Law::from_yaml(conflated).unwrap();
+        let err = law.validate().unwrap_err().to_string();
+        assert!(err.contains("r6"), "error names the namespace violation: {err}");
+    }
+
+    #[test]
+    fn responses_are_wire_neutral_and_law_inert() {
+        // Wire-neutral: a law without responses round-trips byte-identically
+        // (signed, hash-chained laws on disk are unaffected by the new field).
+        let old = "version: \"1.0.0\"\nnorms:\n- id: a\n  selector: r6.role\n  operator: ==\n  value: x\n  decision: allow\n";
+        let law: Law = Law::from_yaml(old).unwrap();
+        assert!(law.responses.is_empty());
+        assert!(!law.to_yaml().unwrap().contains("responses"), "absent responses stay absent");
+
+        // Law-inert (parse-don't-enact): the R6 evaluator is blind to response
+        // rules — identical laws ± responses produce identical outcomes, even
+        // when a response rule's selector text coincides with request fields.
+        let with_responses = r#"
+version: "1.0.0"
+norms:
+  - {id: deny_it, selector: r6.request.action, operator: "==", value: risky, decision: deny, priority: 1}
+responses:
+  - {id: R-HALT, selector: reputation.delta.category, operator: "==", value: anything, response: halt, priority: 999}
+"#;
+        let law2: Law = Law::parse_and_validate(with_responses).unwrap();
+        let r = R6Request { role: "citizen".into(), action: "risky".into(), ..Default::default() };
+        let out = law2.evaluate_outcome(&r);
+        assert_eq!(out.decision, Decision::Deny);
+        assert_eq!(out.winning_norm.as_deref(), Some("deny_it"));
+        let allowed = law2.evaluate_outcome(&R6Request { role: "citizen".into(), action: "benign".into(), ..Default::default() });
+        assert_eq!(allowed.decision, Decision::Allow, "responses never leak into R6 evaluation");
     }
 
     #[test]

--- a/web4-standard/core-spec/hub-law-schema.md
+++ b/web4-standard/core-spec/hub-law-schema.md
@@ -147,15 +147,18 @@ Evaluation order:
 
 ### Response vocabulary (W4IP N3 — prescriptive)
 
-> **Sync direction — inverse of the Decision-semantics section.** The section
-> above *transcribes* the live engine; this section *prescribes* schema that
-> does not yet exist. Until the Phase 2 schema+parse extension lands
-> (hub-track PR against `web4-policy`/`hub-lib`), the engine neither parses
-> nor enacts responses. If code and this section later disagree, adjudicate in
-> that PR's review — do not let either drift silently. Field-level YAML shape
-> below is a minimal contract the implementing PR MAY reshape; the normative
-> content of this section is the **verb set, the ladder semantics, and
-> parse-don't-enact on the kinetic class**.
+> **Sync direction — split as of the Phase 2 code half.** The **schema and
+> parse** below now *transcribe* the live engine (`web4-policy/src/lib.rs`,
+> `ResponseRule` + `Response` + `Law::validate` — the Phase 2 implementing
+> PR): the engine parses and validates `responses:`, and `Law::evaluate*`
+> never reads them. **Enactment** remains *prescribed*: no rung is enacted
+> until individually ratified and implemented (parse-don't-enact holds in
+> code — verified by the `law-inert` regression tests). If code and this
+> section disagree, one of the two is a defect. The normative content stays
+> the **verb set, the ladder semantics, and parse-don't-enact on the kinetic
+> class**. One implementing hardening beyond the minimal contract: the
+> validator REJECTS a response rule whose selector ranges over the pre-act
+> `r6.*` namespace (the vocabularies are disjoint both ways).
 
 *Provenance (informative):* this section lands W4IP N3
 (`proposals/W4IP-DRAFT-2026-07-13-governance-immune-enforcement.md`) per the
@@ -242,14 +245,13 @@ responses:
     description: "Witnessed agency-override delta → reversible containment pending adjudication"
 ```
 
-Prescriptive validation (folds into §2 when the implementing PR lands): every
-response rule has `id`, `selector`, `operator`, `value`, `response`;
-`response` is one of `notice`, `quarantine`, `correct`, `rehabilitate`,
-`slash`, `suspend`, `revoke`, `terminate`, `halt`; kinetic verbs are valid to
-parse. Prescriptive RDF mapping: `responses[]` compiles parallel to `norms[]`
+Validation now lives in §2 (rules 11–13, transcribing the engine). RDF
+mapping lives in §3: `responses[]` compiles parallel to `norms[]`
 (`law:hasResponse` → `law:responseId` / `law:selector` / `law:operator` /
-`law:value` / `law:response` / `law:priority`); the `hub-law.ttl` ontology
-extension lands with the same PR.
+`law:value` / `law:response` / `law:priority`); `hub-law.ttl` defines
+`law:ResponseRule` under the shared `law:Rule` superclass (the shared rule
+anatomy — selector/operator/value/priority — is domained on `law:Rule` so a
+response is never typed as a Norm).
 
 #### Decision point — first-rung name (`notice` vs `warn` vs `caution`)
 
@@ -279,6 +281,16 @@ A law file is valid if:
 8. `escalation[].escalate_to` is a valid role name.
 9. `admission.sponsor_role` is a valid role name.
 10. `atp_issuance.mint_authority` is a valid role name.
+11. Every response rule has `id`, `selector`, `operator`, `value`, `response`;
+    `response` is one of `notice`, `quarantine`, `correct`, `rehabilitate`,
+    `slash`, `suspend`, `revoke`, `terminate`, `halt`. Kinetic verbs are
+    **valid to parse** (parse-don't-enact — see §1 Response vocabulary).
+12. Response rule `id` values are unique among response rules (their own
+    namespace, parallel to rule 5).
+13. A response rule's `selector` MUST NOT range over the pre-act `r6.*`
+    namespace — response selectors range over recognition evidence (e.g.
+    `reputation.delta.category`). The decision and response vocabularies are
+    disjoint both ways.
 
 ## 3. YAML → RDF Compilation
 
@@ -292,6 +304,12 @@ Each YAML key maps to the `hub-law.ttl` ontology:
 | `norms[].value` | `law:value` |
 | `norms[].decision` | `law:decision` |
 | `norms[].priority` | `law:priority` |
+| `responses[].id` | `law:responseId` |
+| `responses[].selector` | `law:selector` |
+| `responses[].operator` | `law:operator` |
+| `responses[].value` | `law:value` |
+| `responses[].response` | `law:response` |
+| `responses[].priority` | `law:priority` |
 | `procedures[].id` | `law:procedureId` |
 | `procedures[].requires_witnesses` | `law:requiresWitnesses` |
 | `procedures[].requires_quorum` | `law:requiresQuorum` |
@@ -303,7 +321,7 @@ Each YAML key maps to the `hub-law.ttl` ontology:
 | `escalation[].escalate_to` | `law:escalateTo` |
 
 The compiled RDF graph is a `law:LawDataset` node with `law:hasNorm`,
-`law:hasProcedure`, etc. edges to typed child nodes.
+`law:hasResponse`, `law:hasProcedure`, etc. edges to typed child nodes.
 
 ## 4. Extension Mechanism
 

--- a/web4-standard/ontology/hub-law.ttl
+++ b/web4-standard/ontology/hub-law.ttl
@@ -24,9 +24,19 @@ law:LawDataset a rdfs:Class ;
     rdfs:label "Law Dataset" ;
     rdfs:comment "A versioned set of rules governing a chapter. Published by the Law Oracle." .
 
+law:Rule a rdfs:Class ;
+    rdfs:label "Rule" ;
+    rdfs:comment "Abstract shared anatomy of a law rule: selector, operator, value, priority. Norm (first-person, pre-act) and ResponseRule (second-person, post-recognition) specialize it with disjoint verb fields." .
+
 law:Norm a rdfs:Class ;
+    rdfs:subClassOf law:Rule ;
     rdfs:label "Norm" ;
     rdfs:comment "A single allow/deny rule with selector, operator, and value." .
+
+law:ResponseRule a rdfs:Class ;
+    rdfs:subClassOf law:Rule ;
+    rdfs:label "Response Rule" ;
+    rdfs:comment "A second-person, post-recognition rule (W4IP N3): what the society does about a target's witnessed act. Parallel in shape to Norm; selectors range over recognition evidence, not the pre-act R6 request. Parsed and validated by the engine but NOT enacted (parse-don't-enact) until each rung's enactment is individually ratified." .
 
 law:Procedure a rdfs:Class ;
     rdfs:label "Procedure" ;
@@ -58,6 +68,11 @@ law:hasNorm a rdf:Property ;
     rdfs:domain law:LawDataset ;
     rdfs:range law:Norm ;
     rdfs:label "has norm" .
+
+law:hasResponse a rdf:Property ;
+    rdfs:domain law:LawDataset ;
+    rdfs:range law:ResponseRule ;
+    rdfs:label "has response rule" .
 
 law:hasProcedure a rdf:Property ;
     rdfs:domain law:LawDataset ;
@@ -106,35 +121,48 @@ law:r6Binding a rdf:Property ;
     rdfs:label "R6 binding" ;
     rdfs:comment "URI of the R6 rules schema this law dataset binds to." .
 
+# --- Properties on Rule (shared by Norm and ResponseRule) ---
+
+law:selector a rdf:Property ;
+    rdfs:domain law:Rule ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Field path this rule applies to. Norms select over the pre-act R6 request (e.g., 'r6.resource.atp'); response rules select over recognition evidence (e.g., 'reputation.delta.category') — the namespaces are deliberately disjoint." .
+
+law:operator a rdf:Property ;
+    rdfs:domain law:Rule ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Comparison operator: <=, >=, ==, !=, in, not_in, matches." .
+
+law:value a rdf:Property ;
+    rdfs:domain law:Rule ;
+    rdfs:range rdfs:Literal .
+
+law:priority a rdf:Property ;
+    rdfs:domain law:Rule ;
+    rdfs:range xsd:integer ;
+    rdfs:comment "Higher number = higher priority; among firing rules the highest priority wins (ties: first declared). Conflicts resolve by priority." .
+
 # --- Properties on Norm ---
 
 law:normId a rdf:Property ;
     rdfs:domain law:Norm ;
     rdfs:range xsd:string .
 
-law:selector a rdf:Property ;
-    rdfs:domain law:Norm ;
-    rdfs:range xsd:string ;
-    rdfs:comment "R6 field path this norm applies to (e.g., 'r6.resource.atp')." .
-
-law:operator a rdf:Property ;
-    rdfs:domain law:Norm ;
-    rdfs:range xsd:string ;
-    rdfs:comment "Comparison operator: <=, >=, ==, !=, in, not_in, matches." .
-
-law:value a rdf:Property ;
-    rdfs:domain law:Norm ;
-    rdfs:range rdfs:Literal .
-
 law:decision a rdf:Property ;
     rdfs:domain law:Norm ;
     rdfs:range xsd:string ;
     rdfs:comment "allow | warn | deny | escalate (warn = non-blocking flagged-allow)" .
 
-law:priority a rdf:Property ;
-    rdfs:domain law:Norm ;
-    rdfs:range xsd:integer ;
-    rdfs:comment "Higher number = higher priority; among firing norms the highest priority wins (ties: first declared). Conflicts resolve by priority." .
+# --- Properties on ResponseRule (W4IP N3) ---
+
+law:responseId a rdf:Property ;
+    rdfs:domain law:ResponseRule ;
+    rdfs:range xsd:string .
+
+law:response a rdf:Property ;
+    rdfs:domain law:ResponseRule ;
+    rdfs:range xsd:string ;
+    rdfs:comment "notice | quarantine | correct | rehabilitate (graded ladder) or slash | suspend | revoke | terminate | halt (kinetic class — valid to parse, law-inert until each rung's enactment is individually ratified)." .
 
 # --- Properties on Procedure ---
 


### PR DESCRIPTION
The implementing PR the supervisor declared queue head (hub-to-legion-pr522-merged reply): schema + parse + tests for the ratified Response vocabulary (#522 / `87377c3`).

**Engine (`web4-policy`):** `ResponseRule` + `Response` (ladder `notice|quarantine|correct|rehabilitate`, kinetic `slash|suspend|revoke|terminate|halt`), `Law.responses` wire-neutral (signed laws round-trip byte-identically — tested). **Parse-don't-enact is locked by regression test**: `Law::evaluate*` never reads responses; kinetic verbs parse and stay law-inert. `consequence_class()` maps the ladder per referenced-acts §4; kinetic → `None` (defers to source primitives; unclassified defaults high).

**Validation:** spec §2 rules 11–13, including one hardening beyond the minimal contract: response selectors are rejected if they range over `r6.*` — the first-person/second-person disjointness enforced both ways. Flagged for review adjudication per the spec's sync note.

**Spec folds (same PR per the ratified section):** §1 sync-note flipped to transcribe-parse/prescribe-enactment, §2 rules folded, §3 RDF rows, `hub-law.ttl` extended with a `law:Rule` superclass (shared anatomy properties re-domained so a response is never typed as a Norm — ttl validates, 154 triples).

Tests: web4-policy 10 (+3) · hub-lib 178 (+1) · hub-daemon 66 · hestia builds against the changed path-dep. RWOA self-audit in the commit (verdict PASS — V is parse-don't-enact itself).

Daemon-code change: stacks onto the already-pending rebuild+reignite (no extra ignite owed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)