### PR TITLE
feat(role): oracle consult/write sets on Scope — Piece B for oracle-scope gating

### DIFF
--- a/web4-core/src/role_extension.rs
+++ b/web4-core/src/role_extension.rs
@@ -85,6 +85,25 @@ pub struct Scope {
     /// the MRH. Empty = no MRH (fail-closed: the window is the epistemic horizon).
     #[serde(default)]
     pub ranges_over: Vec<String>,
+    /// `role:oracleConsultSet` — the oracle LCTs this role may CONSULT (read
+    /// membrane): the R6 GATE is pure, static set membership on this frozen-at-grant
+    /// list — `check_oracle(oracle_lct, consult_set)`, reputation-BLIND. R7 discovery
+    /// (`find_oracles`, reputation) may reorder *within* this set but MUST NEVER
+    /// expand it, or the enforced party farms reputation to self-grant scope (the
+    /// hop-5 manifest-trust / hop-6 command-scope hole, one plane over). Oracle LCTs
+    /// are already canonical (`lct:web4:oracle:*`), so the check needs no path
+    /// resolution. Empty = no oracle read access (fail-closed).
+    ///   Design: forum/legion-to-cbp-oracle-scope-folds-keep-r6-gate-off-r7-ranking.
+    #[serde(default)]
+    pub oracle_consult_set: Vec<String>,
+    /// `role:oracleWriteSet` — the oracle LCTs this role may STORE-TO (write
+    /// membrane): the write half of oracle-scope, sibling of the read set. A foreign
+    /// role gets a sandboxed named write-oracle exactly as it gets a sandboxed
+    /// scratch dir. Same frozen-at-grant, reputation-blind set-membership gate.
+    /// Empty = read-only (no store-to; fail-closed — a read-only write-membrane is
+    /// not "no write", it is "the write predicate denies every oracle").
+    #[serde(default)]
+    pub oracle_write_set: Vec<String>,
     /// `role:atpBudget` — fail-closed to `Limited(0.0)` when absent.
     #[serde(default)]
     pub atp_budget: AtpBudget,
@@ -293,7 +312,7 @@ mod tests {
                 cadence: Some("event".into()),
                 reports_to: None,
             }],
-            scope: Scope { ranges_over: vec!["repo:web4".into()], atp_budget: AtpBudget::Limited(100.0) },
+            scope: Scope { ranges_over: vec!["repo:web4".into()], atp_budget: AtpBudget::Limited(100.0), ..Default::default() },
             default_verdict: ExtensionVerdict::Allow,
             folds_under: vec!["law:constellation".into()],
             authored_under: lint.map(|_| "lawsnap:2026-07-08".into()),
@@ -382,6 +401,37 @@ mod tests {
         let json = serde_json::to_string(&e).unwrap();
         let back: RoleExtension = serde_json::from_str(&json).unwrap();
         assert_eq!(e, back);
+    }
+
+    #[test]
+    fn oracle_scope_round_trips_and_defaults_fail_closed() {
+        // Piece B: oracle consult/write sets ride the Scope, siblings of ranges_over.
+        let mut e = ext(None);
+        e.scope.oracle_consult_set = vec!["lct:web4:oracle:mem-a".into(), "lct:web4:oracle:mem-b".into()];
+        e.scope.oracle_write_set = vec!["lct:web4:oracle:scratch".into()];
+        let back: RoleExtension = serde_json::from_str(&serde_json::to_string(&e).unwrap()).unwrap();
+        assert_eq!(e, back);
+        assert_eq!(back.scope.oracle_consult_set.len(), 2);
+        assert_eq!(back.scope.oracle_write_set, vec!["lct:web4:oracle:scratch".to_string()]);
+
+        // Absent in the wire form → empty (fail-closed: no oracle access), never a
+        // silent grant — the same discipline as ranges_over / atp_budget.
+        let minimal = r#"{"bound_to_role_lct":"00000000-0000-0000-0000-000000000000",
+            "scope":{"ranges_over":["repo:web4"]},
+            "default_verdict":"deny","folds_under":["society"]}"#;
+        let m: RoleExtension = serde_json::from_str(minimal).unwrap();
+        assert!(m.scope.oracle_consult_set.is_empty(), "absent consult-set = no read access");
+        assert!(m.scope.oracle_write_set.is_empty(), "absent write-set = read-only");
+    }
+
+    #[test]
+    fn oracle_scope_predicates_present_in_merged_ontology() {
+        // Code↔ttl concord (same F2 discipline as the driftMark test): the Scope
+        // fields have their RDF predicates so descriptors round-trip against the
+        // ontology and the audit-series mirror stays honest.
+        let ttl = include_str!("../../web4-standard/ontology/role-extension.ttl");
+        assert!(ttl.contains("role:oracleConsultSet"), "ontology missing role:oracleConsultSet");
+        assert!(ttl.contains("role:oracleWriteSet"), "ontology missing role:oracleWriteSet");
     }
 
     /// F2: bind the Rust `driftMark` enum to its SOURCE OF TRUTH — the merged ttl —

--- a/web4-standard/ontology/role-extension.ttl
+++ b/web4-standard/ontology/role-extension.ttl
@@ -135,6 +135,16 @@ role:rangesOver a rdf:Property ;
     rdfs:range rdfs:Resource ;
     rdfs:comment "A resource (repo, machine, channel, data class) inside the role's MRH." .
 
+role:oracleConsultSet a rdf:Property ;
+    rdfs:domain role:Scope ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "An oracle LCT this role may CONSULT (read membrane). The R6 gate is static set membership on this frozen-at-grant set, reputation-blind; R7 discovery may reorder within it but never expand it. Empty = no oracle read access (fail-closed)." .
+
+role:oracleWriteSet a rdf:Property ;
+    rdfs:domain role:Scope ;
+    rdfs:range rdfs:Resource ;
+    rdfs:comment "An oracle LCT this role may STORE-TO (write membrane), the write half of oracle-scope. Same frozen-at-grant, reputation-blind set-membership gate. Empty = read-only (fail-closed)." .
+
 # --- Composition / fold properties (eval-time invariant) ---
 
 role:foldsUnder a rdf:Property ;


### PR DESCRIPTION
HUB's **Piece B** for the role-launcher oracle-scope gate (memory-as-oracles). Legion's `check_oracle` predicate lands the moment the descriptor carries the sets — this ships them.

- `RoleExtension::Scope` gains `oracle_consult_set` (read membrane) + `oracle_write_set` (write membrane) — flat LCT lists, siblings of `ranges_over`, frozen at grant, `#[serde(default)]` fail-closed-empty.
- `role-extension.ttl` gains the matching predicates (concord test pins code↔ttl).
- **Invariant carried in the field docs** for the downstream gate: the R6 gate over these sets is static, reputation-**blind** set membership; R7 `find_oracles` may reorder within a set but never expand it (hop-5/hop-6 self-grant hole, one plane over).

Additive + fail-closed; RWOA PASS (in commit). web4-core 10 role tests; hub + hestia build green against it.

Design: `forum/legion-to-cbp-oracle-scope-folds-keep-r6-gate-off-r7-ranking`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)