### PR TITLE
docs(spec): canonize "Inspectable Evidence, Not Prescribed Trust" principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,12 @@ Trust is a contextual preponderance of evidence scaled to stakes, not a boolean:
 acts may pass on weak evidence (recorded); the required strength of evidence rises with consequence and
 irreversibility.
 
+**Inspectable evidence, not prescribed trust (LCT spec §1.2).** A surface's job is to make the
+evidence unforgeable and inspectable — never to encode a universal trust threshold. Failing an
+assurance bar is *higher risk, not exclusion*; who/when/how-much to trust is the relying party's,
+scaled to stakes. When building a verification surface, produce checkable evidence and let the caller
+decide; do not smuggle in an exclude/admit verdict (the ratchet `satisfied_by` bug, 2026-07-16).
+
 **Gate question:** *Can this path cause a consequential act while, for that act's stakes, R / W / S / O /
 A / V is not satisfied?* If yes for any clause at the act's stakes, the surface FAILS: fix before
 shipping, or escalate with the recorded FAIL (writing the block after the fact to match what was built

--- a/web4-standard/README.md
+++ b/web4-standard/README.md
@@ -162,13 +162,13 @@ Every interaction builds or erodes trust, creating an antifragile system that st
 ### 9. Inspectable Evidence, Not Prescribed Trust
 Web4 makes evidence about entities unforgeable and inspectable; it never states who or when should be trusted. Every verifiable structure — bindings, quorums, device assurance, tensors, a society's authority ratchet — is evidence a relying party weighs, contextual and scaled to stakes. Low assurance is higher risk, not exclusion; the one hard invariant is that an entity cannot prove evidence its structure does not support. See LCT spec §1.2.
 
-### 9. Value as Energy (ATP/ADP)
+### 10. Value as Energy (ATP/ADP)
 A revolutionary economic system where value flows like biological energy—tokens exist in charged/discharged states, cannot be hoarded, and reward productive work over accumulation.
 
-### 10. Semantic Interoperability (Dictionaries)
+### 11. Semantic Interoperability (Dictionaries)
 Living entities that manage the compression-trust relationship fundamental to all communication, enabling seamless translation between domains while tracking confidence and degradation.
 
-### 11. Spatial Web Integration
+### 12. Spatial Web Integration
 Web4 integrates with emerging semantic protocols (HSML, HSTP, Active Inference) to combine rich semantic understanding with trust-native execution. While Spatial Web frameworks handle the "how" of agent communication, Web4 provides the critical "why trust" and "what value" layers. [See detailed integration strategy](./SPATIAL_WEB_INTEGRATION.md)
 
 ## Development Status

--- a/web4-standard/README.md
+++ b/web4-standard/README.md
@@ -159,6 +159,9 @@ Precise authority transfer with scope, caps, and temporal bounds, enabling safe 
 ### 8. Trust-Aware Communication (MCP)
 Every interaction builds or erodes trust, creating an antifragile system that strengthens through use.
 
+### 9. Inspectable Evidence, Not Prescribed Trust
+Web4 makes evidence about entities unforgeable and inspectable; it never states who or when should be trusted. Every verifiable structure — bindings, quorums, device assurance, tensors, a society's authority ratchet — is evidence a relying party weighs, contextual and scaled to stakes. Low assurance is higher risk, not exclusion; the one hard invariant is that an entity cannot prove evidence its structure does not support. See LCT spec §1.2.
+
 ### 9. Value as Energy (ATP/ADP)
 A revolutionary economic system where value flows like biological energy—tokens exist in charged/discharged states, cannot be hoarded, and reward productive work over accumulation.
 

--- a/web4-standard/core-spec/LCT-linked-context-token.md
+++ b/web4-standard/core-spec/LCT-linked-context-token.md
@@ -23,7 +23,36 @@ LCTs solve the fundamental problem of contextual presence in distributed systems
 - **Trust Propagation**: Trust flows through witnessed connections in the Markov Relevancy Horizon (MRH)
 - **Birth Certificates**: Societies issue LCTs as foundational presence documents
 
-### 1.2 Terminology
+### 1.2 Design Principle: Inspectable Evidence, Not Prescribed Trust
+
+Web4 specifies how to make evidence about an entity — its identity, relationships,
+attestations, reputation, and authority structure — **unforgeable and inspectable**.
+It does **not** specify *who* should be trusted, *when*, or *how much*.
+
+Every verifiable structure in this standard — a signed binding proof, a witness
+quorum, a constellation's device assurance, a T3/V3 tensor, a society's authority
+ratchet — is **evidence a relying party weighs**, contextually and scaled to the
+stakes of the specific act. It is never a verdict the protocol renders. Two
+consequences follow, and conforming implementations MUST honor both:
+
+1. **Low assurance is higher risk, not exclusion.** An entity that can present only
+   weak evidence (e.g. single-device, reachability-as-proof) MUST NOT be excluded by
+   the protocol. It is rightly weighed as riskier than one presenting strong evidence
+   (e.g. a multi-device, biometric, richly-witnessed constellation). A relying party
+   MAY accept weak evidence for a low-stakes reversible act and require more for a
+   high-stakes irreversible one — the required strength of evidence rises with
+   consequence and irreversibility. Trust is a contextual preponderance of evidence
+   scaled to stakes, not a boolean.
+
+2. **Evidence is unforgeable; interpretation is free.** The one hard invariant the
+   protocol enforces is that an entity cannot *prove* evidence its structure does not
+   support (identifiers are key-derived, proofs are signature-checked, quorums and
+   assurance levels are recomputed from structure — never trusted from a claimed
+   field). A conforming surface produces verifiable evidence and MUST NOT encode a
+   universal trust threshold: stating who or when to trust is the relying party's,
+   not the standard's.
+
+### 1.3 Terminology
 
 - **Entity**: Any participant in Web4 (human, AI, society, organization, role, task, resource, device, service, oracle, accumulator, dictionary, hybrid, policy, infrastructure — see `entity-types.md` §2.1 for the canonical 15-type taxonomy)
 - **Binding**: Permanent, verifiable cryptographic link between entity and LCT

--- a/web4-standard/core-spec/t3-v3-tensors.md
+++ b/web4-standard/core-spec/t3-v3-tensors.md
@@ -13,6 +13,8 @@ Traditional reputation systems reduce complex behaviors to simple scores. Web4's
 
 **T3/V3 tensors are not absolute properties - they exist only within role contexts.** An entity trusted as a surgeon has no inherent trust as a mechanic. Trust and value are always qualified by the role being performed. RDF triples in the MRH explicitly bind tensors to entity-role pairs, ensuring trust assessments remain contextually appropriate.
 
+Tensors are **evidence, not verdicts**: a T3/V3 score is inspectable input a relying party weighs, scaled to the stakes of the act — the standard never prescribes a trust threshold. See the LCT spec §1.2, *Inspectable Evidence, Not Prescribed Trust*.
+
 ## 2. T3 Tensor: Trust Through Capability
 
 The T3 Tensor measures an entity's trustworthiness through three capability dimensions:


### PR DESCRIPTION
Surfaced by dp (2026-07-16): *"web4 does not state who or when should be trusted — it provides tools to make the evidence inspectable. Low assurance is not exclusion, just rightly deemed higher risk."*

This principle was **implied everywhere** (implementation-defined enforcement, role-contextual trust, recompute-don't-trust device assurance) but stated **first-class nowhere** — and I just proved it's easy to violate: the society-ratchet `satisfied_by` (#529) was framed as "the act gate," smuggling a universal threshold + exclude/admit verdict into a protocol surface. That inverts what web4 is.

## Canonized once, pointed to (docs only, no behavior change)
- **LCT core spec §1.2** (NEW, normative, RFC-2119) — web4 makes evidence unforgeable + inspectable; it does NOT prescribe trust. Two **MUST**s: low assurance is *higher risk, not exclusion* (trust contextual + scaled to stakes, not a boolean); evidence is unforgeable but *interpretation is free* (a surface MUST NOT encode a universal trust threshold).
- **T3/V3 §1.1** — cross-ref (tensors are evidence, not verdicts).
- **README Key Innovation #9.**
- **web4 CLAUDE.md** — operational sharpening beside the RWOA self-audit.

Companion to the ratchet correction. Concord/dp review welcome — this is a foundational scope statement, so it should be ratified, not just merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
