### PR TITLE
feat(lct): birth-certificate + attestation schema (Phase-2 groundwork)

### DIFF
--- a/hub/hub-lib/src/hub.rs
+++ b/hub/hub-lib/src/hub.rs
@@ -140,6 +140,8 @@ pub fn hestia_sovereign_lct(lct_id: Uuid, pubkey_hex: &str) -> Result<Lct> {
         binding_proof: None,
         mrh: web4_core::lct::Mrh::default(),
         legacy_alias: None,
+        attestations: Vec::new(),
+        birth_certificate: None,
     })
 }
 

--- a/web4-core/src/attestation.rs
+++ b/web4-core/src/attestation.rs
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 MetaLINXX Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This software is covered by US Patents 11,477,027 and 12,278,913,
+// and pending application 19/178,619. See PATENTS.md for details.
+
+//! Witness attestations and birth certificates (canon §2.3, §4, §11.2).
+//!
+//! The upgrade path out of a `self_issued` §3.2 bootstrap: a society witnesses
+//! an entity's existence with a **quorum of ≥3 signed attestations** and confers
+//! a **birth certificate**, which carries citizenship (high inherited trust,
+//! permanent citizen pairing). This module is the SCHEMA + the fail-closed
+//! validator; the *conferral flow* (who gathers the quorum, when the society
+//! signs) is the hub-as-society's lane.
+//!
+//! **Verification is fail-closed and comes in two strengths, exactly as §11.2
+//! frames it:** a structural check ([`BirthCertificate::quorum_structurally_ok`])
+//! is the minimum (present + ≥3 distinct witnesses + a present attestation per
+//! witness); a COSE-verified check ([`Lct::verify_birth_certificate`]) is
+//! RECOMMENDED and additionally verifies every witness signature against that
+//! witness's bound public key. Absence is always the closed pole: no birth
+//! certificate ⇒ a Regular LCT (self-issued, low trust), never a silent pass.
+
+use crate::crypto::{KeyPair, PublicKey, SignatureBytes};
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A witness's role when attesting (canon §5.2.3). Birth certificates require
+/// `Existence` attestations; the other roles carry over the same signature
+/// machinery for action/state/quality witnessing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttestationType {
+    Time,
+    Audit,
+    Oracle,
+    Existence,
+    Action,
+    State,
+    Quality,
+}
+
+/// One signed witness attestation over a subject LCT (canon §2.3 `attestations`).
+/// The signature covers [`Attestation::message`] — the subject's canonical id +
+/// the attestation type + the timestamp, domain-separated — so any verifier
+/// reconstructs exactly what was signed from the document alone.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attestation {
+    /// The witnessing entity's canonical LCT id (`lct:web4:…`).
+    pub witness: String,
+    /// What is being attested (birth uses `Existence`).
+    #[serde(rename = "type")]
+    pub attestation_type: AttestationType,
+    /// When the witness observed the subject.
+    pub ts: DateTime<Utc>,
+    /// COSE-style signature by the witness's binding key over [`message`].
+    pub sig: SignatureBytes,
+}
+
+impl Attestation {
+    /// The canonical message a witness signs, reconstructible from the document:
+    /// `"web4:lct:attestation:v1\n" + subject_lct_id + "\n" + type + "\n" + ts`.
+    /// The timestamp is rendered `AutoSi` + `Z` (byte-identical to the serde wire
+    /// form), matching the binding-proof discipline — a non-chrono verifier gets
+    /// the exact bytes. Changing this rendering after any attestation is signed
+    /// requires a `v1`→`v2` bump.
+    pub fn message(subject_lct_id: &str, attestation_type: AttestationType, ts: DateTime<Utc>) -> Vec<u8> {
+        let ty = serde_json::to_string(&attestation_type)
+            .unwrap_or_default()
+            .trim_matches('"')
+            .to_string();
+        format!(
+            "web4:lct:attestation:v1\n{}\n{}\n{}",
+            subject_lct_id,
+            ty,
+            ts.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+        )
+        .into_bytes()
+    }
+
+    /// Sign an existence-style attestation of `subject_lct_id` with the witness's
+    /// keypair. `witness` is recorded as the witness's own canonical id.
+    pub fn sign(
+        subject_lct_id: &str,
+        witness: impl Into<String>,
+        attestation_type: AttestationType,
+        ts: DateTime<Utc>,
+        witness_keypair: &KeyPair,
+    ) -> Self {
+        let sig = witness_keypair.sign(&Self::message(subject_lct_id, attestation_type, ts));
+        Attestation { witness: witness.into(), attestation_type, ts, sig }
+    }
+
+    /// Verify this attestation's signature over `subject_lct_id` against the
+    /// witness's bound public key. **Fail-closed**: `false` on any signature
+    /// failure. (Whether `witness_pubkey` truly belongs to `self.witness` is the
+    /// caller's resolver contract — see [`Lct::verify_birth_certificate`].)
+    pub fn verify(&self, subject_lct_id: &str, witness_pubkey: &PublicKey) -> bool {
+        witness_pubkey
+            .verify(&Self::message(subject_lct_id, self.attestation_type, self.ts), &self.sig)
+            .is_ok()
+    }
+}
+
+/// The birth-certificate section of an LCT (canon §2.3 / §4.2). Its presence is
+/// what distinguishes a citizen (society-conferred, high trust) from a Regular
+/// self-issued LCT.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BirthCertificate {
+    /// LCT id of the issuing society.
+    pub issuing_society: String,
+    /// LCT id of the citizen role this entity inhabits.
+    pub citizen_role: String,
+    /// The witnesses whose quorum attests this birth (≥3, canon-required).
+    /// Canonical LCT ids; each MUST have a matching entry in the LCT's
+    /// `attestations` (checked by the validator).
+    pub birth_witnesses: Vec<String>,
+    pub birth_timestamp: DateTime<Utc>,
+    /// Society-type classification (RECOMMENDED). `None` = unstated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub birth_context: Option<BirthContext>,
+    /// Blockchain anchor for temporal proof (RECOMMENDED; `None` when no anchor).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub genesis_block_hash: Option<String>,
+}
+
+/// Society-type classification (canon §4.2 `birth_context`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BirthContext {
+    Nation,
+    Platform,
+    Network,
+    Organization,
+    Ecosystem,
+}
+
+/// The canon-required minimum witness quorum for a birth certificate (§4.2).
+pub const BIRTH_WITNESS_QUORUM: usize = 3;
+
+impl BirthCertificate {
+    /// Structural quorum check (§11.2, present-only minimum — no signatures):
+    /// ≥3 **distinct** birth witnesses. Distinctness matters — three entries that
+    /// are one witness are not a quorum. Does NOT verify attestations or pairing
+    /// (that is the whole-LCT validator's job, since those live on the LCT).
+    pub fn quorum_structurally_ok(&self) -> bool {
+        let mut seen = std::collections::BTreeSet::new();
+        let distinct = self.birth_witnesses.iter().filter(|w| seen.insert(*w)).count();
+        distinct >= BIRTH_WITNESS_QUORUM
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lct::{EntityType, Lct};
+
+    #[test]
+    fn attestation_signs_and_verifies_fail_closed() {
+        let (subject, _sk) = Lct::new(EntityType::AiSoftware, None);
+        let witness_kp = KeyPair::generate();
+        let att = Attestation::sign(
+            &subject.lct_id(),
+            "lct:web4:witness:1",
+            AttestationType::Existence,
+            subject.created_at,
+            &witness_kp,
+        );
+        assert!(att.verify(&subject.lct_id(), &witness_kp.verifying_key()));
+        // wrong witness key → rejected
+        assert!(!att.verify(&subject.lct_id(), &KeyPair::generate().verifying_key()));
+        // wrong subject → rejected (the id is in the signed message)
+        assert!(!att.verify("lct:web4:mb32:bother", &witness_kp.verifying_key()));
+    }
+
+    #[test]
+    fn quorum_needs_three_distinct_witnesses() {
+        let base = BirthCertificate {
+            issuing_society: "lct:web4:society:hub".into(),
+            citizen_role: "lct:web4:role:citizen".into(),
+            birth_witnesses: vec!["w1".into(), "w2".into(), "w3".into()],
+            birth_timestamp: chrono::DateTime::UNIX_EPOCH.into(),
+            birth_context: Some(BirthContext::Ecosystem),
+            genesis_block_hash: None,
+        };
+        assert!(base.quorum_structurally_ok());
+        // three ENTRIES but one witness = not a quorum
+        let padded = BirthCertificate {
+            birth_witnesses: vec!["w1".into(), "w1".into(), "w1".into()],
+            ..base.clone()
+        };
+        assert!(!padded.quorum_structurally_ok());
+        // two witnesses = below quorum
+        let two = BirthCertificate { birth_witnesses: vec!["w1".into(), "w2".into()], ..base };
+        assert!(!two.quorum_structurally_ok());
+    }
+}

--- a/web4-core/src/lct.rs
+++ b/web4-core/src/lct.rs
@@ -145,6 +145,18 @@ pub struct Lct {
     /// rather than trusting the publisher (F1). See [`LegacyAlias`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub legacy_alias: Option<LegacyAlias>,
+
+    /// `attestations` (canon §2.3): signed witness statements about this LCT —
+    /// the collection the birth-certificate validator consults. Default empty
+    /// (an un-witnessed §3.2 bootstrap). See [`crate::attestation`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attestations: Vec<crate::attestation::Attestation>,
+
+    /// `birth_certificate` (canon §2.3/§4): present iff a society conferred
+    /// citizenship on this entity. `None` = a Regular self-issued LCT (the honest
+    /// default — society-conferred presence is proven, never assumed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub birth_certificate: Option<crate::attestation::BirthCertificate>,
 }
 
 /// The Markov Relevancy Horizon carried on an LCT (canon §5): `bound` (permanent
@@ -362,6 +374,68 @@ impl Lct {
         }
     }
 
+    /// `true` iff this LCT is a valid **birth certificate** (canon §4.2 / §11.2) —
+    /// a society-conferred citizen, COSE-verified. Fail-closed on every clause:
+    ///
+    /// 1. a `birth_certificate` section is present,
+    /// 2. ≥3 **distinct** birth witnesses (structural quorum),
+    /// 3. exactly one **permanent** `birth_certificate` pairing in `mrh.paired`,
+    /// 4. every birth witness has an `Existence` attestation in `attestations`
+    ///    whose signature verifies against that witness's bound public key.
+    ///
+    /// `resolve_witness_pubkey` maps a witness LCT id → its bound key (the
+    /// verifier's registry lookup). A witness whose key does not resolve, or
+    /// whose signature fails, fails the whole certificate — a quorum you cannot
+    /// verify is not a quorum. `None` from the resolver ⇒ reject (never skip).
+    ///
+    /// Absence of a `birth_certificate` returns `false` (a Regular LCT is not a
+    /// birth certificate); use [`Lct::is_self_issued`] to distinguish "no cert"
+    /// from "invalid cert".
+    pub fn verify_birth_certificate<F>(&self, resolve_witness_pubkey: F) -> bool
+    where
+        F: Fn(&str) -> Option<PublicKey>,
+    {
+        let Some(bc) = &self.birth_certificate else {
+            return false;
+        };
+        if !bc.quorum_structurally_ok() {
+            return false;
+        }
+        // Exactly one permanent birth_certificate pairing (§4.2 clause 2).
+        let citizen_pairings = self
+            .mrh
+            .paired
+            .iter()
+            .filter(|e| e.edge_type == "birth_certificate")
+            .count();
+        if citizen_pairings != 1 {
+            return false;
+        }
+        // Every distinct witness must have a signature-valid Existence attestation.
+        let subject = self.lct_id();
+        let mut seen = std::collections::BTreeSet::new();
+        for witness in bc.birth_witnesses.iter().filter(|w| seen.insert(*w)) {
+            let Some(pubkey) = resolve_witness_pubkey(witness) else {
+                return false; // unresolvable witness → cannot verify → reject
+            };
+            let attested = self.attestations.iter().any(|a| {
+                a.witness == *witness
+                    && a.attestation_type == crate::attestation::AttestationType::Existence
+                    && a.verify(&subject, &pubkey)
+            });
+            if !attested {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// `true` for a Regular self-issued LCT — no birth certificate (canon §4.3).
+    /// The honest default state; the complement of "carries a (valid) birth cert".
+    pub fn is_self_issued(&self) -> bool {
+        self.birth_certificate.is_none()
+    }
+
     /// Create a new LCT
     ///
     /// Returns both the LCT and the keypair (which should be securely stored)
@@ -382,6 +456,8 @@ impl Lct {
             binding_proof: None,
             mrh: Mrh::default(),
             legacy_alias: None,
+            attestations: Vec::new(),
+            birth_certificate: None,
         };
 
         (lct, keypair)
@@ -405,6 +481,8 @@ impl Lct {
             binding_proof: None,
             mrh: Mrh::default(),
             legacy_alias: None,
+            attestations: Vec::new(),
+            birth_certificate: None,
         };
 
         (lct, keypair)
@@ -536,6 +614,8 @@ impl LctBuilder {
             binding_proof: None,
             mrh: Mrh::default(),
             legacy_alias: None,
+            attestations: Vec::new(),
+            birth_certificate: None,
         };
 
         (lct, keypair)
@@ -724,6 +804,61 @@ mod tests {
             restored.verify_binding(),
             "signed LCT must verify after a JSON roundtrip (message == wire bytes)"
         );
+    }
+
+    #[test]
+    fn birth_certificate_validates_fail_closed_end_to_end() {
+        use crate::attestation::{Attestation, AttestationType, BirthCertificate, BirthContext};
+        let (mut lct, kp) = Lct::new(EntityType::AiSoftware, None);
+        lct.sign_binding(&kp);
+        let subject = lct.lct_id();
+
+        // Three distinct witnesses, each signs an Existence attestation.
+        let w: Vec<_> = (0..3).map(|_| KeyPair::generate()).collect();
+        let wid: Vec<String> = (0..3).map(|i| format!("lct:web4:witness:{i}")).collect();
+        let ts = lct.created_at;
+        for i in 0..3 {
+            lct.attestations.push(Attestation::sign(&subject, wid[i].clone(), AttestationType::Existence, ts, &w[i]));
+        }
+        lct.birth_certificate = Some(BirthCertificate {
+            issuing_society: "lct:web4:society:hub".into(),
+            citizen_role: "lct:web4:role:citizen".into(),
+            birth_witnesses: wid.clone(),
+            birth_timestamp: ts,
+            birth_context: Some(BirthContext::Ecosystem),
+            genesis_block_hash: None,
+        });
+        // The permanent citizen pairing (§4.2 clause 2).
+        lct.mrh.paired.push(MrhEdge {
+            lct_id: "lct:web4:role:citizen".into(),
+            edge_type: "birth_certificate".into(),
+            ts,
+        });
+
+        let resolver = |id: &str| wid.iter().position(|x| x == id).map(|i| w[i].verifying_key());
+        assert!(lct.verify_birth_certificate(resolver), "well-formed cert verifies");
+        assert!(!lct.is_self_issued());
+
+        // Fail-closed mutations, each independently:
+        // (a) a witness key that doesn't resolve → reject
+        assert!(!lct.verify_birth_certificate(|_| None));
+        // (b) drop below quorum
+        let mut two = lct.clone();
+        two.birth_certificate.as_mut().unwrap().birth_witnesses.truncate(2);
+        assert!(!two.verify_birth_certificate(resolver));
+        // (c) tamper an attestation ts → its signature no longer verifies
+        let mut tampered = lct.clone();
+        tampered.attestations[0].ts = ts + chrono::Duration::seconds(1);
+        assert!(!tampered.verify_birth_certificate(resolver));
+        // (d) missing the permanent pairing → reject
+        let mut nopair = lct.clone();
+        nopair.mrh.paired.clear();
+        assert!(!nopair.verify_birth_certificate(resolver));
+        // (e) no birth_certificate at all → false AND is_self_issued true
+        let mut regular = lct.clone();
+        regular.birth_certificate = None;
+        assert!(!regular.verify_birth_certificate(resolver));
+        assert!(regular.is_self_issued());
     }
 
     #[test]

--- a/web4-core/src/lib.rs
+++ b/web4-core/src/lib.rs
@@ -62,6 +62,7 @@ pub mod delegation;
 pub mod did;
 pub mod error;
 pub mod event;
+pub mod attestation;
 pub mod lct;
 pub mod ledger;
 pub mod pair_channel;
@@ -87,6 +88,7 @@ pub use coherence::{
 };
 pub use crypto::{sha256, sha256_hex, KeyPair, PublicKey, SignatureBytes};
 pub use error::{Result, Web4Error};
+pub use attestation::{Attestation, AttestationType, BirthCertificate, BirthContext, BIRTH_WITNESS_QUORUM};
 pub use lct::{derive_lct_id, EntityType, HardwareBinding, LegacyAlias, LegacyDerivation, Lct, LctBuilder, LctStatus, Mrh, MrhEdge};
 pub use ledger::{
     InMemoryLedger, Ledger, LedgerEntry, LedgerEvent, LedgerProof, LocalLedger, MintReceipt,


### PR DESCRIPTION
The schema half of **Phase 2** — the upgrade path out of `self_issued` §3.2 bootstraps (canon §2.3/§4/§11.2). This is the **data structure + fail-closed validator** both the hub-as-society (conferral) and the registry ingest (verification) build against; the conferral *flow* is HUB's lane (see the concord post).

## What
- **`Attestation`** — witness + type + ts + `sig` over a domain-separated `message` reconstructible from the document (same discipline as `binding_proof`; `AutoSi`/`Z` timestamp so message bytes == wire bytes). `AttestationType` = canon §5.2.3 witness roles.
- **`BirthCertificate`** — issuing_society, citizen_role, birth_witnesses, timestamp, context, genesis anchor. `BIRTH_WITNESS_QUORUM = 3`.
- **`Lct.attestations` + `Lct.birth_certificate`** — both serde-additive fail-closed defaults (empty / `None` = a Regular self-issued LCT, never a silent citizen).
- **`Lct::verify_birth_certificate(resolver)`** — COSE-verified §11.2: present + ≥3 **distinct** witnesses + exactly-one **permanent** citizen pairing + every witness has a signature-valid `Existence` attestation. A witness whose key doesn't resolve fails the whole cert. `is_self_issued()` distinguishes no-cert from invalid-cert.

## Fail-closed, tested
End-to-end validator test with 5 independent mutations each rejected: unresolvable witness, below-quorum, tampered attestation ts, missing pairing, no-cert. Quorum requires 3 *distinct* (a padded single witness is not a quorum). 182 web4-core + 49 trust-core + 214 hestia lockstep green. 0.4.0-track, additive.

## Sequencing
Schema only — the emitter still refuses to construct `SocietyConferred` provenance until the quorum machinery exists (unchanged). This just makes the target shape real so HUB can build conferral against it. dp/CBP veto window on the Phase-2 architecture is the concord post, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
