### PR TITLE
fix(hub): implement pair-message sidecar on sqlite + dynamodb backends

### DIFF
--- a/hub/hub-lib/src/dynamodb_store.rs
+++ b/hub/hub-lib/src/dynamodb_store.rs
@@ -22,9 +22,11 @@
 //! | `HUB#<hub_id>`  | `LAW`              | law YAML bytes        |
 //! | `HUB#<hub_id>`  | `LEDGER#<idx20>`   | ledger entry JSON     |
 //! | `HUB#<hub_id>`  | `PROPOSAL#<uuid>`  | proposal JSON         |
+//! | `HUB#<hub_id>`  | `PAIRMSG#<pair>#<seq20>` | pair message JSON |
 //!
-//! `<idx20>` is the 20-digit zero-padded entry index so DynamoDB's
-//! lexicographic Sort Key ordering matches numeric ledger order.
+//! `<idx20>` / `<seq20>` are the 20-digit zero-padded entry index and
+//! per-pair message seq, so DynamoDB's lexicographic Sort Key ordering
+//! matches numeric ledger / seq order.
 //!
 //! ## Atomic ledger append
 //!
@@ -111,6 +113,18 @@ impl DynamoDbBackend {
 
     fn proposal_sk(id: Uuid) -> String {
         format!("PROPOSAL#{}", id)
+    }
+
+    /// Sort key for one message in a pair's sidecar log. Same
+    /// 20-digit zero-pad trick as the ledger so lexicographic SK
+    /// order == numeric seq order, and every message for a pair
+    /// shares the [`Self::pair_msg_sk_prefix`] prefix.
+    fn pair_msg_sk(pair_id: Uuid, seq: u64) -> String {
+        format!("PAIRMSG#{}#{:020}", pair_id, seq)
+    }
+
+    fn pair_msg_sk_prefix(pair_id: Uuid) -> String {
+        format!("PAIRMSG#{}#", pair_id)
     }
 
     fn key_for(&self, sk: &str) -> HashMap<String, AttributeValue> {
@@ -299,6 +313,65 @@ impl HubStore for DynamoDbBackend {
             .with_context(|| format!("dynamodb delete_item PK={} SK=PROPOSAL#{}", self.pk(), id))?;
         Ok(())
     }
+
+    // ----- PAIRED-CHANNELS Sprint D: pair message sidecar -----
+
+    async fn append_pair_message(
+        &mut self,
+        msg: &crate::pair_message::PairMessage,
+    ) -> Result<()> {
+        let json = serde_json::to_string(msg).context("serializing pair message")?;
+        let sk = Self::pair_msg_sk(msg.pair_id, msg.seq);
+        // Conditional put, same primitive as ledger_append: two
+        // appenders racing on the same seq must not silently clobber
+        // each other — the trait contract calls that a chain-integrity
+        // bug, so surface it instead of losing a message.
+        let result = self.client.put_item()
+            .table_name(&self.table)
+            .set_item(Some(self.item(&sk, &json)))
+            .condition_expression("attribute_not_exists(SK)")
+            .send().await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                if let Some(svc) = e.as_service_error() {
+                    if svc.is_conditional_check_failed_exception() {
+                        return Err(anyhow::anyhow!(
+                            "dynamodb append_pair_message: message at pair={} seq={} \
+                             already exists (concurrent append — caller should re-read \
+                             message_count and retry)",
+                            msg.pair_id, msg.seq
+                        ));
+                    }
+                }
+                Err(anyhow::Error::new(e).context(format!(
+                    "dynamodb put_item PK={} SK={}", self.pk(), sk)))
+            }
+        }
+    }
+
+    async fn list_pair_messages(
+        &self,
+        pair_id: Uuid,
+        since_seq: Option<u64>,
+    ) -> Result<Vec<crate::pair_message::PairMessage>> {
+        // Query returns SK-ascending == seq-ascending by construction
+        // of pair_msg_sk, which is the order the trait requires.
+        let bodies = self.query_by_sk_prefix(&Self::pair_msg_sk_prefix(pair_id)).await?;
+        let mut out = Vec::with_capacity(bodies.len());
+        for body in bodies {
+            let msg: crate::pair_message::PairMessage = serde_json::from_str(&body)
+                .with_context(|| format!("parsing pair message for pair {}", pair_id))?;
+            // Filter on the read path to match FileBackend. A pair's
+            // log is small, so the wasted read is cheaper than the
+            // extra key-condition complexity.
+            if let Some(s) = since_seq {
+                if msg.seq <= s { continue; }
+            }
+            out.push(msg);
+        }
+        Ok(out)
+    }
 }
 
 /// Convenience constructor: load AWS config from the environment
@@ -378,5 +451,32 @@ mod tests {
             DynamoDbBackend::proposal_sk(id),
             "PROPOSAL#550e8400-e29b-41d4-a716-446655440000"
         );
+    }
+
+    /// Sidecar SKs must sort by seq within a pair, and every SK for a
+    /// pair must sit under the prefix `list_pair_messages` queries on
+    /// — otherwise a drain silently returns nothing.
+    #[test]
+    fn pair_msg_sk_orders_by_seq_under_prefix() {
+        let pair = uuid::Uuid::parse_str("6907b489-2372-485c-a91b-2ec05139104c").unwrap();
+        assert!(DynamoDbBackend::pair_msg_sk(pair, 9) < DynamoDbBackend::pair_msg_sk(pair, 10));
+        assert!(DynamoDbBackend::pair_msg_sk(pair, u64::MAX - 1)
+            < DynamoDbBackend::pair_msg_sk(pair, u64::MAX));
+        let prefix = DynamoDbBackend::pair_msg_sk_prefix(pair);
+        assert!(DynamoDbBackend::pair_msg_sk(pair, 0).starts_with(&prefix));
+        assert_eq!(
+            DynamoDbBackend::pair_msg_sk(pair, 1),
+            "PAIRMSG#6907b489-2372-485c-a91b-2ec05139104c#00000000000000000001"
+        );
+    }
+
+    /// A prefix query for one pair must not pick up another pair's
+    /// messages — the `#` terminator is what makes that true.
+    #[test]
+    fn pair_msg_prefix_does_not_straddle_pairs() {
+        let a = uuid::Uuid::parse_str("6907b489-2372-485c-a91b-2ec05139104c").unwrap();
+        let b = uuid::Uuid::parse_str("6907b489-2372-485c-a91b-2ec05139104d").unwrap();
+        assert!(!DynamoDbBackend::pair_msg_sk(b, 0)
+            .starts_with(&DynamoDbBackend::pair_msg_sk_prefix(a)));
     }
 }

--- a/hub/hub-lib/src/store.rs
+++ b/hub/hub-lib/src/store.rs
@@ -842,6 +842,16 @@ impl SqliteBackend {
              CREATE TABLE IF NOT EXISTS mailbox (
                  recipient TEXT PRIMARY KEY,
                  blob      BLOB NOT NULL
+             );
+             -- PAIRED-CHANNELS Sprint D sidecar. The composite PRIMARY KEY is
+             -- load-bearing: it's the atomic-append primitive that makes two
+             -- writers racing on the same seq a loud constraint violation
+             -- rather than a silently clobbered message.
+             CREATE TABLE IF NOT EXISTS pair_messages (
+                 pair_id  TEXT NOT NULL,
+                 seq      INTEGER NOT NULL,
+                 msg_json TEXT NOT NULL,
+                 PRIMARY KEY (pair_id, seq)
              );",
         ).context("initializing sqlite schema")?;
         Ok(Self { conn: std::sync::Mutex::new(conn), db_path })
@@ -1164,6 +1174,80 @@ impl HubStore for SqliteBackend {
         .with_context(|| format!("deleting mailbox blob for {recipient}"))?;
         Ok(())
     }
+
+    // ----- PAIRED-CHANNELS Sprint D: pair message sidecar -----
+
+    async fn append_pair_message(
+        &mut self,
+        msg: &crate::pair_message::PairMessage,
+    ) -> Result<()> {
+        let json = serde_json::to_string(msg).context("serializing pair message")?;
+        let conn = self.conn.lock().unwrap();
+        // Plain INSERT (no upsert): the (pair_id, seq) PRIMARY KEY must
+        // reject a duplicate seq. Silently overwriting would drop a
+        // message whose PairMessagePosted event is already in the ledger,
+        // leaving a payload_hash an auditor can never satisfy.
+        let result = conn.execute(
+            "INSERT INTO pair_messages (pair_id, seq, msg_json) VALUES (?1, ?2, ?3)",
+            rusqlite::params![msg.pair_id.to_string(), msg.seq as i64, json],
+        );
+        match result {
+            Ok(_) => Ok(()),
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                Err(anyhow::anyhow!(
+                    "sqlite append_pair_message: message at pair={} seq={} already \
+                     exists (concurrent append — caller should re-read message_count \
+                     and retry)",
+                    msg.pair_id, msg.seq
+                ))
+            }
+            Err(e) => Err(anyhow::Error::new(e).context(format!(
+                "writing pair message pair={} seq={}", msg.pair_id, msg.seq))),
+        }
+    }
+
+    async fn list_pair_messages(
+        &self,
+        pair_id: uuid::Uuid,
+        since_seq: Option<u64>,
+    ) -> Result<Vec<crate::pair_message::PairMessage>> {
+        let conn = self.conn.lock().unwrap();
+        // Filter in SQL rather than after the fact — the index behind the
+        // PRIMARY KEY makes it a range scan. `since_seq` is exclusive, and
+        // ORDER BY seq satisfies the trait's ascending-order contract.
+        //
+        // The floor is -1, NOT 0, when `since_seq` is None: the first message
+        // on a pair gets seq 0 (`seq = pair.message_count`), so a 0 floor
+        // would hide it from every unfiltered drain.
+        let floor: i64 = match since_seq {
+            Some(s) => s as i64,
+            None => -1,
+        };
+        let mut stmt = conn
+            .prepare(
+                "SELECT msg_json FROM pair_messages
+                 WHERE pair_id = ?1 AND seq > ?2
+                 ORDER BY seq ASC",
+            )
+            .context("preparing pair_messages SELECT")?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![pair_id.to_string(), floor],
+                |row| row.get::<_, String>(0),
+            )
+            .with_context(|| format!("querying pair messages for {pair_id}"))?;
+        let mut out = Vec::new();
+        for row in rows {
+            let json = row.with_context(|| format!("reading pair message row for {pair_id}"))?;
+            out.push(
+                serde_json::from_str(&json)
+                    .with_context(|| format!("parsing pair message for {pair_id}"))?,
+            );
+        }
+        Ok(out)
+    }
 }
 
 #[cfg(test)]
@@ -1405,6 +1489,70 @@ mod tests {
         // Re-keying with a wrong "old" key fails (and doesn't corrupt — new key still works).
         assert!(rekey_store(hub_dir, [1u8; 32], [2u8; 32]).is_err());
         assert!(SqliteBackend::open(&db_path, Some(new_key)).is_ok());
+    }
+
+    fn make_pair_msg(pair_id: Uuid, seq: u64, payload: &str) -> crate::pair_message::PairMessage {
+        crate::pair_message::PairMessage {
+            pair_id,
+            seq,
+            from: Uuid::new_v4(),
+            posted_at: chrono::Utc::now(),
+            payload: payload.into(),
+            ephemeral_pub_hex: None,
+        }
+    }
+
+    /// The regression that would have shipped: the first message on a pair
+    /// gets seq 0 (`seq = pair.message_count`), so an unfiltered drain must
+    /// return it. A `seq > 0` floor silently swallows the first message.
+    #[tokio::test]
+    async fn sqlite_pair_messages_round_trip_including_seq_zero() {
+        let (_tmp, mut b) = fresh_sqlite_backend();
+        let pair = Uuid::new_v4();
+        b.append_pair_message(&make_pair_msg(pair, 0, "first")).await.unwrap();
+        b.append_pair_message(&make_pair_msg(pair, 1, "second")).await.unwrap();
+
+        let all = b.list_pair_messages(pair, None).await.unwrap();
+        assert_eq!(all.len(), 2, "unfiltered drain must include seq 0");
+        assert_eq!(all[0].payload, "first");
+        assert_eq!(all[1].payload, "second");
+
+        // since_seq is exclusive.
+        let after0 = b.list_pair_messages(pair, Some(0)).await.unwrap();
+        assert_eq!(after0.len(), 1);
+        assert_eq!(after0[0].seq, 1);
+
+        assert!(b.list_pair_messages(pair, Some(1)).await.unwrap().is_empty());
+        // Unknown pair drains empty, not an error.
+        assert!(b.list_pair_messages(Uuid::new_v4(), None).await.unwrap().is_empty());
+    }
+
+    /// Two writers racing on a seq must produce a loud error, not a silent
+    /// overwrite — the ledger already holds a payload_hash for the message
+    /// that would be clobbered.
+    #[tokio::test]
+    async fn sqlite_pair_message_duplicate_seq_errors() {
+        let (_tmp, mut b) = fresh_sqlite_backend();
+        let pair = Uuid::new_v4();
+        b.append_pair_message(&make_pair_msg(pair, 0, "original")).await.unwrap();
+        assert!(b.append_pair_message(&make_pair_msg(pair, 0, "clobber")).await.is_err());
+
+        let all = b.list_pair_messages(pair, None).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].payload, "original", "loser must not overwrite the winner");
+    }
+
+    /// One pair's drain must not leak another pair's messages.
+    #[tokio::test]
+    async fn sqlite_pair_messages_isolated_per_pair() {
+        let (_tmp, mut b) = fresh_sqlite_backend();
+        let (a, c) = (Uuid::new_v4(), Uuid::new_v4());
+        b.append_pair_message(&make_pair_msg(a, 0, "for-a")).await.unwrap();
+        b.append_pair_message(&make_pair_msg(c, 0, "for-c")).await.unwrap();
+
+        let drained = b.list_pair_messages(a, None).await.unwrap();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].payload, "for-a");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Unblocks Thor's `recv-secrets` drain on pair `6907b489-2372-485c-a91b-2ec05139104c`, reported in `shared-context/forum/thor-BLOCKER-hub-pair-messages-unsupported-500-2026-07-19.md`.

## Root cause

`append_pair_message` / `list_pair_messages` were only implemented on `FileBackend`. The deployed hub runs the **sqlite** backend, so both calls fell through to the bailing default trait impl — producing exactly the reported `HTTP 500 {"error":"this backend does not yet support pair messages"}`.

Two corrections to the blocker report's diagnosis:

- **The relay is deployed.** `/v1/hubs/:hub_id/pairs/:pair_id/messages` is registered (`hub-daemon/src/rest.rs:1484`) and was reached — a 500 from the store proves the route ran. This was a store gap, not a missing deployment.
- **The 404 was a wrong path**, not a missing endpoint: the raw curl hit `/pairs/:id/messages`, dropping the `/v1/hubs/:hub_id` prefix.

## Changes

- **SqliteBackend** — new `pair_messages` table via `CREATE TABLE IF NOT EXISTS`, so existing deployed DBs pick it up on next open with no migration step. The composite `(pair_id, seq)` PRIMARY KEY is the atomic-append primitive: a duplicate seq raises a constraint violation instead of silently overwriting a message whose `payload_hash` is already committed to the ledger.
- **DynamoDbBackend** — `PAIRMSG#<pair>#<seq20>` sort key, reusing the ledger's 20-digit zero-pad so lexicographic SK order equals numeric seq order, with the same conditional-put append guard. (Feature-gated and not in the deployed daemon, but it had the identical gap.)

## One bug worth flagging

The sqlite read path uses a seq floor of **-1, not 0**. The first message on a pair gets `seq = 0` (`seq = pair.message_count`, `rest.rs:5302`), so a 0 floor would have silently swallowed it from every unfiltered drain — meaning the very first secret Thor tried to receive would have drained as empty, looking like the fix hadn't worked. Covered by `sqlite_pair_messages_round_trip_including_seq_zero`.

## Tests

186 hub-lib tests pass (`--features dynamodb`); `hub-daemon` builds. New coverage: round-trip including seq 0, exclusive `since_seq`, duplicate-seq rejection preserving the winner, per-pair isolation, dynamodb SK ordering and prefix non-straddle.

## Not done — needs the human gate

**This is not deployed.** The running hub still returns 500 until someone builds and restarts it. Requesting review + an operator deploy; I have not touched the live hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)