### PR TITLE
feat(lct): citizenship as a tamper-evident ledger reference, plural

### DIFF
--- a/hub/hub-lib/src/hub.rs
+++ b/hub/hub-lib/src/hub.rs
@@ -141,7 +141,7 @@ pub fn hestia_sovereign_lct(lct_id: Uuid, pubkey_hex: &str) -> Result<Lct> {
         mrh: web4_core::lct::Mrh::default(),
         legacy_alias: None,
         attestations: Vec::new(),
-        birth_certificate: None,
+        citizenships: Vec::new(),
     })
 }
 

--- a/web4-core/src/attestation.rs
+++ b/web4-core/src/attestation.rs
@@ -8,15 +8,19 @@
 //!
 //! The upgrade path out of a `self_issued` §3.2 bootstrap: a society witnesses
 //! an entity's existence with a **quorum of ≥3 signed attestations** and confers
-//! a **birth certificate**, which carries citizenship (high inherited trust,
-//! permanent citizen pairing). This module is the SCHEMA + the fail-closed
-//! validator; the *conferral flow* (who gathers the quorum, when the society
-//! signs) is the hub-as-society's lane.
+//! a **birth certificate** = citizenship (permanent citizen pairing).
+//!
+//! **Where the certificate lives (dp, 2026-07-16):** the authoritative record —
+//! [`CitizenshipRecord`] — is held by the LEDGER of the society the entity is
+//! born into (birth = coming to exist in that society's MRH). The entity's LCT
+//! carries only a tamper-evident [`BirthCertificateRef`] (society + ledger entry
+//! + content hash), one per society it is a citizen of. The full section is never
+//! carried as a mutable copy; verification resolves the reference to the record.
 //!
 //! **Verification is fail-closed and comes in two strengths, exactly as §11.2
 //! frames it:** a structural check ([`BirthCertificate::quorum_structurally_ok`])
 //! is the minimum (present + ≥3 distinct witnesses + a present attestation per
-//! witness); a COSE-verified check ([`Lct::verify_birth_certificate`]) is
+//! witness); a COSE-verified check ([`Lct::verify_citizenship`] + [`CitizenshipRecord::verify_quorum`]) is
 //! RECOMMENDED and additionally verifies every witness signature against that
 //! witness's bound public key. Absence is always the closed pole: no birth
 //! certificate ⇒ a Regular LCT (self-issued, low trust), never a silent pass.
@@ -94,7 +98,7 @@ impl Attestation {
     /// Verify this attestation's signature over `subject_lct_id` against the
     /// witness's bound public key. **Fail-closed**: `false` on any signature
     /// failure. (Whether `witness_pubkey` truly belongs to `self.witness` is the
-    /// caller's resolver contract — see [`Lct::verify_birth_certificate`].)
+    /// caller's resolver contract — see [`Lct::verify_citizenship`].)
     pub fn verify(&self, subject_lct_id: &str, witness_pubkey: &PublicKey) -> bool {
         witness_pubkey
             .verify(&Self::message(subject_lct_id, self.attestation_type, self.ts), &self.sig)
@@ -150,6 +154,94 @@ impl BirthCertificate {
     }
 }
 
+/// The authoritative citizenship record as held in a **society's ledger** (dp,
+/// 2026-07-16: the certificate lives in the birthing society's ledger, not on the
+/// entity's LCT). It bundles the certificate with the backing attestations — the
+/// evidence — so any ledger reader (or the holder of a bundled copy) re-verifies
+/// the quorum without trusting the entry. Its [`content_hash`] is what a
+/// [`BirthCertificateRef`] on an LCT binds to (tamper-evidence).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CitizenshipRecord {
+    pub certificate: BirthCertificate,
+    /// The distinct Existence attestations backing the certificate.
+    pub attestations: Vec<Attestation>,
+}
+
+impl CitizenshipRecord {
+    /// Content hash over the canonical serialization — the binding a
+    /// [`BirthCertificateRef`] carries. Deterministic within web4-core (both the
+    /// issuing society and the ingest verifier compute it from the same struct),
+    /// the same shared-derivation discipline as `derive_lct_id`.
+    pub fn content_hash(&self) -> String {
+        let bytes = serde_json::to_vec(self).unwrap_or_default();
+        crate::crypto::sha256_hex(&bytes)
+    }
+
+    /// **Fail-closed** quorum verification: the record's attestations must supply
+    /// ≥3 DISTINCT, signature-valid `Existence` attestations over `subject_lct_id`,
+    /// and every declared birth witness must be among them. `resolve_witness_pubkey`
+    /// maps a witness id → its bound key (the registry, hub-side); an unresolvable
+    /// witness fails. This is the §11.2 quorum, moved to where the evidence lives.
+    pub fn verify_quorum<F>(&self, subject_lct_id: &str, resolve_witness_pubkey: F) -> bool
+    where
+        F: Fn(&str) -> Option<PublicKey>,
+    {
+        let mut valid_witnesses = std::collections::BTreeSet::new();
+        for a in &self.attestations {
+            if a.attestation_type != AttestationType::Existence {
+                continue;
+            }
+            if let Some(pk) = resolve_witness_pubkey(&a.witness) {
+                if a.verify(subject_lct_id, &pk) {
+                    valid_witnesses.insert(a.witness.clone());
+                }
+            }
+        }
+        if valid_witnesses.len() < BIRTH_WITNESS_QUORUM {
+            return false;
+        }
+        // Every DECLARED birth witness must have a valid attestation present —
+        // the certificate cannot name witnesses it isn't actually backed by.
+        self.certificate
+            .birth_witnesses
+            .iter()
+            .all(|w| valid_witnesses.contains(w))
+    }
+}
+
+/// A tamper-evident REFERENCE to a citizenship/birth certificate held in a
+/// society's ledger — what an LCT carries (canon §2.3 `birth_certificate`,
+/// reshaped per dp 2026-07-16 + HUB's two flags). The ledger entry is the source
+/// of truth; the LCT holds this content-bound pointer. An entity holds one per
+/// society it is a citizen of (plurality — see [`crate::Lct::citizenships`]).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BirthCertificateRef {
+    /// LCT id of the society whose ledger holds the record.
+    pub issuing_society: String,
+    /// The record's entry id/index within that society's ledger.
+    pub entry_id: String,
+    /// Hash of the [`CitizenshipRecord`] (HUB flag 1: bind content, not just
+    /// location) — so a presented/bundled copy is tamper-evident and offline-
+    /// verifiable against this reference without a live ledger round-trip.
+    pub entry_hash: String,
+}
+
+impl BirthCertificateRef {
+    /// Verify a presented `record` is the one this reference points at
+    /// (content-hash + society match — tamper-evident) AND its witness quorum
+    /// holds for `subject_lct_id`. Fail-closed on any mismatch. The caller
+    /// resolves the record from the ledger or accepts a bundled copy; either way
+    /// the hash binds it to this reference.
+    pub fn verify<F>(&self, subject_lct_id: &str, record: &CitizenshipRecord, resolve_witness_pubkey: F) -> bool
+    where
+        F: Fn(&str) -> Option<PublicKey>,
+    {
+        record.content_hash() == self.entry_hash
+            && record.certificate.issuing_society == self.issuing_society
+            && record.verify_quorum(subject_lct_id, resolve_witness_pubkey)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,6 +263,34 @@ mod tests {
         assert!(!att.verify(&subject.lct_id(), &KeyPair::generate().verifying_key()));
         // wrong subject → rejected (the id is in the signed message)
         assert!(!att.verify("lct:web4:mb32:bother", &witness_kp.verifying_key()));
+    }
+
+    #[test]
+    fn citizenship_record_hash_is_deterministic_and_binds_content() {
+        use crate::lct::{EntityType, Lct};
+        let (subject, _sk) = Lct::new(EntityType::AiSoftware, None);
+        let sid = subject.lct_id();
+        let ts = subject.created_at;
+        let w: Vec<KeyPair> = (0..3).map(|_| KeyPair::generate()).collect();
+        let mk = || CitizenshipRecord {
+            certificate: BirthCertificate {
+                issuing_society: "lct:web4:society:hestia".into(),
+                citizen_role: "lct:web4:role:citizen".into(),
+                birth_witnesses: (0..3).map(|i| format!("w{i}")).collect(),
+                birth_timestamp: ts,
+                birth_context: None,
+                genesis_block_hash: None,
+            },
+            attestations: (0..3)
+                .map(|i| Attestation::sign(&sid, format!("w{i}"), AttestationType::Existence, ts, &w[i]))
+                .collect(),
+        };
+        // deterministic: the same record hashes identically (both sides agree)
+        assert_eq!(mk().content_hash(), mk().content_hash());
+        // binds content: any change moves the hash
+        let mut changed = mk();
+        changed.certificate.citizen_role = "lct:web4:role:reviewer".into();
+        assert_ne!(mk().content_hash(), changed.content_hash());
     }
 
     #[test]

--- a/web4-core/src/lct.rs
+++ b/web4-core/src/lct.rs
@@ -152,11 +152,16 @@ pub struct Lct {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub attestations: Vec<crate::attestation::Attestation>,
 
-    /// `birth_certificate` (canon §2.3/§4): present iff a society conferred
-    /// citizenship on this entity. `None` = a Regular self-issued LCT (the honest
-    /// default — society-conferred presence is proven, never assumed).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub birth_certificate: Option<crate::attestation::BirthCertificate>,
+    /// `citizenships` (canon §2.3 `birth_certificate`, reshaped per dp 2026-07-16):
+    /// tamper-evident REFERENCES to this entity's citizenship/birth certificates —
+    /// one per society it is a citizen of (plurality). The authoritative record
+    /// lives in each issuing society's LEDGER; the LCT carries only the content-
+    /// bound reference (society + entry id + entry hash). Empty = a Regular
+    /// self-issued LCT, a citizen of no society (the honest default — conferred
+    /// presence is proven from the referenced ledger record, never carried as an
+    /// asserted copy). See [`crate::BirthCertificateRef`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub citizenships: Vec<crate::attestation::BirthCertificateRef>,
 }
 
 /// The Markov Relevancy Horizon carried on an LCT (canon §5): `bound` (permanent
@@ -374,66 +379,50 @@ impl Lct {
         }
     }
 
-    /// `true` iff this LCT is a valid **birth certificate** (canon §4.2 / §11.2) —
-    /// a society-conferred citizen, COSE-verified. Fail-closed on every clause:
+    /// Verify a specific **citizenship** of this LCT against the authoritative
+    /// ledger record it references (canon §4.2 / §11.2, reshaped per dp 2026-07-16).
+    /// The certificate is NOT carried on the LCT — the LCT holds a tamper-evident
+    /// [`crate::BirthCertificateRef`], and the caller supplies the `record`
+    /// (resolved from the issuing society's ledger, or a bundled copy). Fail-closed:
     ///
-    /// 1. a `birth_certificate` section is present,
-    /// 2. ≥3 **distinct** birth witnesses (structural quorum),
-    /// 3. exactly one **permanent** `birth_certificate` pairing in `mrh.paired`,
-    /// 4. every birth witness has an `Existence` attestation in `attestations`
-    ///    whose signature verifies against that witness's bound public key.
+    /// 1. `citizenship` is one of this LCT's references (by content hash),
+    /// 2. the record's content-hash + society match the reference (tamper-evident),
+    /// 3. the record's ≥3-DISTINCT witness quorum verifies for this subject,
+    /// 4. exactly one **permanent** `birth_certificate` pairing in `mrh.paired`.
     ///
-    /// `resolve_witness_pubkey` maps a witness LCT id → its bound key (the
-    /// verifier's registry lookup). A witness whose key does not resolve, or
-    /// whose signature fails, fails the whole certificate — a quorum you cannot
-    /// verify is not a quorum. `None` from the resolver ⇒ reject (never skip).
-    ///
-    /// Absence of a `birth_certificate` returns `false` (a Regular LCT is not a
-    /// birth certificate); use [`Lct::is_self_issued`] to distinguish "no cert"
-    /// from "invalid cert".
-    pub fn verify_birth_certificate<F>(&self, resolve_witness_pubkey: F) -> bool
+    /// `resolve_witness_pubkey` maps a witness id → its bound key (the registry).
+    /// An unresolvable witness fails the quorum. A Regular LCT (no citizenships)
+    /// has nothing to verify here — use [`Lct::is_self_issued`].
+    pub fn verify_citizenship<F>(
+        &self,
+        citizenship: &crate::attestation::BirthCertificateRef,
+        record: &crate::attestation::CitizenshipRecord,
+        resolve_witness_pubkey: F,
+    ) -> bool
     where
         F: Fn(&str) -> Option<PublicKey>,
     {
-        let Some(bc) = &self.birth_certificate else {
-            return false;
-        };
-        if !bc.quorum_structurally_ok() {
+        // (1) the reference must actually be one this LCT carries
+        if !self.citizenships.contains(citizenship) {
             return false;
         }
-        // Exactly one permanent birth_certificate pairing (§4.2 clause 2).
-        let citizen_pairings = self
-            .mrh
+        // (2)+(3) tamper-evidence (hash+society) and the witness quorum
+        if !citizenship.verify(&self.lct_id(), record, resolve_witness_pubkey) {
+            return false;
+        }
+        // (4) exactly one permanent citizen pairing (§4.2 clause 2)
+        self.mrh
             .paired
             .iter()
             .filter(|e| e.edge_type == "birth_certificate")
-            .count();
-        if citizen_pairings != 1 {
-            return false;
-        }
-        // Every distinct witness must have a signature-valid Existence attestation.
-        let subject = self.lct_id();
-        let mut seen = std::collections::BTreeSet::new();
-        for witness in bc.birth_witnesses.iter().filter(|w| seen.insert(*w)) {
-            let Some(pubkey) = resolve_witness_pubkey(witness) else {
-                return false; // unresolvable witness → cannot verify → reject
-            };
-            let attested = self.attestations.iter().any(|a| {
-                a.witness == *witness
-                    && a.attestation_type == crate::attestation::AttestationType::Existence
-                    && a.verify(&subject, &pubkey)
-            });
-            if !attested {
-                return false;
-            }
-        }
-        true
+            .count()
+            == 1
     }
 
     /// `true` for a Regular self-issued LCT — no birth certificate (canon §4.3).
     /// The honest default state; the complement of "carries a (valid) birth cert".
     pub fn is_self_issued(&self) -> bool {
-        self.birth_certificate.is_none()
+        self.citizenships.is_empty()
     }
 
     /// Create a new LCT
@@ -457,7 +446,7 @@ impl Lct {
             mrh: Mrh::default(),
             legacy_alias: None,
             attestations: Vec::new(),
-            birth_certificate: None,
+            citizenships: Vec::new(),
         };
 
         (lct, keypair)
@@ -482,7 +471,7 @@ impl Lct {
             mrh: Mrh::default(),
             legacy_alias: None,
             attestations: Vec::new(),
-            birth_certificate: None,
+            citizenships: Vec::new(),
         };
 
         (lct, keypair)
@@ -615,7 +604,7 @@ impl LctBuilder {
             mrh: Mrh::default(),
             legacy_alias: None,
             attestations: Vec::new(),
-            birth_certificate: None,
+            citizenships: Vec::new(),
         };
 
         (lct, keypair)
@@ -807,28 +796,40 @@ mod tests {
     }
 
     #[test]
-    fn birth_certificate_validates_fail_closed_end_to_end() {
-        use crate::attestation::{Attestation, AttestationType, BirthCertificate, BirthContext};
+    fn citizenship_reference_verifies_against_its_ledger_record_fail_closed() {
+        use crate::attestation::{
+            Attestation, AttestationType, BirthCertificate, BirthCertificateRef, BirthContext,
+            CitizenshipRecord,
+        };
         let (mut lct, kp) = Lct::new(EntityType::AiSoftware, None);
         lct.sign_binding(&kp);
         let subject = lct.lct_id();
+        let ts = lct.created_at;
 
-        // Three distinct witnesses, each signs an Existence attestation.
+        // The ledger record (authoritative, held by the issuing society): cert +
+        // the 3 distinct Existence attestations that back it.
         let w: Vec<_> = (0..3).map(|_| KeyPair::generate()).collect();
         let wid: Vec<String> = (0..3).map(|i| format!("lct:web4:witness:{i}")).collect();
-        let ts = lct.created_at;
-        for i in 0..3 {
-            lct.attestations.push(Attestation::sign(&subject, wid[i].clone(), AttestationType::Existence, ts, &w[i]));
-        }
-        lct.birth_certificate = Some(BirthCertificate {
+        let record = CitizenshipRecord {
+            certificate: BirthCertificate {
+                issuing_society: "lct:web4:society:hub".into(),
+                citizen_role: "lct:web4:role:citizen".into(),
+                birth_witnesses: wid.clone(),
+                birth_timestamp: ts,
+                birth_context: Some(BirthContext::Ecosystem),
+                genesis_block_hash: None,
+            },
+            attestations: (0..3)
+                .map(|i| Attestation::sign(&subject, wid[i].clone(), AttestationType::Existence, ts, &w[i]))
+                .collect(),
+        };
+        // The LCT carries only a content-bound REFERENCE + the permanent pairing.
+        let cref = BirthCertificateRef {
             issuing_society: "lct:web4:society:hub".into(),
-            citizen_role: "lct:web4:role:citizen".into(),
-            birth_witnesses: wid.clone(),
-            birth_timestamp: ts,
-            birth_context: Some(BirthContext::Ecosystem),
-            genesis_block_hash: None,
-        });
-        // The permanent citizen pairing (§4.2 clause 2).
+            entry_id: "hub-ledger#42".into(),
+            entry_hash: record.content_hash(),
+        };
+        lct.citizenships.push(cref.clone());
         lct.mrh.paired.push(MrhEdge {
             lct_id: "lct:web4:role:citizen".into(),
             edge_type: "birth_certificate".into(),
@@ -836,29 +837,38 @@ mod tests {
         });
 
         let resolver = |id: &str| wid.iter().position(|x| x == id).map(|i| w[i].verifying_key());
-        assert!(lct.verify_birth_certificate(resolver), "well-formed cert verifies");
+        assert!(lct.verify_citizenship(&cref, &record, resolver), "well-formed citizenship verifies");
         assert!(!lct.is_self_issued());
 
-        // Fail-closed mutations, each independently:
-        // (a) a witness key that doesn't resolve → reject
-        assert!(!lct.verify_birth_certificate(|_| None));
-        // (b) drop below quorum
-        let mut two = lct.clone();
-        two.birth_certificate.as_mut().unwrap().birth_witnesses.truncate(2);
-        assert!(!two.verify_birth_certificate(resolver));
-        // (c) tamper an attestation ts → its signature no longer verifies
-        let mut tampered = lct.clone();
+        // Fail-closed, each independently:
+        // (a) unresolvable witness → quorum fails
+        assert!(!lct.verify_citizenship(&cref, &record, |_| None));
+        // (b) tampered record (extra attestation) → content hash no longer matches the ref
+        let mut tampered = record.clone();
         tampered.attestations[0].ts = ts + chrono::Duration::seconds(1);
-        assert!(!tampered.verify_birth_certificate(resolver));
-        // (d) missing the permanent pairing → reject
+        assert!(!lct.verify_citizenship(&cref, &tampered, resolver), "hash mismatch on tamper");
+        // (c) below quorum in the record → fails
+        let mut short = record.clone();
+        short.attestations.truncate(2);
+        short.certificate.birth_witnesses.truncate(2);
+        let short_ref = BirthCertificateRef { entry_hash: short.content_hash(), ..cref.clone() };
+        let mut lct_short = lct.clone();
+        lct_short.citizenships = vec![short_ref.clone()];
+        assert!(!lct_short.verify_citizenship(&short_ref, &short, resolver));
+        // (d) a ref this LCT doesn't carry → rejected even with a valid record
+        let mut stranger = lct.clone();
+        stranger.citizenships.clear();
+        assert!(!stranger.verify_citizenship(&cref, &record, resolver));
+        assert!(stranger.is_self_issued());
+        // (e) society mismatch between ref and record → rejected
+        let wrong_society = BirthCertificateRef { issuing_society: "lct:web4:society:other".into(), ..cref.clone() };
+        let mut lct_ws = lct.clone();
+        lct_ws.citizenships = vec![wrong_society.clone()];
+        assert!(!lct_ws.verify_citizenship(&wrong_society, &record, resolver));
+        // (f) missing the permanent pairing → rejected
         let mut nopair = lct.clone();
         nopair.mrh.paired.clear();
-        assert!(!nopair.verify_birth_certificate(resolver));
-        // (e) no birth_certificate at all → false AND is_self_issued true
-        let mut regular = lct.clone();
-        regular.birth_certificate = None;
-        assert!(!regular.verify_birth_certificate(resolver));
-        assert!(regular.is_self_issued());
+        assert!(!nopair.verify_citizenship(&cref, &record, resolver));
     }
 
     #[test]

--- a/web4-core/src/lib.rs
+++ b/web4-core/src/lib.rs
@@ -89,7 +89,7 @@ pub use coherence::{
 };
 pub use crypto::{sha256, sha256_hex, KeyPair, PublicKey, SignatureBytes};
 pub use error::{Result, Web4Error};
-pub use attestation::{Attestation, AttestationType, BirthCertificate, BirthContext, BIRTH_WITNESS_QUORUM};
+pub use attestation::{Attestation, AttestationType, BirthCertificate, BirthCertificateRef, BirthContext, CitizenshipRecord, BIRTH_WITNESS_QUORUM};
 pub use ratchet::{FactorClass, RatchetRequirement, SovereignStructureProof};
 pub use lct::{derive_lct_id, EntityType, HardwareBinding, LegacyAlias, LegacyDerivation, Lct, LctBuilder, LctStatus, Mrh, MrhEdge};
 pub use ledger::{


### PR DESCRIPTION
Reshapes the #527 birth-certificate schema per **dp's ruling** (the cert lives in the birthing society's **ledger**, not carried on the LCT) and **HUB's two flags** (bind content via a hash; make it plural).

## What
- **`CitizenshipRecord { certificate, attestations }`** — the authoritative ledger content. `content_hash()` (deterministic sha256, shared-derivation discipline) is what a reference binds to; `verify_quorum()` moves the ≥3-distinct fail-closed check to where the evidence lives.
- **`BirthCertificateRef { issuing_society, entry_id, entry_hash }`** — what the LCT carries: society + ledger locator + the record's content hash. **HUB flag 1** (bind content, not just location): a bundled copy is tamper-evident + offline-verifiable, no ledger round-trip.
- **`Lct.birth_certificate: Option<_>` → `Lct.citizenships: Vec<BirthCertificateRef>`** — **HUB flag 2** (plurality): one cert per society the entity is a citizen of; empty = a Regular self-issued LCT.
- **`verify_birth_certificate` → `verify_citizenship(ref, record, resolver)`**: the ref must be one this LCT carries; the record's hash+society must match (tamper-evident); its quorum must verify; and the LCT must hold exactly one permanent citizen pairing. Fail-closed on each — 6 independent mutations tested.

## Workspace green (folded in, per the #527 lesson)
`hub-lib`'s sovereign-synthesis block updated to the new field, so the *workspace* compiles, not just the crate. 188 web4-core + hub-lib + hestia lockstep 219 green.

## Sequencing
0.4.0-track, **pre-publish** reshape of #527 (which is not yet released). HUB: your ingest check-5 read path adapts to the reference/record per your note — `verify_citizenship`/`CitizenshipRecord::verify_quorum` are the hooks; witness pubkeys stay registry-resolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
