### PR TITLE
refactor(hub): retire the presented-key constellation verify to #[cfg(test)] (Phase 3)

### DIFF
--- a/hub/hub-lib/src/constellation.rs
+++ b/hub/hub-lib/src/constellation.rs
@@ -186,9 +186,17 @@ pub fn signing_payload(
 }
 
 impl ConstellationAttestation {
-    /// Rules 2–5: max-age, pinned-owner-key match, owner signature, device
-    /// co-signs (silent drop), derived tier. Rule 1 (nonce) and rule 6
-    /// (binding) live in [`ConstellationGate`], which owns the per-pair state.
+    /// The original presented-key verifier (device sigs checked against the
+    /// attestation's OWN `pubkey_hex`, class from its OWN `device_type`).
+    ///
+    /// **RETIRED from the API (2026-07-21): `#[cfg(test)]`-only.** It was the
+    /// network self-authentication hole — an owner-key holder could mint fresh
+    /// keys, label them `Hardware`, and forge a tier (GPT report). Every path now
+    /// uses [`Self::verify_enrolled`], which resolves device facts from the
+    /// authoritative enrollment registry. This is kept only so the historical
+    /// presented-key behavior tests still document what changed; a production
+    /// caller can't name it.
+    #[cfg(test)]
     pub fn verify(
         &self,
         pinned_owner_pubkey_hex: &str,


### PR DESCRIPTION
The network self-authentication hole is closed by `verify_enrolled` (#560). The old `ConstellationAttestation::verify` — device sigs checked against the attestation's OWN `pubkey_hex`, class from its OWN `device_type` — is now dead in production (`present()` uses `verify_enrolled`) but remained a **public footgun**: a future caller could pick it and silently reintroduce the hole.

This gates it `#[cfg(test)]` — a production caller can't even name it. The historical presented-key tests still compile (cfg(test)) and document what changed. hub-lib prod builds without it, the daemon never referenced it, all hub-lib tests pass.

Companion to hestia `216c1c9` (`verify_internal_consistency` → `#[cfg(test)]`). Completes **Phase 3** of the enrollment-registry fix. Surface removal — no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)