### PR TITLE
fix(hub): GET /v1/hubs/{id}/state 500s on every encrypted hub — read the society through the in-memory key

### DIFF
--- a/hub/hub-daemon/src/rest.rs
+++ b/hub/hub-daemon/src/rest.rs
@@ -2322,7 +2322,10 @@ async fn read_state(
     }
     let ledger = s.ledger.lock().await;
     let state = HubState::project(&ledger);
-    let society = load_society(s.paths.root.clone()).await
+    // Via the in-memory-keyed store, NOT the free `init::load_society`: the
+    // passphrase is dropped at ignition, so re-opening from disk keyless fails
+    // closed on an encrypted hub and 500s this read for the whole fleet.
+    let society = s.society().await
         .map_err(ApiError::internal)?;
     let filled_roles: Vec<RoleSnapshot> = society.roles.iter()
         .map(|(name, ra)| RoleSnapshot {
@@ -6063,6 +6066,38 @@ mod lct_registry_tests {
         assert!(
             after_drain.notifications.lock().await.is_empty(),
             "drained mailbox stays empty after restart"
+        );
+    }
+
+    /// Regression: `GET /v1/hubs/{id}/state` on an **ignited but encrypted** hub.
+    /// `read_state` used to call the free `init::load_society`, which re-opens the
+    /// store from disk keyless — but the passphrase is dropped at ignition, so the
+    /// endpoint failed closed with a 500 on every post-encryption hub (observed live
+    /// on the Web4 Fleet hub, 2026-07-22). It must read through the in-memory-keyed
+    /// `RestState::society()`, the same seam `open_store` gives every other handler.
+    #[tokio::test]
+    async fn read_state_serves_an_ignited_encrypted_hub() {
+        let (_tmp, hub_dir, state) = fresh_sqlite_state().await;
+
+        // Encrypt the state store at rest (first keyed open migrates it in place),
+        // then hand the daemon the derived key the way ignition does: in memory,
+        // with no HUB_PASSPHRASE in the environment. The already-open ledger is a
+        // pure in-memory projection, so it is unaffected by the migration.
+        let key = hub_lib::store::derive_store_key(&hub_dir, "correct horse battery staple").unwrap();
+        drop(hub_lib::store::open_hub_store_with_key(&hub_dir, Some(key)).unwrap());
+        assert!(
+            load_society(&hub_dir).await.is_err(),
+            "precondition: the keyless disk re-open must fail on an encrypted store"
+        );
+        *state.store_key.write().await = Some(zeroize::Zeroizing::new(key));
+
+        let out = read_state(State(state.clone()), Path(state.hub_id))
+            .await
+            .expect("an ignited hub must serve /state even though its store is encrypted");
+        assert_eq!(out.0.hub_id, state.hub_id);
+        assert!(
+            out.0.filled_roles.iter().any(|r| r.role == "sovereign"),
+            "roles come from the society read — the part that used to fail"
         );
     }
 


### PR DESCRIPTION
## Found live, not in review

Probing the Web4 Fleet hub after dp's 2026-07-22 10:28 PDT ignite (the restart that took the staged-dark #560/#561 binary live), `GET /v1/hubs/{hub_id}/state` returned **500** on a **fully ignited** hub:

```
{"error":"opening hub store: hub state at /home/dp/web4-hub/web4-fleet/hub.db is encrypted
  but no HUB_PASSPHRASE is set — set the vault passphrase to open it (the state needs tier-1 ignition)"}
```

## Cause

`read_state` was the last handler still calling the free `init::load_society`, which re-opens the store **from disk with no key**. Since #361 the passphrase is used once at ignition and dropped, so that re-open can never succeed on an encrypted hub. The endpoint has been dead for every caller since encryption landed — ignited or not — and leaked the absolute db path in the error body while failing.

This is a straggler, not a new seam: `RestState::society()` already exists for exactly this and names the trap in its doc comment ("unlike `init::load_society` … thus fails on an ignited *encrypted* hub"), and `mcp.rs` explicitly avoids the free function for the same reason. Not a #560/#561 regression — those merely made it observable by being the binary that got ignited.

## Fix

One line: read via `s.society()`, which goes through `open_store()` and the in-memory store key.

## Test

`read_state_serves_an_ignited_encrypted_hub` — encrypts the store at rest, hands the state the derived key the way ignition does (env passphrase absent), asserts the keyless disk re-open still fails (precondition), then asserts `/state` serves 200 with society-sourced roles.

**Verified it FAILS with the old line**, reproducing the exact live 500:
```
panicked: an ignited hub must serve /state ...: ApiError { status: 500,
  message: "opening hub store: hub state at /tmp/.tmpDwF5al/hub/hub.db is encrypted but no HUB_PASSPHRASE is set ..." }
```

Build gate: **189 hub-lib + 68 hub-daemon** tests pass (`cargo test -p hub-lib -p hub-daemon`).

## RWOA (surface: GET /v1/hubs/{id}/state)

```
act: public read of hub identity/roster/ledger-head — no state mutation
S: low/reversible [construct: read-only handler; no commit path]
R: n/a — public read, no reachability gate claimed
W: n/a — unauthenticated public read by design (PublicState only)
O: pass [construct: hub_id match check precedes every read; no side effects at all]
A: n/a — appends nothing to the ledger
V: n/a — reversible, no consequential act
verdict: PASS
```
The change strictly narrows a disk re-open to the already-authorized in-memory key, exposes no field the handler didn't already return, and removes an internal-path leak from the failure body.

## Deploy note

HUB will **not** restart the live daemon for this — a restart drops the hub to a LOCKED 503 that only dp can re-ignite, and dp ignited it 30 minutes before this was found. Binary stages dark; goes live at dp's next ignite window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)